### PR TITLE
Apply consistent formatting

### DIFF
--- a/src/FreeImage.Standard/Classes/FreeImageBitmap.cs
+++ b/src/FreeImage.Standard/Classes/FreeImageBitmap.cs
@@ -54,7 +54,7 @@ namespace FreeImageAPI
 	[Serializable, Guid("64a4c935-b757-499c-ab8c-6110316a9e51")]
 	public class FreeImageBitmap : MarshalByRefObject, ICloneable, IDisposable, IEnumerable, ISerializable
 	{
-#region Fields
+		#region Fields
 
 		/// <summary>
 		/// Indicates whether this instance is disposed.
@@ -125,9 +125,9 @@ namespace FreeImageAPI
 		private const string ErrorCreatingBitmap = "Unable to create bitmap.";
 		private const string ErrorUnloadBitmap = "Unable to unload bitmap.";
 
-#endregion
+		#endregion
 
-#region Constructors and Destructor
+		#region Constructors and Destructor
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="FreeImageBitmap"/> class.
@@ -945,7 +945,7 @@ namespace FreeImageAPI
 
 		#endregion
 
-#region Operators
+		#region Operators
 
 		/// <summary>
 		/// Converts a <see cref="FreeImageBitmap"/> instance to a <see cref="Bitmap"/> instance.
@@ -1018,9 +1018,9 @@ namespace FreeImageAPI
 			return (!(left == right));
 		}
 
-#endregion
+		#endregion
 
-#region Properties
+		#region Properties
 
 		/// <summary>
 		/// Type of the bitmap.
@@ -1716,9 +1716,9 @@ namespace FreeImageAPI
 			get { EnsureNotDisposed(); return dib; }
 		}
 
-#endregion
+		#endregion
 
-#region Methods
+		#region Methods
 
 		/// <summary>
 		/// Gets the bounds of this <see cref="FreeImageBitmap"/> in the specified unit.
@@ -1937,9 +1937,15 @@ namespace FreeImageAPI
 
 					switch (FreeImage.GetBPP(dib))
 					{
-						case 1u: result = new Scanline<FI1BIT>(dib, scanline, width); break;
-						case 4u: result = new Scanline<FI4BIT>(dib, scanline, width); break;
-						case 8u: result = new Scanline<Byte>(dib, scanline, width); break;
+						case 1u:
+							result = new Scanline<FI1BIT>(dib, scanline, width);
+							break;
+						case 4u:
+							result = new Scanline<FI4BIT>(dib, scanline, width);
+							break;
+						case 8u:
+							result = new Scanline<Byte>(dib, scanline, width);
+							break;
 						case 16u:
 							if ((RedMask == FreeImage.FI16_555_RED_MASK) &&
 								(GreenMask == FreeImage.FI16_555_GREEN_MASK) &&
@@ -1958,25 +1964,53 @@ namespace FreeImageAPI
 								result = new Scanline<UInt16>(dib, scanline, width);
 							}
 							break;
-						case 24u: result = new Scanline<RGBTRIPLE>(dib, scanline, width); break;
-						case 32u: result = new Scanline<RGBQUAD>(dib, scanline, width); break;
-						default: throw new ArgumentException("Color depth is not supported.");
+						case 24u:
+							result = new Scanline<RGBTRIPLE>(dib, scanline, width);
+							break;
+						case 32u:
+							result = new Scanline<RGBQUAD>(dib, scanline, width);
+							break;
+						default:
+							throw new ArgumentException("Color depth is not supported.");
 					}
 					break;
 
-				case FREE_IMAGE_TYPE.FIT_COMPLEX: result = new Scanline<FICOMPLEX>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_DOUBLE: result = new Scanline<Double>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_FLOAT: result = new Scanline<Single>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_INT16: result = new Scanline<Int16>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_INT32: result = new Scanline<Int32>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_RGB16: result = new Scanline<FIRGB16>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_RGBA16: result = new Scanline<FIRGBA16>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_RGBAF: result = new Scanline<FIRGBAF>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_RGBF: result = new Scanline<FIRGBF>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_UINT16: result = new Scanline<UInt16>(dib, scanline, width); break;
-				case FREE_IMAGE_TYPE.FIT_UINT32: result = new Scanline<UInt32>(dib, scanline, width); break;
+				case FREE_IMAGE_TYPE.FIT_COMPLEX:
+					result = new Scanline<FICOMPLEX>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_DOUBLE:
+					result = new Scanline<Double>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_FLOAT:
+					result = new Scanline<Single>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_INT16:
+					result = new Scanline<Int16>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_INT32:
+					result = new Scanline<Int32>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGB16:
+					result = new Scanline<FIRGB16>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBA16:
+					result = new Scanline<FIRGBA16>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBAF:
+					result = new Scanline<FIRGBAF>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBF:
+					result = new Scanline<FIRGBF>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_UINT16:
+					result = new Scanline<UInt16>(dib, scanline, width);
+					break;
+				case FREE_IMAGE_TYPE.FIT_UINT32:
+					result = new Scanline<UInt32>(dib, scanline, width);
+					break;
 				case FREE_IMAGE_TYPE.FIT_UNKNOWN:
-				default: throw new ArgumentException("Type is not supported.");
+				default:
+					throw new ArgumentException("Type is not supported.");
 			}
 
 			return result;
@@ -2039,9 +2073,15 @@ namespace FreeImageAPI
 
 					switch (FreeImage.GetBPP(dib))
 					{
-						case 1u: list = new List<Scanline<FI1BIT>>(height); break;
-						case 4u: list = new List<Scanline<FI4BIT>>(height); break;
-						case 8u: list = new List<Scanline<Byte>>(height); break;
+						case 1u:
+							list = new List<Scanline<FI1BIT>>(height);
+							break;
+						case 4u:
+							list = new List<Scanline<FI4BIT>>(height);
+							break;
+						case 8u:
+							list = new List<Scanline<Byte>>(height);
+							break;
 						case 16u:
 							if (FreeImage.IsRGB555(dib))
 							{
@@ -2056,25 +2096,53 @@ namespace FreeImageAPI
 								list = new List<Scanline<UInt16>>(height);
 							}
 							break;
-						case 24u: list = new List<Scanline<RGBTRIPLE>>(height); break;
-						case 32u: list = new List<Scanline<RGBQUAD>>(height); break;
-						default: throw new ArgumentException("Color depth is not supported.");
+						case 24u:
+							list = new List<Scanline<RGBTRIPLE>>(height);
+							break;
+						case 32u:
+							list = new List<Scanline<RGBQUAD>>(height);
+							break;
+						default:
+							throw new ArgumentException("Color depth is not supported.");
 					}
 					break;
 
-				case FREE_IMAGE_TYPE.FIT_COMPLEX: list = new List<Scanline<FICOMPLEX>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_DOUBLE: list = new List<Scanline<Double>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_FLOAT: list = new List<Scanline<Single>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_INT16: list = new List<Scanline<Int16>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_INT32: list = new List<Scanline<Int32>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_RGB16: list = new List<Scanline<FIRGB16>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_RGBA16: list = new List<Scanline<FIRGBA16>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_RGBAF: list = new List<Scanline<FIRGBAF>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_RGBF: list = new List<Scanline<FIRGBF>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_UINT16: list = new List<Scanline<UInt16>>(height); break;
-				case FREE_IMAGE_TYPE.FIT_UINT32: list = new List<Scanline<UInt32>>(height); break;
+				case FREE_IMAGE_TYPE.FIT_COMPLEX:
+					list = new List<Scanline<FICOMPLEX>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_DOUBLE:
+					list = new List<Scanline<Double>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_FLOAT:
+					list = new List<Scanline<Single>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_INT16:
+					list = new List<Scanline<Int16>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_INT32:
+					list = new List<Scanline<Int32>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGB16:
+					list = new List<Scanline<FIRGB16>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBA16:
+					list = new List<Scanline<FIRGBA16>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBAF:
+					list = new List<Scanline<FIRGBAF>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_RGBF:
+					list = new List<Scanline<FIRGBF>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_UINT16:
+					list = new List<Scanline<UInt16>>(height);
+					break;
+				case FREE_IMAGE_TYPE.FIT_UINT32:
+					list = new List<Scanline<UInt32>>(height);
+					break;
 				case FREE_IMAGE_TYPE.FIT_UNKNOWN:
-				default: throw new ArgumentException("Type is not supported.");
+				default:
+					throw new ArgumentException("Type is not supported.");
 			}
 
 			for (int i = 0; i < height; i++)
@@ -4170,9 +4238,9 @@ namespace FreeImageAPI
 			return FreeImage.CreatePropertyItem();
 		}
 
-#endregion
+		#endregion
 
-#region Helper functions
+		#region Helper functions
 
 		/// <summary>
 		/// Throws an exception in case the instance has already been disposed.
@@ -4270,9 +4338,9 @@ namespace FreeImageAPI
 			AddMemoryPressure();
 		}
 
-#endregion
+		#endregion
 
-#region Interfaces
+		#region Interfaces
 
 		/// <summary>
 		/// Helper class to store informations for <see cref="FreeImageBitmap.SaveAdd()"/>.
@@ -4380,6 +4448,6 @@ namespace FreeImageAPI
 			}
 		}
 
-#endregion
+		#endregion
 	}
 }

--- a/src/FreeImage.Standard/Classes/FreeImageEngine.cs
+++ b/src/FreeImage.Standard/Classes/FreeImageEngine.cs
@@ -11,7 +11,7 @@ namespace FreeImageAPI
 		// TODO: ideally FreeImage would provide this... either way, it should probably be cleared before any call to the API...
 		[ThreadStatic]
 		public static string LastErrorMessage;
-		
+
 		#region Callback
 
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -73,7 +73,7 @@ namespace FreeImageAPI
 
 									// Get a local copy of the multicast-delegate
 									OutputMessageFunction m = FreeImageEngine.message;
-									
+
 									// Check the local copy instead of the static instance
 									// to prevent a second thread from setting the delegate
 									// to null, which would cause a nullreference exception

--- a/src/FreeImage.Standard/Classes/ImageMetadata.cs
+++ b/src/FreeImage.Standard/Classes/ImageMetadata.cs
@@ -69,7 +69,8 @@ namespace FreeImageAPI.Metadata
 		/// will be hidden until a tag to this model is added.</param>
 		public ImageMetadata(FIBITMAP dib, bool hideEmptyModels)
 		{
-			if (dib.IsNull) throw new ArgumentNullException("dib");
+			if (dib.IsNull)
+				throw new ArgumentNullException("dib");
 			data = new List<MetadataModel>(FreeImage.FREE_IMAGE_MDMODELS.Length);
 			this.dib = dib;
 			this.hideEmptyModels = hideEmptyModels;

--- a/src/FreeImage.Standard/Classes/MemoryArray.cs
+++ b/src/FreeImage.Standard/Classes/MemoryArray.cs
@@ -372,7 +372,7 @@ namespace FreeImageAPI
 
 			if (isOneBit || isFourBit)
 			{
-				for (int i = 0; i != values.Length; )
+				for (int i = 0; i != values.Length;)
 				{
 					SetValueInternal(values[i++], index++);
 				}

--- a/src/FreeImage.Standard/Classes/MetadataModel.cs
+++ b/src/FreeImage.Standard/Classes/MetadataModel.cs
@@ -437,7 +437,7 @@ namespace FreeImageAPI.Metadata
 		{
 			uint[] value = GetUInt32Array(key);
 			return value == null ? default(uint?) : value[0];
-		}	
+		}
 
 		/// <summary>
 		/// Sets the value of the specified tag.

--- a/src/FreeImage.Standard/Classes/MetadataModels.cs
+++ b/src/FreeImage.Standard/Classes/MetadataModels.cs
@@ -40,6685 +40,6685 @@ using System.Text;
 
 namespace FreeImageAPI.Metadata
 {
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_ANIMATION"/>.
-    /// </summary>
-    public class MDM_ANIMATION : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_ANIMATION(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_ANIMATION; }
-        }
-
-        /// <summary>
-        /// Gets or sets the width of the entire canvas area, that each page is displayed in.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? LogicalWidth
-        {
-            get
-            {
-                return GetTagValue<ushort>("LogicalWidth");
-            }
-            set
-            {
-                SetTagValue("LogicalWidth", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the height of the entire canvas area, that each page is displayed in.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? LogicalHeight
-        {
-            get
-            {
-                return GetTagValue<ushort>("LogicalHeight");
-            }
-            set
-            {
-                SetTagValue("LogicalHeight", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the global palette of the GIF image.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public Palette GlobalPalette
-        {
-            get
-            {
-                MetadataTag mdtag = GetTag("GlobalPalette");
-                return (mdtag == null) ? null : new Palette(mdtag);
-            }
-            set
-            {
-                SetTagValue("GlobalPalette", (value != null) ? null : value.Data);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of replays for the animation.
-        /// Use 0 (zero) to specify an infinte number of replays.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? LoopCount
-        {
-            get
-            {
-                return GetTagValue<uint>("Loop");
-            }
-            set
-            {
-                SetTagValue("Loop", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the horizontal offset within the logical canvas area, this frame is to be displayed at.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? FrameLeft
-        {
-            get
-            {
-                return GetTagValue<ushort>("FrameLeft");
-            }
-            set
-            {
-                SetTagValue("FrameLeft", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the vertical offset within the logical canvas area, this frame is to be displayed at.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? FrameTop
-        {
-            get
-            {
-                return GetTagValue<ushort>("FrameTop");
-            }
-            set
-            {
-                SetTagValue("FrameTop", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a flag to supress saving the dib's attached palette
-        /// (making it use the global palette). The local palette is the palette used by a page.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public bool? NoLocalPalette
-        {
-            get
-            {
-                byte? useGlobalPalette = GetTagValue<byte>("NoLocalPalette");
-                return useGlobalPalette.HasValue ? (useGlobalPalette.Value != 0) : default(bool?);
-            }
-            set
-            {
-                byte? val = null;
-                if (value.HasValue)
-                {
-                    val = (byte)(value.Value ? 1 : 0);
-                }
-                SetTagValue("NoLocalPalette", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the image is interlaced.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public bool? Interlaced
-        {
-            get
-            {
-                byte? useGlobalPalette = GetTagValue<byte>("Interlaced");
-                return useGlobalPalette.HasValue ? (useGlobalPalette.Value != 0) : default(bool?);
-            }
-            set
-            {
-                byte? val = null;
-                if (value.HasValue)
-                {
-                    val = (byte)(value.Value ? 1 : 0);
-                }
-                SetTagValue("Interlaced", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the amout of time in milliseconds this frame is to be displayed.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? FrameTime
-        {
-            get
-            {
-                return GetTagValue<uint>("FrameTime");
-            }
-            set
-            {
-                SetTagValue("FrameTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets this frame's disposal method. Generally, this method defines, how to
-        /// remove or replace a frame when the next frame has to be drawn.<para/>
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DisposalMethodType? DisposalMethod
-        {
-            get
-            {
-                return GetTagValue<DisposalMethodType>("DisposalMethod");
-            }
-            set
-            {
-                SetTagValue("DisposalMethod", value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_COMMENTS"/>.
-    /// </summary>
-    public class MDM_COMMENTS : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_COMMENTS(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_COMMENTS; }
-        }
-
-        /// <summary>
-        /// Gets or sets the comment of the image.
-        /// Supported formats are JPEG, PNG and GIF.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Comment
-        {
-            get
-            {
-                return GetTagText("Comment");
-            }
-            set
-            {
-                SetTagValue("Comment", value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_CUSTOM"/>.
-    /// </summary>
-    public class MDM_CUSTOM : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_CUSTOM(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_CUSTOM; }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_EXIF"/>.
-    /// </summary>
-    public class MDM_EXIF_EXIF : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_EXIF_EXIF(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_EXIF; }
-        }
-
-        /// <summary>
-        /// Gets or sets the version of this standard supported.
-        /// Constant length or 4.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] ExifVersion
-        {
-            get
-            {
-                return GetTagArray<byte>("ExifVersion");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 4);
-                SetTagValueUndefined("ExifVersion", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the Flashpix format version supported by a FPXR file.
-        /// Constant length or 4.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] FlashpixVersion
-        {
-            get
-            {
-                return GetTagArray<byte>("FlashpixVersion");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 4);
-                SetTagValueUndefined("FlashpixVersion", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the color space information tag.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>sRGB (default)</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>0xFFFF</term>
-        ///			<description>uncalibrated</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? ColorSpace
-        {
-            get
-            {
-                return GetTagValue<ushort>("ColorSpace");
-            }
-            set
-            {
-                SetTagValue("ColorSpace", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the valid width of a compressed image.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? PixelXDimension
-        {
-            get
-            {
-                return GetUInt32Value("PixelXDimension");
-            }
-            set
-            {
-                RemoveTag("PixelXDimension");
-                if (value.HasValue)
-                {
-                    SetTagValue("PixelXDimension", value.Value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the valid height of a compressed image.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? PixelYDimension
-        {
-            get
-            {
-                return GetUInt32Value("PixelYDimension");
-            }
-            set
-            {
-                RemoveTag("PixelYDimension");
-                if (value.HasValue)
-                {
-                    SetTagValue("PixelYDimension", value.Value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets components configuration. See remarks for further information.
-        /// Constant length of 4.
-        /// </summary>
-        /// <remarks>
-        /// The channels of each component are arranged in order from the 1st component to the 4th.
-        /// For uncompressed data the data arrangement is given in the PhotometricInterpretation tag.
-        /// However, since PhotometricInterpretation can only express the order of Y,Cb and Cr,
-        /// this tag is provided for cases when compressed data uses components other than Y, Cb,
-        /// and Cr and to enable support of other sequences.<para/>
-        /// Default = 4 5 6 0 (if RGB uncompressed)<para/>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>does not exist</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>Y</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>Cb</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>Cr</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>R</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>5</term>
-        ///			<description>R</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>6</term>
-        ///			<description>R</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] ComponentsConfiguration
-        {
-            get
-            {
-                return GetTagArray<byte>("ComponentsConfiguration");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 4);
-                SetTagValueUndefined("ComponentsConfiguration", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets compression mode used for a compressed image is indicated
-        /// in unit bits per pixel.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? CompressedBitsPerPixel
-        {
-            get
-            {
-                return GetTagValue<FIURational>("CompressedBitsPerPixel");
-            }
-            set
-            {
-                SetTagValue("CompressedBitsPerPixel", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a tag for manufacturers of Exif writers to record any desired information.
-        /// The contents are up to the manufacturer, but this tag should not be used for any other
-        /// than its intended purpose.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] MakerNote
-        {
-            get
-            {
-                return GetTagArray<byte>("FlashpixVersion");
-            }
-            set
-            {
-                SetTagValueUndefined("FlashpixVersion", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a tag for Exif users to write keywords or comments on the image besides
-        /// those in ImageDescription, and without the character code limitations of the ImageDescription tag.
-        /// Minimum length of 8. See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The character code used in the UserComment tag is identified based on an ID code in a fixed 8-byte
-        /// area at the start of the tag data area. The unused portion of the area is padded with NULL.
-        /// The ID code for the UserComment area may be a Defined code such as JIS or ASCII, or may be Undefined.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] UserComment
-        {
-            get
-            {
-                return GetTagArray<byte>("UserComment");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 8, int.MaxValue);
-                SetTagValueUndefined("UserComment", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the name of an audio file related to the image data.
-        /// The format is 8.3.
-        /// Constant length of 12
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string RelatedSoundFile
-        {
-            get
-            {
-                string text = GetTagText("RelatedSoundFile");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    FreeImage.Resize(ref value, 12);
-                    value += '\0';
-                }
-                SetTagValue("RelatedSoundFile", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the date and time when the original image data was generated.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DateTime? DateTimeOriginal
-        {
-            get
-            {
-                DateTime? result = null;
-                string text = GetTagText("DateTimeOriginal");
-                if (text != null)
-                {
-                    try
-                    {
-                        result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
-                    }
-                    catch
-                    {
-                    }
-                }
-                return result;
-            }
-            set
-            {
-                string val = null;
-                if (value.HasValue)
-                {
-                    try
-                    {
-                        val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
-                    }
-                    catch
-                    {
-                    }
-                }
-                SetTagValue("DateTimeOriginal", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the date and time when the image was stored as digital data.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DateTime? DateTimeDigitized
-        {
-            get
-            {
-                DateTime? result = null;
-                string text = GetTagText("DateTimeDigitized");
-                if (text != null)
-                {
-                    try
-                    {
-                        result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
-                    }
-                    catch
-                    {
-                    }
-                }
-                return result;
-            }
-            set
-            {
-                string val = null;
-                if (value.HasValue)
-                {
-                    try
-                    {
-                        val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
-                    }
-                    catch
-                    {
-                    }
-                }
-                SetTagValue("DateTimeDigitized", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a tag used to record fractions of seconds for the DateTime tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SubsecTime
-        {
-            get
-            {
-                string text = GetTagText("SubsecTime");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("SubsecTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a tag used to record fractions of seconds for the DateTimeOriginal tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SubsecTimeOriginal
-        {
-            get
-            {
-                string text = GetTagText("SubsecTimeOriginal");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("SubsecTimeOriginal", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a tag used to record fractions of seconds for the DateTimeDigitized tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SubsecTimeDigitized
-        {
-            get
-            {
-                string text = GetTagText("SubsecTimeDigitized");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("SubsecTimeDigitized", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or the exposure time, given in seconds (sec).
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? ExposureTime
-        {
-            get
-            {
-                return GetTagValue<FIURational>("ExposureTime");
-            }
-            set
-            {
-                SetTagValue("ExposureTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or the F number.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? FNumber
-        {
-            get
-            {
-                return GetTagValue<FIURational>("FNumber");
-            }
-            set
-            {
-                SetTagValue("FNumber", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the class of the program used by the camera to set exposure when the
-        /// picture is taken.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>not defined</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>manual</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>normal program</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>aperture priority</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>shutter priority</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>5</term>
-        ///			<description>create program</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>6</term>
-        ///			<description>action program</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>7</term>
-        ///			<description>portrait mode</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>8</term>
-        ///			<description>landscape mode</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>others</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? ExposureProgram
-        {
-            get
-            {
-                return GetTagValue<ushort>("ExposureProgram");
-            }
-            set
-            {
-                SetTagValue("ExposureProgram", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the spectral sensitivity of each channel of the camera used.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SpectralSensitivity
-        {
-            get
-            {
-                string text = GetTagText("SpectralSensitivity");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("SpectralSensitivity", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the the ISO Speed and ISO Latitude of the camera or input device as
-        /// specified in ISO 12232.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] ISOSpeedRatings
-        {
-            get
-            {
-                return GetTagArray<ushort>("ISOSpeedRatings");
-            }
-            set
-            {
-                SetTagValue("ISOSpeedRatings", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the Opto-Electric Conversion Function (OECF) specified in ISO 14524.
-        /// OECF is the relationship between the camera optical input and the image values.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] OECF
-        {
-            get
-            {
-                return GetTagArray<byte>("OECF");
-            }
-            set
-            {
-                SetTagValueUndefined("OECF", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the shutter speed. The unit is the APEX (Additive System of Photographic Exposure).
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIRational? ShutterSpeedValue
-        {
-            get
-            {
-                return GetTagValue<FIRational>("ShutterSpeedValue");
-            }
-            set
-            {
-                SetTagValue("ShutterSpeedValue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the lens aperture. The unit is the APEX value.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? ApertureValue
-        {
-            get
-            {
-                return GetTagValue<FIURational>("ApertureValue");
-            }
-            set
-            {
-                SetTagValue("ApertureValue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of brightness. The unit is the APEX value.
-        /// Ordinarily it is given in the range of -99.99 to 99.99.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIRational? BrightnessValue
-        {
-            get
-            {
-                return GetTagValue<FIRational>("BrightnessValue");
-            }
-            set
-            {
-                SetTagValue("BrightnessValue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the exposure bias. The unit is the APEX value.
-        /// Ordinarily it is given in the range of –99.99 to 99.99.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIRational? ExposureBiasValue
-        {
-            get
-            {
-                return GetTagValue<FIRational>("ExposureBiasValue");
-            }
-            set
-            {
-                SetTagValue("ExposureBiasValue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the smallest F number of the lens. The unit is the APEX value.
-        /// Ordinarily it is given in the range of 00.00 to 99.99,
-        /// but it is not limited to this range.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? MaxApertureValue
-        {
-            get
-            {
-                return GetTagValue<FIURational>("MaxApertureValue");
-            }
-            set
-            {
-                SetTagValue("MaxApertureValue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets distance to the subject, given in meters.
-        /// Note that if the numerator of the recorded value is FFFFFFFF, infinity shall be indicated;
-        /// and if the numerator is 0, distance unknown shall be indicated.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? SubjectDistance
-        {
-            get
-            {
-                return GetTagValue<FIURational>("SubjectDistance");
-            }
-            set
-            {
-                SetTagValue("SubjectDistance", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the metering mode. See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>unknown</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>average</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>center-weighted-average</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>spot</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>multi-spot</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>5</term>
-        ///			<description>pattern</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>6</term>
-        ///			<description>partial</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>255</term>
-        ///			<description>other</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? MeteringMode
-        {
-            get
-            {
-                return GetTagValue<ushort>("MeteringMode");
-            }
-            set
-            {
-                SetTagValue("MeteringMode", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the kind of light source.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>unknown</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>daylight</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>fluorescent</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>tungsten</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>flash</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>9</term>
-        ///			<description>fine weather</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>10</term>
-        ///			<description>cloudy weather</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>11</term>
-        ///			<description>shade</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>12</term>
-        ///			<description>daylight fluorecent (D 5700 - 7100K)</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>13</term>
-        ///			<description>day white fluorescent (N 4600 - 5400K)</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>14</term>
-        ///			<description>cool white fluorescent (W 3900 - 4500K)</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>15</term>
-        ///			<description>white fluorescent (WW 3200 - 3700K)</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>17</term>
-        ///			<description>standard light A</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>18</term>
-        ///			<description>standard light B</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>19</term>
-        ///			<description>standard light C</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>20</term>
-        ///			<description>D55</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>21</term>
-        ///			<description>D65</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>22</term>
-        ///			<description>D75</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>23</term>
-        ///			<description>D50</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>24</term>
-        ///			<description>ISO studio tungsten</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>255</term>
-        ///			<description>other light source</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? LightSource
-        {
-            get
-            {
-                return GetTagValue<ushort>("LightSource");
-            }
-            set
-            {
-                SetTagValue("LightSource", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating the status of flash when the image was shot.
-        /// Bit 0 indicates the flash firing status, bits 1 and 2 indicate the flash return
-        /// status, bits 3 and 4 indicate the flash mode, bit 5 indicates whether the flash
-        /// function is present, and bit 6 indicates "red eye" mode.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? Flash
-        {
-            get
-            {
-                return GetTagValue<ushort>("Flash");
-            }
-            set
-            {
-                SetTagValue("Flash", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating the location and area of the main subject in
-        /// the overall scene. Variable length between 2 and 4.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] SubjectArea
-        {
-            get
-            {
-                return GetTagArray<ushort>("SubjectArea");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 2, 4);
-                SetTagValue("SubjectArea", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the actual focal length of the lens, in mm.
-        /// Conversion is not made to the focal length of a 35 mm film camera.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? FocalLength
-        {
-            get
-            {
-                return GetTagValue<FIURational>("FocalLength");
-            }
-            set
-            {
-                SetTagValue("FocalLength", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the strobe energy at the time the image is captured,
-        /// as measured in Beam Candle Power Seconds (BCPS).
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? FlashEnergy
-        {
-            get
-            {
-                return GetTagValue<FIURational>("FlashEnergy");
-            }
-            set
-            {
-                SetTagValue("FlashEnergy", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the camera or input device spatial frequency table and SFR values
-        /// in the direction of image width, image height, and diagonal direction,
-        /// as specified in ISO 12233.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] SpatialFrequencyResponse
-        {
-            get
-            {
-                return GetTagArray<byte>("SpatialFrequencyResponse");
-            }
-            set
-            {
-                SetTagValueUndefined("SpatialFrequencyResponse", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of pixels in the image width (X) direction per
-        /// FocalPlaneResolutionUnit on the camera focal plane.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? FocalPlaneXResolution
-        {
-            get
-            {
-                return GetTagValue<FIURational>("FocalPlaneXResolution");
-            }
-            set
-            {
-                SetTagValue("FocalPlaneXResolution", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of pixels in the image height (Y) direction per
-        /// FocalPlaneResolutionUnit on the camera focal plane.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? FocalPlaneYResolution
-        {
-            get
-            {
-                return GetTagValue<FIURational>("FocalPlaneYResolution");
-            }
-            set
-            {
-                SetTagValue("FocalPlaneYResolution", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the unit for measuring FocalPlaneXResolution and FocalPlaneYResolution.
-        /// This value is the same as the ResolutionUnit.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? FocalPlaneResolutionUnit
-        {
-            get
-            {
-                return GetTagValue<ushort>("FocalPlaneResolutionUnit");
-            }
-            set
-            {
-                SetTagValue("FocalPlaneResolutionUnit", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the location of the main subject in the scene.
-        /// The value of this tag represents the pixel at the center of the main subject
-        /// relative to the left edge, prior to rotation processing as per the Rotation tag.
-        /// The first value indicates the X column number and second indicates the Y row number.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? SubjectLocation
-        {
-            get
-            {
-                return GetTagValue<ushort>("SubjectLocation");
-            }
-            set
-            {
-                SetTagValue("SubjectLocation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the exposure index selected on the camera or input device at the
-        /// time the image was captured.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? ExposureIndex
-        {
-            get
-            {
-                return GetTagValue<FIURational>("ExposureIndex");
-            }
-            set
-            {
-                SetTagValue("ExposureIndex", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the image sensor type on the camera or input device.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are defined:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>not defined</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>one-chip color area sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>two-chip color area sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>three-chip color area sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>5</term>
-        ///			<description>color sequential area sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>7</term>
-        ///			<description>trilinear sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>8</term>
-        ///			<description>color sequential linear sensor</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? SensingMethod
-        {
-            get
-            {
-                return GetTagValue<ushort>("SensingMethod");
-            }
-            set
-            {
-                SetTagValue("SensingMethod", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the image source. If a DSC recorded the image, this tag value of this
-        /// tag always be set to 3, indicating that the image was recorded on a DSC.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte? FileSource
-        {
-            get
-            {
-                return GetTagValue<byte>("FileSource");
-            }
-            set
-            {
-                SetTagValueUndefined("FileSource", value.HasValue ? new byte[] { value.Value } : null);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the type of scene. If a DSC recorded the image, this tag value shall
-        /// always be set to 1, indicating that the image was directly photographed.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte? SceneType
-        {
-            get
-            {
-                return GetTagValue<byte>("SceneType");
-            }
-            set
-            {
-                SetTagValueUndefined("SceneType", value.HasValue ? new byte[] { value.Value } : null);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the color filter array (CFA) geometric pattern of the image sensor
-        /// when a one-chip color area sensor is used. It does not apply to all sensing methods.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] CFAPattern
-        {
-            get
-            {
-                return GetTagArray<byte>("CFAPattern");
-            }
-            set
-            {
-                SetTagValueUndefined("CFAPattern", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the use of special processing on image data, such as rendering geared to output.
-        /// When special processing is performed, the reader is expected to disable or minimize any
-        /// further processing. See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>normal process</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>custom process</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? CustomRendered
-        {
-            get
-            {
-                return GetTagValue<ushort>("CustomRendered");
-            }
-            set
-            {
-                SetTagValue("CustomRendered", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the exposure mode set when the image was shot.
-        /// In auto-bracketing mode, the camera shoots a series of frames of the same scene
-        /// at different exposure settings. See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>auto exposure</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>manual exposure</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>auto bracket</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? ExposureMode
-        {
-            get
-            {
-                return GetTagValue<ushort>("ExposureMode");
-            }
-            set
-            {
-                SetTagValue("ExposureMode", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the white balance mode set when the image was shot.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>auto white balance</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>manual white balance</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? WhiteBalance
-        {
-            get
-            {
-                return GetTagValue<ushort>("WhiteBalance");
-            }
-            set
-            {
-                SetTagValue("WhiteBalance", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the digital zoom ratio when the image was shot.
-        /// If the numerator of the recorded value is 0, this indicates that digital zoom was not used.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? DigitalZoomRatio
-        {
-            get
-            {
-                return GetTagValue<FIURational>("DigitalZoomRatio");
-            }
-            set
-            {
-                SetTagValue("DigitalZoomRatio", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the equivalent focal length assuming a 35mm film camera, in mm.
-        /// A value of 0 means the focal length is unknown. Note that this tag differs
-        /// from the FocalLength tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? FocalLengthIn35mmFilm
-        {
-            get
-            {
-                return GetTagValue<ushort>("DigitalZoomRatio");
-            }
-            set
-            {
-                SetTagValue("DigitalZoomRatio", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the type of scene that was shot.
-        /// It can also be used to record the mode in which the image was shot.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>standard</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>landscape</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>portrait</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>night scene</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? SceneCaptureType
-        {
-            get
-            {
-                return GetTagValue<ushort>("SceneCaptureType");
-            }
-            set
-            {
-                SetTagValue("SceneCaptureType", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the degree of overall image gain adjustment.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>none</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>low gain up</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>high gain up</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>low gain down</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>4</term>
-        ///			<description>high gain down</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? GainControl
-        {
-            get
-            {
-                return GetTagValue<ushort>("GainControl");
-            }
-            set
-            {
-                SetTagValue("GainControl", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the direction of contrast processing applied by the camera
-        /// when the image was shot.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>normal</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>soft</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>hard</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? Contrast
-        {
-            get
-            {
-                return GetTagValue<ushort>("Contrast");
-            }
-            set
-            {
-                SetTagValue("Contrast", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the direction of saturation processing applied by the camera
-        /// when the image was shot.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>normal</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>low saturation</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>high saturation</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? Saturation
-        {
-            get
-            {
-                return GetTagValue<ushort>("Saturation");
-            }
-            set
-            {
-                SetTagValue("Saturation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the direction of sharpness processing applied by the camera
-        /// when the image was shot.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>normal</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>soft</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>hard</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? Sharpness
-        {
-            get
-            {
-                return GetTagValue<ushort>("Sharpness");
-            }
-            set
-            {
-                SetTagValue("Sharpness", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets information on the picture-taking conditions of a particular camera model.
-        /// The tag is used only to indicate the picture-taking conditions in the reader.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] DeviceSettingDescription
-        {
-            get
-            {
-                return GetTagArray<byte>("DeviceSettingDescription");
-            }
-            set
-            {
-                SetTagValueUndefined("DeviceSettingDescription", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the distance to the subject.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>0</term>
-        ///			<description>unknown</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>macro</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>close view</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>distant view</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? SubjectDistanceRange
-        {
-            get
-            {
-                return GetTagValue<ushort>("SubjectDistanceRange");
-            }
-            set
-            {
-                SetTagValue("SubjectDistanceRange", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets an identifier assigned uniquely to each image.
-        /// It is recorded as an ASCII string equivalent to hexadecimal notation and 128-bit fixed length.
-        /// Constant length of 32.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ImageUniqueID
-        {
-            get
-            {
-                string text = GetTagText("ImageUniqueID");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    FreeImage.Resize(ref value, 32);
-                    value += '\0';
-                }
-                SetTagValue("ImageUniqueID", value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_GPS"/>.
-    /// </summary>
-    public class MDM_EXIF_GPS : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_EXIF_GPS(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_GPS; }
-        }
-
-        /// <summary>
-        /// Gets or sets the GPS version ID. Constant length of 4.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] VersionID
-        {
-            get
-            {
-                return GetTagArray<byte>("GPSVersionID");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 4);
-                SetTagValue("GPSVersionID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the <see cref="Latitude"/>
-        /// is north or south latitude.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public LatitudeType? LatitudeDirection
-        {
-            get
-            {
-                return ToLatitudeType(GetTagText("GPSLatitudeRef"));
-            }
-            set
-            {
-                SetTagValue("GPSLatitudeRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the latitude of the image. The latitude is expressed as three rational
-        /// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="LatitudeDirection"/>
-        public FIURational[] Latitude
-        {
-            get
-            {
-                return GetTagArray<FIURational>("GPSLatitude");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("GPSLatitude", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether <see cref="Longitude"/>
-        /// is east or west longitude.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public LongitudeType? LongitudeDirection
-        {
-            get
-            {
-                return ToLongitudeType(GetTagText("GPSLongitudeRef"));
-            }
-            set
-            {
-                SetTagValue("GPSLongitudeRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the longitude of the image. The longitude is expressed as three rational
-        /// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="LongitudeDirection"/>
-        public FIURational[] Longitude
-        {
-            get
-            {
-                return GetTagArray<FIURational>("GPSLongitude");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("GPSLongitude", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether <see cref="Altitude"/> is sea level and the altitude
-        /// is above sea level. If the altitude is below sea level <see cref="Altitude"/> is
-        /// indicated as an absolute value.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public AltitudeType? AltitudeDirection
-        {
-            get
-            {
-                byte? flag = GetTagValue<byte>("GPSAltitudeRef");
-                if (flag.HasValue)
-                {
-                    switch (flag.Value)
-                    {
-                        case 0:
-                            return AltitudeType.AboveSeaLevel;
-                        case 1:
-                            return AltitudeType.BelowSeaLevel;
-                        default:
-                            return AltitudeType.Undefined;
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                byte? val = null;
-                if (value.HasValue)
-                {
-                    switch (value.Value)
-                    {
-                        case AltitudeType.AboveSeaLevel:
-                            val = 0;
-                            break;
-
-                        case AltitudeType.BelowSeaLevel:
-                            val = 1;
-                            break;
-
-                        default:
-                            val = 2;
-                            break;
-                    }
-                }
-                SetTagValue("GPSAltitudeRef", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the altitude based on the reference in <see cref="AltitudeDirection"/>.
-        /// Altitude is expressed as one rational value. The reference unit is meters.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? Altitude
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSAltitude");
-            }
-            set
-            {
-                SetTagValue("GPSAltitude", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the sign of the <see cref="SignedAltitude"/>.
-        /// </summary>
-        /// <remarks>
-        /// This is a derived property. There is no metadata tag directly associated
-        /// with this property value.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public int? AltitudeSign
-        {
-            get
-            {
-                AltitudeType? seaLevel = AltitudeDirection;
-                if (seaLevel.HasValue)
-                {
-                    return (seaLevel.Value == AltitudeType.BelowSeaLevel) ? -1 : 1;
-                }
-                return null;
-            }
-            set
-            {
-                if (value.HasValue)
-                {
-                    AltitudeDirection = value.Value >= 0 ? AltitudeType.AboveSeaLevel : AltitudeType.BelowSeaLevel;
-                }
-                else
-                {
-                    AltitudeDirection = null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the signed altitude.
-        /// Altitude is expressed as one rational value. The reference unit is meters.
-        /// </summary>
-        /// <exception cref="OverflowException">
-        /// Altitude is too large to fit into a FIRational.
-        /// </exception>
-        /// <remarks>
-        /// This is a derived property. There is no metadata tag directly associated
-        /// with this property value.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIRational? SignedAltitude
-        {
-            get
-            {
-                FIRational? result = null;
-                FIURational? altitude = Altitude;
-                if (altitude.HasValue)
-                {
-                    int sign = AltitudeSign ?? 1;
-                    if (((int)altitude.Value.Numerator < 0) || ((int)altitude.Value.Denominator < 0))
-                        throw new OverflowException();
-                    result = new FIRational((int)altitude.Value.Numerator * sign, (int)altitude.Value.Denominator);
-                }
-                return result;
-            }
-            set
-            {
-                FIURational? val = null;
-                if (value.HasValue)
-                {
-                    if (value.Value < 0)
-                    {
-                        AltitudeSign = -1;
-                        value = -value.Value;
-                    }
-                    else
-                    {
-                        AltitudeSign = 1;
-                    }
-                    val = new FIURational((uint)value.Value.Numerator, (uint)value.Value.Denominator);
-                }
-                Altitude = val;
-            }
-        }
-
-
-        /// <summary>
-        /// Gets or sets the time as UTC (Coordinated Universal Time). Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public TimeSpan? TimeStamp
-        {
-            get
-            {
-                FIURational[] stamp = GetTagArray<FIURational>("GPSTimeStamp");
-                if ((stamp == null) || stamp.Length != 3)
-                {
-                    return null;
-                }
-                else
-                {
-                    return new TimeSpan((int)stamp[0], (int)stamp[1], (int)stamp[2]);
-                }
-            }
-            set
-            {
-                FIURational[] stamp = null;
-                if (value.HasValue)
-                {
-                    TimeSpan span = value.Value;
-                    stamp = new FIURational[3];
-                    stamp[0] = span.Hours;
-                    stamp[1] = span.Minutes;
-                    stamp[2] = span.Seconds;
-                }
-                SetTagValue("GPSTimeStamp", stamp);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the GPS satellites used for measurements. This tag can be used to describe
-        /// the number of satellites, their ID number, angle of elevation, azimuth, SNR and other
-        /// information in ASCII notation. The format is not specified.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Satellites
-        {
-            get
-            {
-                string result = GetTagText("GPSSatellites");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("GPSTimeStamp", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating the status of the GPS receiver when the image was recorded.
-        /// <b>true</b> indicates measurement was in progress;
-        /// <b>false</b> indicates measurement was Interoperability.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public bool? Status
-        {
-            get
-            {
-                string text = GetTagText("GPSStatus");
-                return string.IsNullOrEmpty(text) ? default(bool?) : text[0] == 'A';
-            }
-            set
-            {
-                SetTagValue("GPSStatus", value.HasValue ? (value.Value ? "A\0" : "V\0") : null);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating the GPS measurement mode.
-        /// <b>true</b> indicates three-dimensional measurement;
-        /// <b>false</b> indicated two-dimensional measurement was in progress.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public bool? MeasureMode3D
-        {
-            get
-            {
-                string text = GetTagText("GPSMeasureMode");
-                return string.IsNullOrEmpty(text) ? default(bool?) : text[0] == '3';
-            }
-            set
-            {
-                SetTagValue("GPSMeasureMode", value.HasValue ? (value.Value ? "3\0" : "2\0") : null);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the GPS DOP (data degree of precision). An HDOP value is written during
-        /// two-dimensional measurement, and PDOP during three-dimensional measurement.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? DOP
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSDOP");
-            }
-            set
-            {
-                SetTagValue("GPSDOP", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the unit used to express the GPS receiver <see cref="Speed"/> of movement.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="Speed"/>
-        public VelocityUnit? SpeedUnit
-        {
-            get
-            {
-                return ToUnitType(GetTagText("GPSSpeedRef"));
-            }
-            set
-            {
-                SetTagValue("GPSSpeedRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the speed of GPS receiver movement.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="SpeedUnit"/>
-        public FIURational? Speed
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSSpeed");
-            }
-            set
-            {
-                SetTagValue("GPSSpeed", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the reference for giving the direction of GPS receiver movement.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="Track"/>
-        public DirectionReference? TrackDirectionReference
-        {
-            get
-            {
-                return ToDirectionType(GetTagText("GPSTrackRef"));
-            }
-            set
-            {
-                SetTagValue("GPSTrackRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the direction of GPS receiver movement.
-        /// The range of values is from 0.00 to 359.99.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="TrackDirectionReference"/>
-        public FIURational? Track
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSTrack");
-            }
-            set
-            {
-                SetTagValue("GPSTrack", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the reference for giving the direction of GPS receiver movement.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="ImageDirection"/>
-        public DirectionReference? ImageDirectionReference
-        {
-            get
-            {
-                return ToDirectionType(GetTagText("GPSImgDirectionRef"));
-            }
-            set
-            {
-                SetTagValue("GPSImgDirectionRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the direction of the image when it was captured.
-        /// The range of values is from 0.00 to 359.99.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="ImageDirectionReference"/>
-        public FIURational? ImageDirection
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSImgDirection");
-            }
-            set
-            {
-                SetTagValue("GPSImgDirection", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the geodetic survey data used by the GPS receiver. If the survey data
-        /// is restricted to Japan, the value of this tag is 'TOKYO' or 'WGS-84'.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string MapDatum
-        {
-            get
-            {
-                string result = GetTagText("GPSMapDatum");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                SetTagValue("GPSMapDatum", value + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the destination point
-        /// is north or south latitude.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="Latitude"/>
-        public LatitudeType? DestinationLatitudeDirection
-        {
-            get
-            {
-                return ToLatitudeType(GetTagText("GPSDestLatitudeRef"));
-            }
-            set
-            {
-                SetTagValue("GPSDestLatitudeRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the latitude of the destination point. The latitude is expressed as three rational
-        /// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="DestinationLatitudeDirection"/>
-        public FIURational[] DestinationLatitude
-        {
-            get
-            {
-                return GetTagArray<FIURational>("GPSDestLatitude");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("GPSDestLatitude", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the destination point
-        /// is east or west longitude.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="Latitude"/>
-        public LongitudeType? DestinationLongitudeDirection
-        {
-            get
-            {
-                return ToLongitudeType(GetTagText("GPSDestLongitudeRef"));
-            }
-            set
-            {
-                SetTagValue("GPSDestLongitudeRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the longitude of the destination point. The longitude is expressed as three rational
-        /// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational[] DestinationLongitude
-        {
-            get
-            {
-                return GetTagArray<FIURational>("GPSDestLongitude");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("GPSDestLongitude", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the reference used for giving the bearing to the destination point.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="DestinationBearing"/>
-        public DirectionReference? DestinationDirectionReference
-        {
-            get
-            {
-                return ToDirectionType(GetTagText("GPSDestBearingRef"));
-            }
-            set
-            {
-                SetTagValue("GPSDestBearingRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the bearing to the destination point.
-        /// The range of values is from 0.00 to 359.99.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="DestinationDirectionReference"/>
-        public FIURational? DestinationBearing
-        {
-            get
-            {
-                return GetTagValue<FIURational>("GPSDestBearing");
-            }
-            set
-            {
-                SetTagValue("GPSDestBearing", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the unit used to express the distance to the destination point.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="DestinationBearing"/>
-        public VelocityUnit? DestinationUnit
-        {
-            get
-            {
-                return ToUnitType(GetTagText("GPSDestDistanceRef"));
-            }
-            set
-            {
-                SetTagValue("GPSDestDistanceRef", ToString(value) + '\0');
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a character string recording the name of the method used
-        /// for location finding. The first byte indicates the character code used,
-        /// and this is followed by the name of the method. Since the Type is not ASCII,
-        /// NULL termination is not necessary.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] ProcessingMethod
-        {
-            get
-            {
-                return GetTagArray<byte>("GPSProcessingMethod");
-            }
-            set
-            {
-                SetTagValue("GPSProcessingMethod", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a character string recording the name of the GPS area.
-        /// The first byte indicates the character code used, and this is followed by
-        /// the name of the GPS area. Since the Type is not ASCII, NULL termination is
-        /// not necessary. 
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public byte[] AreaInformation
-        {
-            get
-            {
-                return GetTagArray<byte>("GPSAreaInformation");
-            }
-            set
-            {
-                SetTagValue("GPSAreaInformation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets date and time information relative to UTC (Coordinated Universal Time). 
-        /// </summary>
-        /// <remarks>
-        /// This is a derived property. There is no metadata tag directly associated
-        /// with this property value.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DateTime? DateTimeStamp
-        {
-            get
-            {
-                DateTime? date = DateStamp;
-                TimeSpan? time = TimeStamp;
-                if ((date == null) && (time == null))
-                {
-                    return null;
-                }
-                else
-                {
-                    if (date == null)
-                    {
-                        date = DateTime.MinValue;
-                    }
-                    if (time == null)
-                    {
-                        time = TimeSpan.MinValue;
-                    }
-                    return date.Value.Add(time.Value);
-                }
-            }
-            set
-            {
-                if (value.HasValue)
-                {
-                    DateStamp = value.Value.Date;
-                    TimeStamp = value.Value.TimeOfDay;
-                }
-                else
-                {
-                    DateStamp = null;
-                    TimeStamp = null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets date information relative to UTC (Coordinated Universal Time).
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DateTime? DateStamp
-        {
-            get
-            {
-                string stamp = GetTagText("GPSDateStamp");
-                if (stamp != null)
-                {
-                    try
-                    {
-                        return DateTime.ParseExact(stamp, "yyyy:MM:dd\0", null);
-                    }
-                    catch
-                    {
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                string val = null;
-                if (value.HasValue)
-                {
-                    try
-                    {
-                        val = value.Value.ToString("yyyy:MM:dd\0");
-                    }
-                    catch
-                    {
-                    }
-                }
-                SetTagValue("GPSDateStamp", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether differential correction was applied to
-        /// the GPS receiver. 
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public bool? IsDifferential
-        {
-            get
-            {
-                ushort? value = GetTagValue<ushort>("GPSDifferential");
-                return value.HasValue ? (value != 0) : (default(bool?));
-            }
-            set
-            {
-                SetTagValue("GPSDifferential", value.HasValue ? (object)(value.Value ? (ushort)1 : (ushort)0) : (null));
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_INTEROP"/>.
-    /// </summary>
-    public class MDM_INTEROP : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_INTEROP(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_INTEROP; }
-        }
-
-        /// <summary>
-        /// Gets or sets the identification of the Interoperability rule.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public InteroperabilityMode? Identification
-        {
-            get
-            {
-                return ToInteroperabilityType(GetTagText("InteroperabilityIndex"));
-            }
-            set
-            {
-                SetTagValue("InteroperabilityIndex", ToString(value) + '\0');
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN"/>.
-    /// <para/>
-    /// <b>This class is obsolete. Use class <see cref="MDM_EXIF_MAIN"/> instead.</b>
-    /// </summary>
-    [Obsolete("To be removed in future releases. Use MDM_EXIF_MAIN instead.")]
-    public class MDM_MAIN : MDM_EXIF_MAIN
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_MAIN(FIBITMAP dib) : base(dib) { }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN"/>.
-    /// </summary>
-    public class MDM_EXIF_MAIN : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_EXIF_MAIN(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN; }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of columns of image data, equal to the number
-        /// of pixels per row. In JPEG compressed data a JPEG marker is used
-        /// instead of this tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? ImageWidth
-        {
-            get
-            {
-                return GetUInt32Value("ImageWidth");
-            }
-            set
-            {
-                RemoveTag("ImageWidth");
-                if (value.HasValue)
-                {
-                    SetTagValue("ImageWidth", value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets number of rows of image data. In JPEG compressed data a JPEG marker
-        /// is used instead of this tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? ImageHeight
-        {
-            get
-            {
-                return GetUInt32Value("ImageLength");
-            }
-            set
-            {
-                RemoveTag("ImageLength");
-                if (value.HasValue)
-                {
-                    SetTagValue("ImageLength", value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets number of bits per image component. In this standard
-        /// each component of the image is 8 bits, so the value for this tag is 8.
-        /// Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] BitsPerSample
-        {
-            get
-            {
-                return GetTagArray<ushort>("BitsPerSample");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("BitsPerSample", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets compression scheme used for the image data. When a primary image
-        /// is JPEG compressed, this designation is not necessary and is omitted.
-        /// When thumbnails use JPEG compression, this tag value is set to 6.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? Compression
-        {
-            get
-            {
-                return GetTagValue<ushort>("Compression");
-            }
-            set
-            {
-                SetTagValue("Compression", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets pixel composition. In JPEG compressed data a JPEG marker is
-        /// used instead of this tag. See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>RGB</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>6</term>
-        ///			<description>YCbCr</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? PhotometricInterpretation
-        {
-            get
-            {
-                return GetTagValue<ushort>("PhotometricInterpretation");
-            }
-            set
-            {
-                SetTagValue("PhotometricInterpretation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the image orientation viewed in terms of rows and columns.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ExifImageOrientation? Orientation
-        {
-            get
-            {
-                return (ExifImageOrientation?)GetTagValue<ushort>("Orientation");
-            }
-            set
-            {
-                SetTagValue("Orientation", (ushort?)value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of components per pixel. Since this standard applies
-        /// to RGB and YCbCr images, the value set for this tag is 3. In JPEG compressed
-        /// data a JPEG marker is used instead of this tag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? SamplesPerPixel
-        {
-            get
-            {
-                return GetTagValue<ushort>("SamplesPerPixel");
-            }
-            set
-            {
-                SetTagValue("SamplesPerPixel", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value that indicates whether pixel components are recorded in
-        /// chunky or planar format. In JPEG compressed files a JPEG marker is used instead
-        /// of this tag. If this field does not exist, the TIFF default of 1 (chunky) is assumed.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>chunky format</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>planar format</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? PlanarConfiguration
-        {
-            get
-            {
-                return GetTagValue<ushort>("PlanarConfiguration");
-            }
-            set
-            {
-                SetTagValue("PlanarConfiguration", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the sampling ratio of chrominance components in relation to
-        /// the luminance component. In JPEG compressed dat a JPEG marker is used
-        /// instead of this tag.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>[2,1]</term>
-        ///			<description>YCbCr4:2:2</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>[2,2]</term>
-        ///			<description>YCbCr4:2:0</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] YCbCrSubSampling
-        {
-            get
-            {
-                return GetTagArray<ushort>("YCbCrSubSampling");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 2);
-                SetTagValue("YCbCrSubSampling", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets position of chrominance components in relation to the luminance component.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// This field is designated only for JPEG compressed data or uncompressed YCbCr data.
-        /// The TIFF default is 1 (centered); but when Y:Cb:Cr = 4:2:2 it is recommended in
-        /// this standard that 2 (co-sited) be used to record data, in order to improve the
-        /// image quality when viewed on TV systems.
-        /// <para/>
-        /// When this field does not exist, the reader shall assume the TIFF default.
-        /// In the case of Y:Cb:Cr = 4:2:0, the TIFF default (centered) is recommended.
-        /// If the reader does not have the capability of supporting both kinds of YCbCrPositioning,
-        /// it shall follow the TIFF default regardless of the value in this field.
-        /// It is preferable that readers be able to support both centered and co-sited positioning.
-        /// <para/>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>1</term>
-        ///			<description>centered</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>co-sited</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>reserved</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? YCbCrPositioning
-        {
-            get
-            {
-                return GetTagValue<ushort>("YCbCrPositioning");
-            }
-            set
-            {
-                SetTagValue("YCbCrPositioning", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of pixels per <see cref="ResolutionUnit"/>
-        /// in the <see cref="ImageWidth"/> direction. When the image resolution is unknown,
-        /// 72 [dpi] is designated.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? XResolution
-        {
-            get
-            {
-                return GetTagValue<FIURational>("XResolution");
-            }
-            set
-            {
-                SetTagValue("XResolution", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of pixels per <see cref="ResolutionUnit"/>
-        /// in the <see cref="ImageHeight"/> direction. When the image resolution is unknown,
-        /// 72 [dpi] is designated.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational? YResolution
-        {
-            get
-            {
-                return GetTagValue<FIURational>("YResolution");
-            }
-            set
-            {
-                SetTagValue("YResolution", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the unit for measuring <see cref="XResolution"/> and <see cref="YResolution"/>.
-        /// The same unit is used for both <see cref="XResolution"/> and <see cref="YResolution"/>.
-        /// If the image resolution in unknown, 2 (inches) is designated.
-        /// See remarks for further information.
-        /// </summary>
-        /// <remarks>
-        /// The following values are definied:<para/>
-        /// <list type="table">
-        ///		<listheader>
-        ///			<term>ID</term>
-        ///			<description>Description</description>
-        ///		</listheader>
-        ///		<item>
-        ///			<term>2</term>
-        ///			<description>inches</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>3</term>
-        ///			<description>YCbCr4:2:0</description>
-        ///		</item>
-        ///		<item>
-        ///			<term>other</term>
-        ///			<description>centimeters</description>
-        ///		</item>
-        /// </list>
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort? ResolutionUnit
-        {
-            get
-            {
-                return GetTagValue<ushort>("ResolutionUnit");
-            }
-            set
-            {
-                SetTagValue("ResolutionUnit", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the byte offset of that strip.
-        /// It is recommended that this be selected so the number of strip bytes
-        /// does not exceed 64 Kbytes.
-        /// With JPEG compressed data this designation is not needed and is omitted.
-        /// Constant length of <see cref="SamplesPerPixel"/> * StripsPerImage.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="RowsPerStrip"/>
-        /// <see cref="StripByteCounts"/>
-        public uint[] StripOffsets
-        {
-            get
-            {
-                return GetUInt32Array("StripOffsets");
-            }
-            set
-            {
-                RemoveTag("StripOffsets");
-                if (value != null)
-                {
-                    SetTagValue("StripOffsets", value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets number of rows per strip. This is the number of rows in the image of
-        /// one strip when an image is divided into strips. With JPEG compressed data this
-        /// designation is not needed and is omitted.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        /// <seealso cref="StripByteCounts"/>
-        public uint? RowsPerStrip
-        {
-            get
-            {
-                return GetUInt32Value("RowsPerStrip");
-            }
-            set
-            {
-                RemoveTag("RowsPerStrip");
-                if (value.HasValue)
-                {
-                    SetTagValue("RowsPerStrip", value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the total number of bytes in each strip.
-        /// With JPEG compressed data this designation is not needed and is omitted.
-        /// Constant length of <see cref="SamplesPerPixel"/> * StripsPerImage.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint[] StripByteCounts
-        {
-            get
-            {
-                return GetUInt32Array("StripByteCounts");
-            }
-            set
-            {
-                RemoveTag("StripByteCounts");
-                if (value != null)
-                {
-                    SetTagValue("StripByteCounts", value);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the offset to the start byte (SOI) of JPEG compressed thumbnail data.
-        /// This is not used for primary image JPEG data.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? JPEGInterchangeFormat
-        {
-            get
-            {
-                return GetTagValue<uint>("JPEGInterchangeFormat");
-            }
-            set
-            {
-                SetTagValue("JPEGInterchangeFormat", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the number of bytes of JPEG compressed thumbnail data.
-        /// </summary>
-        /// <remarks>
-        /// This is not used for primary image JPEG data.
-        /// JPEG thumbnails are not divided but are recorded as a continuous
-        /// JPEG bitstream from SOI to EOI. APPn and COM markers should not be recorded.
-        /// Compressed thumbnails shall be recorded in no more than 64 Kbytes,
-        /// including all other data to be recorded in APP1.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? JPEGInterchangeFormatLength
-        {
-            get
-            {
-                return GetTagValue<uint>("JPEGInterchangeFormatLength");
-            }
-            set
-            {
-                SetTagValue("JPEGInterchangeFormatLength", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a transfer function for the image, described in tabular style.
-        /// Constant length of 3 * 256.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] TransferFunction
-        {
-            get
-            {
-                return GetTagArray<ushort>("TransferFunction");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3 * 256);
-                SetTagValue("TransferFunction", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the chromaticity of the white point of the image.
-        /// Constant length of 2.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational[] WhitePoint
-        {
-            get
-            {
-                return GetTagArray<FIURational>("WhitePoint");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 2);
-                SetTagValue("WhitePoint", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the chromaticity of the three primary colors of the image.
-        /// Constant length of 6.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational[] PrimaryChromaticities
-        {
-            get
-            {
-                return GetTagArray<FIURational>("PrimaryChromaticities");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 6);
-                SetTagValue("PrimaryChromaticities", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the matrix coefficients for transformation from RGB to YCbCr image data.
-        /// Constant length of 3.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational[] YCbCrCoefficients
-        {
-            get
-            {
-                return GetTagArray<FIURational>("YCbCrCoefficients");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 3);
-                SetTagValue("PrimaryChromaticities", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the reference black point value and reference white point value.
-        /// Constant length of 6.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public FIURational[] ReferenceBlackWhite
-        {
-            get
-            {
-                return GetTagArray<FIURational>("ReferenceBlackWhite");
-            }
-            set
-            {
-                FreeImage.Resize(ref value, 6);
-                SetTagValue("ReferenceBlackWhite", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the date and time of image creation.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public DateTime? DateTime
-        {
-            get
-            {
-                DateTime? result = null;
-                string text = GetTagText("DateTime");
-                if (text != null)
-                {
-                    try
-                    {
-                        result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
-                    }
-                    catch
-                    {
-                    }
-                }
-                return result;
-            }
-            set
-            {
-                string val = null;
-                if (value.HasValue)
-                {
-                    try
-                    {
-                        val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
-                    }
-                    catch
-                    {
-                    }
-                }
-                SetTagValue("DateTime", val);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a string giving the title of the image.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ImageDescription
-        {
-            get
-            {
-                string result = GetTagText("ImageDescription");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("ImageDescription", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the manufacturer of the recording equipment.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Make
-        {
-            get
-            {
-                string result = GetTagText("Make");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("Make", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the model name or model number of the equipment.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string EquipmentModel
-        {
-            get
-            {
-                string result = GetTagText("Model");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("Model", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the name and version of the software or firmware of the camera
-        /// or image input device used to generate the image.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Software
-        {
-            get
-            {
-                string result = GetTagText("Software");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("Software", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the camera owner, photographer or image creator.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Artist
-        {
-            get
-            {
-                string result = GetTagText("Artist");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    result = result.Substring(0, result.Length - 1);
-                }
-                return result;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("Artist", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the photographer and editor copyrights.
-        /// Constant length of 1-2.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string[] Copyright
-        {
-            get
-            {
-                string[] result = null;
-                string text = GetTagText("Copyright");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    result = text.Split(new char[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
-                }
-                return result;
-            }
-            set
-            {
-                string val = null;
-                if (value != null)
-                {
-                    if (value.Length == 1)
-                    {
-                        if (value[0] != null)
-                        {
-                            val = value[0] + '\0';
-                        }
-                    }
-                    else if (value.Length == 2)
-                    {
-                        if ((value[0] != null) && (value[1] != null))
-                        {
-                            val = value[0] + '\0' + value[1] + '\0';
-                        }
-                    }
-                }
-                SetTagValue("Copyright", val);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAKERNOTE"/>.
-    /// </summary>
-    public class MDM_MAKERNOTE : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_MAKERNOTE(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_MAKERNOTE; }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_GEOTIFF"/>.
-    /// </summary>
-    public class MDM_GEOTIFF : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_GEOTIFF(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_GEOTIFF; }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF GeoASCIIParamsTag.
-        /// </summary>
-        /// <remarks>
-        /// The GeoASCIIParamsTag is used to store all of the <see cref="String"/> valued
-        /// GeoKeys, referenced by the <see cref="GeoKeyDirectory"/> property. Since keys
-        /// defined in the GeoKeyDirectoryTag use offsets into this tag, any special
-        /// comments may be placed at the beginning of this tag.
-        /// For the most part, the only keys that are <see cref="String"/> valued are
-        /// <i>Citation</i> keys, giving documentation and references for obscure
-        /// projections, datums, etc.
-        /// <para/>
-        /// Special handling is required for <see cref="String"/>-valued keys. While it
-        /// is true that TIFF 6.0 permits multiple NULL-delimited strings within a single
-        /// ASCII tag, the secondary strings might not appear in the output of naive
-        /// <i>tiffdump</i> programs. For this reason, the NULL delimiter of each ASCII key
-        /// value shall be converted to a "|" (pipe) character before being installed
-        /// back into the <see cref="String"/> holding tag, so that a dump of the tag
-        /// will look like this.
-        /// <para/>
-        /// AsciiTag="first_value|second_value|etc...last_value|"
-        /// <para/>
-        /// A baseline GeoTIFF-reader must check for and convert the final "|" pipe 
-        /// character of a key back into a NULL before returning it to the client 
-        /// software.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string GeoASCIIParams
-        {
-            get
-            {
-                string text = GetTagText("GeoASCIIParams");
-                if (!string.IsNullOrEmpty(text))
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                return text;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    value += '\0';
-                }
-                SetTagValue("GeoASCIIParams", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF GeoDoubleParamsTag.
-        /// </summary>
-        /// <remarks>
-        /// The GeoDoubleParamsTag is used to store all of the <see cref="Double"/> valued
-        /// GeoKeys, referenced by the <see cref="GeoKeyDirectory"/> property. The meaning of
-        /// any value of this double array is determined from the GeoKeyDirectoryTag reference
-        /// pointing to it. <see cref="Single"/> values should first be converted to
-        /// <see cref="Double"/> and stored here.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public double[] GeoDoubleParams
-        {
-            get
-            {
-                return GetTagArray<double>("GeoDoubleParams");
-            }
-            set
-            {
-                SetTagValue("GeoDoubleParams", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF GeoKeyDirectoryTag.
-        /// </summary>
-        /// <remarks>
-        /// The GeoKeyDirectoryTag may be used to store the GeoKey Directory, which defines and
-        /// references the <i>GeoKeys</i>.
-        /// <para/>
-        /// The tag is an array of unsigned <see cref="UInt16"/> values, which are primarily
-        /// grouped into blocks of 4. The first 4 values are special, and contain GeoKey directory
-        /// header information. The header values consist of the following information, in order:
-        /// <para/>
-        /// Header={KeyDirectoryVersion, KeyRevision, MinorRevision, NumberOfKeys}
-        /// <para/>
-        /// where
-        /// <para/>
-        /// <i>KeyDirectoryVersion</i> indicates the current version of Key implementation, and will
-        /// only change if this Tag's Key structure is changed. (Similar to the TIFFVersion (42)).
-        /// The current DirectoryVersion number is 1. This value will most likely never change,
-        /// and may be used to ensure that this is a valid Key-implementation.
-        /// <para/>
-        /// <i>KeyRevision</i> indicates what revision of Key-Sets are used.
-        /// <para/>
-        /// <i>MinorRevision</i> indicates what set of Key-Codes are used. The complete revision number
-        /// is denoted &lt;KeyRevision&gt;.&lt;MinorRevision&gt;.
-        /// <para/>
-        /// <i>NumberOfKeys</i> indicates how many Keys are defined by the rest of this Tag.
-        /// <para/>
-        /// This header is immediately followed by a collection of &lt;NumberOfKeys&gt; KeyEntry
-        /// sets, each of which is also 4-<see cref="UInt16"/> long. Each KeyEntry is modeled on the
-        /// <i>TIFFEntry</i> format of the TIFF directory header, and is of the form:
-        /// <para/>
-        /// KeyEntry = { KeyID, TIFFTagLocation, Count, Value_Offset }
-        /// <para/>
-        /// where
-        /// <para/>
-        /// <i>KeyID</i> gives the Key-ID value of the Key (identical in function to TIFF tag ID,
-        /// but completely independent of TIFF tag-space),
-        /// <para/>
-        /// <i>TIFFTagLocation</i> indicates which TIFF tag contains the value(s) of the Key: if
-        /// TIFFTagLocation is 0, then the value is <see cref="UInt16"/>, and is contained in the
-        /// <i>Value_Offset</i> entry. Otherwise, the type (format) of the value is implied by the
-        /// TIFF-Type of the tag containing the value.
-        /// <para/>
-        /// <i>Count</i> indicates the number of values in this key.
-        /// <para/>
-        /// <i>Value_Offset</i> Value_Offset indicates the index-offset into the TagArray indicated
-        /// by TIFFTagLocation, if it is nonzero. If TIFFTagLocation is 0 (zero) , then Value_Offset 
-        /// contains the actual (<see cref="UInt16"/>) value of the Key, and Count=1 is implied.
-        /// Note that the offset is not a byte-offset, but rather an index based on the natural data
-        /// type of the specified tag array.
-        /// <para/>
-        /// Following the KeyEntry definitions, the KeyDirectory tag may also contain additional
-        /// values. For example, if a key requires multiple <see cref="UInt16"/> values, they shall
-        /// be placed at the end of this tag, and the KeyEntry will set
-        /// TIFFTagLocation=GeoKeyDirectoryTag, with the Value_Offset pointing to the location of the
-        /// value(s).
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public ushort[] GeoKeyDirectory
-        {
-            get
-            {
-                return GetTagArray<ushort>("GeoKeyDirectory");
-            }
-            set
-            {
-                SetTagValue("GeoKeyDirectory", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF ModelPixelScaleTag.
-        /// </summary>
-        /// <remarks>
-        /// The ModelPixelScaleTag tag may be used to specify the size of raster pixel spacing
-        /// in the model space units, when the raster space can be embedded in the model space
-        /// coordinate system without rotation, and consists of the following 3 values:
-        /// <para/>
-        /// ModelPixelScaleTag = (ScaleX, ScaleY, ScaleZ)
-        /// <para/>
-        /// where <i>ScaleX</i> and <i>ScaleY</i> give the horizontal and vertical spacing of
-        /// raster pixels. The <i>ScaleZ</i> is primarily used to map the pixel value of a
-        /// digital elevation model into the correct Z-scale, and so for most other purposes
-        /// this value should be zero (since most model spaces are 2-D, with Z=0).
-        /// <para/>
-        /// A single tiepoint in the <see cref="ModelTiePoints"/> tag, together with this tag,
-        /// completely determine the relationship between raster and model space; thus they
-        /// comprise the two tags which Baseline GeoTIFF files most often will use to place a
-        /// raster image into a "standard position" in model space.
-        /// <para/>
-        /// Like the <see cref="ModelTiePoints"/> tag, this tag information is independent of the
-        /// XPosition, YPosition, Resolution and Orientation tags of the standard TIFF 6.0 spec.
-        /// However, simple reversals of orientation between raster and model space
-        /// (e.g. horizontal or vertical flips) may be indicated by reversal of sign in the
-        /// corresponding component of the ModelPixelScaleTag. GeoTIFF compliant readers must
-        /// honor this signreversal convention.
-        /// <para/>
-        /// This tag must not be used if the raster image requires rotation or shearing to place
-        /// it into the standard model space. In such cases the transformation shall be defined
-        /// with the more general <see cref="ModelTransformationMatrix"/>.
-        /// <para/>
-        /// <br/><b>Naming differences</b><para/>
-        /// In the native FreeImage library and thus, in the FreeImage API documentation, this
-        /// property's key is named <i>GeoPixelScale</i>. Since the GeoTIFF specification
-        /// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
-        /// <see cref="ModelPixelScale"/>, this property was renamed accordingly.
-        /// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
-        /// the native FreeImage tag key <i>GeoPixelScale</i> must be used.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public double[] ModelPixelScale
-        {
-            get
-            {
-                return GetTagArray<double>("GeoPixelScale");
-            }
-            set
-            {
-                SetTagValue("GeoPixelScale", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF GeoTiePointsTag.
-        /// </summary>
-        /// <remarks>
-        /// The GeoTiePointsTag stores raster -> model tiepoint pairs in the order
-        /// <para/>
-        /// ModelTiePoints = (...,I,J,K, X,Y,Z...),
-        /// <para/>
-        /// where <i>(I,J,K)</i> is the point at location <i>(I,J)</i> in raster space with 
-        /// pixel-value <i>K</i>, and <i>(X,Y,Z)</i> is a vector in model space. In most cases
-        /// the model space is only two-dimensional, in which case both K and Z should be set
-        /// to zero; this third dimension is provided in anticipation of future support for 3D
-        /// digital elevation models and vertical coordinate systems.
-        /// <para/>
-        /// A raster image may be georeferenced simply by specifying its location, size and
-        /// orientation in the model coordinate space M. This may be done by specifying the
-        /// location of three of the four bounding corner points. However, tiepoints are only
-        /// to be considered exact at the points specified; thus defining such a set of
-        /// bounding tiepoints does not imply that the model space locations of the interior
-        /// of the image may be exactly computed by a linear interpolation of these tiepoints.
-        /// <para/>
-        /// However, since the relationship between the Raster space and the model space will
-        /// often be an exact, affine transformation, this relationship can be defined using
-        /// one set of tiepoints and the <see cref="ModelPixelScale"/>, described below, which
-        /// gives the vertical and horizontal raster grid cell size, specified in model units.
-        /// <para/>
-        /// If possible, the first tiepoint placed in this tag shall be the one establishing
-        /// the location of the point (0,0) in raster space. However, if this is not possible
-        /// (for example, if (0,0) is goes to a part of model space in which the projection is
-        /// ill-defined), then there is no particular order in which the tiepoints need be
-        /// listed.
-        /// <para/>
-        /// For orthorectification or mosaicking applications a large number of tiepoints may
-        /// be specified on a mesh over the raster image. However, the definition of associated
-        /// grid interpolation methods is not in the scope of the current GeoTIFF spec.
-        /// <para/>
-        /// <br/><b>Naming differences</b><para/>
-        /// In the native FreeImage library and thus, in the FreeImage API documentation, this
-        /// property's key is named <i>GeoTiePoints</i>. Since the GeoTIFF specification
-        /// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
-        /// <see cref="ModelTiePoints"/>, this property was renamed accordingly.
-        /// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
-        /// the native FreeImage tag key <i>GeoTiePoints</i> must be used.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public double[] ModelTiePoints
-        {
-            get
-            {
-                return GetTagArray<double>("GeoTiePoints");
-            }
-            set
-            {
-                SetTagValue("GeoTiePoints", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF ModelTransformationMatrixTag.
-        /// </summary>
-        /// <remarks>
-        /// This tag may be used to specify the transformation matrix between the raster space
-        /// (and its dependent pixel-value space) and the (possibly 3D) model space.
-        /// <para/>
-        /// <br/><b>Naming differences</b><para/>
-        /// In the native FreeImage library and thus, in the FreeImage API documentation, this
-        /// property's key is named <i>GeoTransformationMatrix</i>. Since the GeoTIFF specification
-        /// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
-        /// <see cref="ModelTransformationMatrix"/>, this property was renamed accordingly.
-        /// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
-        /// the native FreeImage tag key <i>GeoTransformationMatrix</i> must be used.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public double[] ModelTransformationMatrix
-        {
-            get
-            {
-                return GetTagArray<double>("GeoTransformationMatrix");
-            }
-            set
-            {
-                SetTagValue("GeoTransformationMatrix", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF IntergraphTransformationMatrixTag.
-        /// </summary>
-        /// <remarks>
-        /// The IntergraphTransformationMatrixTag conflicts with an internal software implementation
-        /// at Intergraph, and so its use is no longer encouraged. A GeoTIFF reader should look first
-        /// for the new tag, and only if it is not found should it check for this older tag. If found,
-        /// it should only consider it to be contain valid GeoTIFF matrix information if the tag-count
-        /// is 16; the Intergraph version uses 17 values.
-        /// <para/>
-        /// <br/><b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public double[] IntergraphTransformationMatrix
-        {
-            get
-            {
-                return GetTagArray<double>("Intergraph TransformationMatrix");
-            }
-            set
-            {
-                SetTagValue("Intergraph TransformationMatrix", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the GeoTIFF JPLCartoIFDOffsetTag.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public uint? JPLCartoIFDOffset
-        {
-            get
-            {
-                return GetTagValue<uint>("JPL Carto IFD offset");
-            }
-            set
-            {
-                SetTagValue("JPL Carto IFD offset", value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_IPTC"/>.
-    /// </summary>
-    public class MDM_IPTC : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_IPTC(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_IPTC; }
-        }
-
-        /// <summary>
-        /// Gets the Application Record Version.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public short? ApplicationRecordVersion
-        {
-            get
-            {
-                return GetTagValue<short>("ApplicationRecordVersion");
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Type Reference.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectTypeReference
-        {
-            get
-            {
-                return GetTagText("ObjectTypeReference");
-            }
-            set
-            {
-                SetTagValue("ObjectTypeReference", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Attribute Reference.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectAttributeReference
-        {
-            get
-            {
-                return GetTagText("ObjectAttributeReference");
-            }
-            set
-            {
-                SetTagValue("ObjectAttributeReference", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Name.
-        /// This is also referred to as Title.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectName
-        {
-            get
-            {
-                return GetTagText("ObjectName");
-            }
-            set
-            {
-                SetTagValue("ObjectName", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Edit Status.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string EditStatus
-        {
-            get
-            {
-                return GetTagText("EditStatus");
-            }
-            set
-            {
-                SetTagValue("EditStatus", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Editorial Update.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string EditorialUpdate
-        {
-            get
-            {
-                return GetTagText("EditorialUpdate");
-            }
-            set
-            {
-                SetTagValue("EditorialUpdate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Urgency.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Urgency
-        {
-            get
-            {
-                return GetTagText("Urgency");
-            }
-            set
-            {
-                SetTagValue("Urgency", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Subject Reference.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SubjectReference
-        {
-            get
-            {
-                return GetTagText("SubjectReference");
-            }
-            set
-            {
-                SetTagValue("SubjectReference", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Category.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Category
-        {
-            get
-            {
-                return GetTagText("Category");
-            }
-            set
-            {
-                SetTagValue("Category", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Supplemental Categories.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SupplementalCategories
-        {
-            get
-            {
-                return GetTagText("SupplementalCategories");
-            }
-            set
-            {
-                SetTagValue("SupplementalCategories", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Fixture Identifier.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string FixtureIdentifier
-        {
-            get
-            {
-                return GetTagText("FixtureIdentifier");
-            }
-            set
-            {
-                SetTagValue("FixtureIdentifier", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Keywords.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Keywords
-        {
-            get
-            {
-                return GetTagText("Keywords");
-            }
-            set
-            {
-                SetTagValue("Keywords", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Content Location Code.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ContentLocationCode
-        {
-            get
-            {
-                return GetTagText("ContentLocationCode");
-            }
-            set
-            {
-                SetTagValue("ContentLocationCode", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Content Location Name.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ContentLocationName
-        {
-            get
-            {
-                return GetTagText("ContentLocationName");
-            }
-            set
-            {
-                SetTagValue("ContentLocationName", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Release Date.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ReleaseDate
-        {
-            get
-            {
-                return GetTagText("ReleaseDate");
-            }
-            set
-            {
-                SetTagValue("ReleaseDate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Release Time.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ReleaseTime
-        {
-            get
-            {
-                return GetTagText("ReleaseTime");
-            }
-            set
-            {
-                SetTagValue("ReleaseTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Expiration Date.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ExpirationDate
-        {
-            get
-            {
-                return GetTagText("ExpirationDate");
-            }
-            set
-            {
-                SetTagValue("ExpirationDate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Expiration Time.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ExpirationTime
-        {
-            get
-            {
-                return GetTagText("ExpirationTime");
-            }
-            set
-            {
-                SetTagValue("ExpirationTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Special Instructions.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SpecialInstructions
-        {
-            get
-            {
-                return GetTagText("SpecialInstructions");
-            }
-            set
-            {
-                SetTagValue("SpecialInstructions", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Action Advised.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ActionAdvised
-        {
-            get
-            {
-                return GetTagText("ActionAdvised");
-            }
-            set
-            {
-                SetTagValue("ActionAdvised", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Reference Service.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ReferenceService
-        {
-            get
-            {
-                return GetTagText("ReferenceService");
-            }
-            set
-            {
-                SetTagValue("ReferenceService", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Reference Date.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ReferenceDate
-        {
-            get
-            {
-                return GetTagText("ReferenceDate");
-            }
-            set
-            {
-                SetTagValue("ReferenceDate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Reference Number.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ReferenceNumber
-        {
-            get
-            {
-                return GetTagText("ReferenceNumber");
-            }
-            set
-            {
-                SetTagValue("ReferenceNumber", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Date Created.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string DateCreated
-        {
-            get
-            {
-                return GetTagText("DateCreated");
-            }
-            set
-            {
-                SetTagValue("DateCreated", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Time Created.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string TimeCreated
-        {
-            get
-            {
-                return GetTagText("TimeCreated");
-            }
-            set
-            {
-                SetTagValue("TimeCreated", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Digital Creation Date.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string DigitalCreationDate
-        {
-            get
-            {
-                return GetTagText("DigitalCreationDate");
-            }
-            set
-            {
-                SetTagValue("DigitalCreationDate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Digital Creation Time.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string DigitalCreationTime
-        {
-            get
-            {
-                return GetTagText("DigitalCreationTime");
-            }
-            set
-            {
-                SetTagValue("DigitalCreationTime", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Originating Program.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string OriginatingProgram
-        {
-            get
-            {
-                return GetTagText("OriginatingProgram");
-            }
-            set
-            {
-                SetTagValue("OriginatingProgram", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Program Version.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ProgramVersion
-        {
-            get
-            {
-                return GetTagText("ProgramVersion");
-            }
-            set
-            {
-                SetTagValue("ProgramVersion", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Cycle.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectCycle
-        {
-            get
-            {
-                return GetTagText("ObjectCycle");
-            }
-            set
-            {
-                SetTagValue("ObjectCycle", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag By Line.
-        /// This is the author's name.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ByLine
-        {
-            get
-            {
-                return GetTagText("By-line");
-            }
-            set
-            {
-                SetTagValue("By-line", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag By Line Title.
-        /// This is the author's position.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ByLineTitle
-        {
-            get
-            {
-                return GetTagText("By-lineTitle");
-            }
-            set
-            {
-                SetTagValue("By-lineTitle", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag City.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string City
-        {
-            get
-            {
-                return GetTagText("City");
-            }
-            set
-            {
-                SetTagValue("City", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Sub Location.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SubLocation
-        {
-            get
-            {
-                return GetTagText("SubLocation");
-            }
-            set
-            {
-                SetTagValue("SubLocation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Province State.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ProvinceState
-        {
-            get
-            {
-                return GetTagText("ProvinceState");
-            }
-            set
-            {
-                SetTagValue("ProvinceState", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Country Primary Location Code.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string CountryPrimaryLocationCode
-        {
-            get
-            {
-                return GetTagText("Country-PrimaryLocationCode");
-            }
-            set
-            {
-                SetTagValue("Country-PrimaryLocationCode", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Country Primary Location Name.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string CountryPrimaryLocationName
-        {
-            get
-            {
-                return GetTagText("Country-PrimaryLocationName");
-            }
-            set
-            {
-                SetTagValue("Country-PrimaryLocationName", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Original Transmission Reference.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string OriginalTransmissionReference
-        {
-            get
-            {
-                return GetTagText("OriginalTransmissionReference");
-            }
-            set
-            {
-                SetTagValue("OriginalTransmissionReference", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Headline.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Headline
-        {
-            get
-            {
-                return GetTagText("Headline");
-            }
-            set
-            {
-                SetTagValue("Headline", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Credit.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Credit
-        {
-            get
-            {
-                return GetTagText("Credit");
-            }
-            set
-            {
-                SetTagValue("Credit", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Source.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Source
-        {
-            get
-            {
-                return GetTagText("Source");
-            }
-            set
-            {
-                SetTagValue("Source", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Copyright Notice.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string CopyrightNotice
-        {
-            get
-            {
-                return GetTagText("CopyrightNotice");
-            }
-            set
-            {
-                SetTagValue("CopyrightNotice", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Contact.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Contact
-        {
-            get
-            {
-                return GetTagText("Contact");
-            }
-            set
-            {
-                SetTagValue("Contact", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Caption Abstract.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string CaptionAbstract
-        {
-            get
-            {
-                return GetTagText("CaptionAbstract");
-            }
-            set
-            {
-                SetTagValue("CaptionAbstract", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Writer Editor.
-        /// This is also referred to as Caption Writer.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string WriterEditor
-        {
-            get
-            {
-                return GetTagText("WriterEditor");
-            }
-            set
-            {
-                SetTagValue("WriterEditor", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Rasterized Caption.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string RasterizedCaption
-        {
-            get
-            {
-                return GetTagText("RasterizedCaption");
-            }
-            set
-            {
-                SetTagValue("RasterizedCaption", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Image Type.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ImageType
-        {
-            get
-            {
-                return GetTagText("ImageType");
-            }
-            set
-            {
-                SetTagValue("ImageType", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Image Orientation.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ImageOrientation
-        {
-            get
-            {
-                return GetTagText("ImageOrientation");
-            }
-            set
-            {
-                SetTagValue("ImageOrientation", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Language Identifier.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string LanguageIdentifier
-        {
-            get
-            {
-                return GetTagText("LanguageIdentifier");
-            }
-            set
-            {
-                SetTagValue("LanguageIdentifier", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Audio Type.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string AudioType
-        {
-            get
-            {
-                return GetTagText("AudioType");
-            }
-            set
-            {
-                SetTagValue("AudioType", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Audio Sampling Rate.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string AudioSamplingRate
-        {
-            get
-            {
-                return GetTagText("AudioSamplingRate");
-            }
-            set
-            {
-                SetTagValue("AudioSamplingRate", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Audio Sampling Resolution.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string AudioSamplingResolution
-        {
-            get
-            {
-                return GetTagText("AudioSamplingResolution");
-            }
-            set
-            {
-                SetTagValue("AudioSamplingResolution", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Audio Duration.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string AudioDuration
-        {
-            get
-            {
-                return GetTagText("AudioDuration");
-            }
-            set
-            {
-                SetTagValue("AudioDuration", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Audio Outcue.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string AudioOutcue
-        {
-            get
-            {
-                return GetTagText("AudioOutcue");
-            }
-            set
-            {
-                SetTagValue("AudioOutcue", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Job I D.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string JobID
-        {
-            get
-            {
-                return GetTagText("JobID");
-            }
-            set
-            {
-                SetTagValue("JobID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Master Document I D.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string MasterDocumentID
-        {
-            get
-            {
-                return GetTagText("MasterDocumentID");
-            }
-            set
-            {
-                SetTagValue("MasterDocumentID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Short Document I D.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ShortDocumentID
-        {
-            get
-            {
-                return GetTagText("ShortDocumentID");
-            }
-            set
-            {
-                SetTagValue("ShortDocumentID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Unique Document I D.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string UniqueDocumentID
-        {
-            get
-            {
-                return GetTagText("UniqueDocumentID");
-            }
-            set
-            {
-                SetTagValue("UniqueDocumentID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Owner I D.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string OwnerID
-        {
-            get
-            {
-                return GetTagText("OwnerID");
-            }
-            set
-            {
-                SetTagValue("OwnerID", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Preview File Format.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectPreviewFileFormat
-        {
-            get
-            {
-                return GetTagText("ObjectPreviewFileFormat");
-            }
-            set
-            {
-                SetTagValue("ObjectPreviewFileFormat", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Preview File Version.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectPreviewFileVersion
-        {
-            get
-            {
-                return GetTagText("ObjectPreviewFileVersion");
-            }
-            set
-            {
-                SetTagValue("ObjectPreviewFileVersion", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Object Preview Data.
-        /// This is also referred to as Audio Outcue.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ObjectPreviewData
-        {
-            get
-            {
-                return GetTagText("ObjectPreviewData");
-            }
-            set
-            {
-                SetTagValue("ObjectPreviewData", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Prefs.
-        /// This is also referred to as photo-mechanic preferences.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Prefs
-        {
-            get
-            {
-                return GetTagText("Prefs");
-            }
-            set
-            {
-                SetTagValue("Prefs", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Classify State.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ClassifyState
-        {
-            get
-            {
-                return GetTagText("ClassifyState");
-            }
-            set
-            {
-                SetTagValue("ClassifyState", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Similarity Index.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string SimilarityIndex
-        {
-            get
-            {
-                return GetTagText("SimilarityIndex");
-            }
-            set
-            {
-                SetTagValue("SimilarityIndex", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Document Notes.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string DocumentNotes
-        {
-            get
-            {
-                return GetTagText("DocumentNotes");
-            }
-            set
-            {
-                SetTagValue("DocumentNotes", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Document History.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string DocumentHistory
-        {
-            get
-            {
-                return GetTagText("DocumentHistory");
-            }
-            set
-            {
-                SetTagValue("DocumentHistory", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the value of the IPTC/NAA tag Exif Camera Info.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string ExifCameraInfo
-        {
-            get
-            {
-                return GetTagText("ExifCameraInfo");
-            }
-            set
-            {
-                SetTagValue("ExifCameraInfo", value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_NODATA"/>.
-    /// </summary>
-    public class MDM_NODATA : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_NODATA(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_NODATA; }
-        }
-    }
-
-    /// <summary>
-    /// Represents a collection of all tags contained in the metadata model
-    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_XMP"/>.
-    /// </summary>
-    public class MDM_XMP : MetadataModel
-    {
-        /// <summary>
-        /// Initializes a new instance of this class.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public MDM_XMP(FIBITMAP dib) : base(dib) { }
-
-        /// <summary>
-        /// Retrieves the datamodel that this instance represents.
-        /// </summary>
-        public override FREE_IMAGE_MDMODEL Model
-        {
-            get { return FREE_IMAGE_MDMODEL.FIMD_XMP; }
-        }
-
-        /// <summary>
-        /// Gets or sets the XMP XML content.
-        /// </summary>
-        /// <remarks>
-        /// <b>Handling of null values</b><para/>
-        /// A null value indicates, that the corresponding metadata tag is not
-        /// present in the metadata model.
-        /// Setting this property's value to a non-null reference creates the
-        /// metadata tag if necessary.
-        /// Setting this property's value to a null reference deletes the
-        /// metadata tag from the metadata model.
-        /// </remarks>
-        public string Xml
-        {
-            get
-            {
-                return GetTagText("XMLPacket");
-            }
-            set
-            {
-                SetTagValue("XMLPacket", value);
-            }
-        }
-
-        /// <summary>
-        /// Gets an <see cref="XmlReader"/> initialized to read the XMP XML content.
-        /// Returns null, if the metadata tag <i>XMLPacket</i> is not present in
-        /// this model.
-        /// </summary>
-        public XmlReader XmlReader
-        {
-            get
-            {
-                string xmlString = Xml;
-                if (xmlString == null)
-                {
-                    return null;
-                }
-                else
-                {
-                    MemoryStream stream = new MemoryStream();
-                    StreamWriter writer = new StreamWriter(stream);
-                    writer.Write(xmlString);
-                    return XmlReader.Create(stream);
-                }
-            }
-        }
-    }
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_ANIMATION"/>.
+	/// </summary>
+	public class MDM_ANIMATION : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_ANIMATION(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_ANIMATION; }
+		}
+
+		/// <summary>
+		/// Gets or sets the width of the entire canvas area, that each page is displayed in.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? LogicalWidth
+		{
+			get
+			{
+				return GetTagValue<ushort>("LogicalWidth");
+			}
+			set
+			{
+				SetTagValue("LogicalWidth", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the height of the entire canvas area, that each page is displayed in.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? LogicalHeight
+		{
+			get
+			{
+				return GetTagValue<ushort>("LogicalHeight");
+			}
+			set
+			{
+				SetTagValue("LogicalHeight", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the global palette of the GIF image.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public Palette GlobalPalette
+		{
+			get
+			{
+				MetadataTag mdtag = GetTag("GlobalPalette");
+				return (mdtag == null) ? null : new Palette(mdtag);
+			}
+			set
+			{
+				SetTagValue("GlobalPalette", (value != null) ? null : value.Data);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of replays for the animation.
+		/// Use 0 (zero) to specify an infinte number of replays.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? LoopCount
+		{
+			get
+			{
+				return GetTagValue<uint>("Loop");
+			}
+			set
+			{
+				SetTagValue("Loop", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the horizontal offset within the logical canvas area, this frame is to be displayed at.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? FrameLeft
+		{
+			get
+			{
+				return GetTagValue<ushort>("FrameLeft");
+			}
+			set
+			{
+				SetTagValue("FrameLeft", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the vertical offset within the logical canvas area, this frame is to be displayed at.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? FrameTop
+		{
+			get
+			{
+				return GetTagValue<ushort>("FrameTop");
+			}
+			set
+			{
+				SetTagValue("FrameTop", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a flag to supress saving the dib's attached palette
+		/// (making it use the global palette). The local palette is the palette used by a page.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public bool? NoLocalPalette
+		{
+			get
+			{
+				byte? useGlobalPalette = GetTagValue<byte>("NoLocalPalette");
+				return useGlobalPalette.HasValue ? (useGlobalPalette.Value != 0) : default(bool?);
+			}
+			set
+			{
+				byte? val = null;
+				if (value.HasValue)
+				{
+					val = (byte)(value.Value ? 1 : 0);
+				}
+				SetTagValue("NoLocalPalette", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the image is interlaced.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public bool? Interlaced
+		{
+			get
+			{
+				byte? useGlobalPalette = GetTagValue<byte>("Interlaced");
+				return useGlobalPalette.HasValue ? (useGlobalPalette.Value != 0) : default(bool?);
+			}
+			set
+			{
+				byte? val = null;
+				if (value.HasValue)
+				{
+					val = (byte)(value.Value ? 1 : 0);
+				}
+				SetTagValue("Interlaced", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the amout of time in milliseconds this frame is to be displayed.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? FrameTime
+		{
+			get
+			{
+				return GetTagValue<uint>("FrameTime");
+			}
+			set
+			{
+				SetTagValue("FrameTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets this frame's disposal method. Generally, this method defines, how to
+		/// remove or replace a frame when the next frame has to be drawn.<para/>
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DisposalMethodType? DisposalMethod
+		{
+			get
+			{
+				return GetTagValue<DisposalMethodType>("DisposalMethod");
+			}
+			set
+			{
+				SetTagValue("DisposalMethod", value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_COMMENTS"/>.
+	/// </summary>
+	public class MDM_COMMENTS : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_COMMENTS(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_COMMENTS; }
+		}
+
+		/// <summary>
+		/// Gets or sets the comment of the image.
+		/// Supported formats are JPEG, PNG and GIF.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Comment
+		{
+			get
+			{
+				return GetTagText("Comment");
+			}
+			set
+			{
+				SetTagValue("Comment", value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_CUSTOM"/>.
+	/// </summary>
+	public class MDM_CUSTOM : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_CUSTOM(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_CUSTOM; }
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_EXIF"/>.
+	/// </summary>
+	public class MDM_EXIF_EXIF : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_EXIF_EXIF(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_EXIF; }
+		}
+
+		/// <summary>
+		/// Gets or sets the version of this standard supported.
+		/// Constant length or 4.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] ExifVersion
+		{
+			get
+			{
+				return GetTagArray<byte>("ExifVersion");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 4);
+				SetTagValueUndefined("ExifVersion", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the Flashpix format version supported by a FPXR file.
+		/// Constant length or 4.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] FlashpixVersion
+		{
+			get
+			{
+				return GetTagArray<byte>("FlashpixVersion");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 4);
+				SetTagValueUndefined("FlashpixVersion", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the color space information tag.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>1</term>
+		///			<description>sRGB (default)</description>
+		///		</item>
+		///		<item>
+		///			<term>0xFFFF</term>
+		///			<description>uncalibrated</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? ColorSpace
+		{
+			get
+			{
+				return GetTagValue<ushort>("ColorSpace");
+			}
+			set
+			{
+				SetTagValue("ColorSpace", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the valid width of a compressed image.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? PixelXDimension
+		{
+			get
+			{
+				return GetUInt32Value("PixelXDimension");
+			}
+			set
+			{
+				RemoveTag("PixelXDimension");
+				if (value.HasValue)
+				{
+					SetTagValue("PixelXDimension", value.Value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the valid height of a compressed image.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? PixelYDimension
+		{
+			get
+			{
+				return GetUInt32Value("PixelYDimension");
+			}
+			set
+			{
+				RemoveTag("PixelYDimension");
+				if (value.HasValue)
+				{
+					SetTagValue("PixelYDimension", value.Value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets components configuration. See remarks for further information.
+		/// Constant length of 4.
+		/// </summary>
+		/// <remarks>
+		/// The channels of each component are arranged in order from the 1st component to the 4th.
+		/// For uncompressed data the data arrangement is given in the PhotometricInterpretation tag.
+		/// However, since PhotometricInterpretation can only express the order of Y,Cb and Cr,
+		/// this tag is provided for cases when compressed data uses components other than Y, Cb,
+		/// and Cr and to enable support of other sequences.<para/>
+		/// Default = 4 5 6 0 (if RGB uncompressed)<para/>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>does not exist</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>Y</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>Cb</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>Cr</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>R</description>
+		///		</item>
+		///		<item>
+		///			<term>5</term>
+		///			<description>R</description>
+		///		</item>
+		///		<item>
+		///			<term>6</term>
+		///			<description>R</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] ComponentsConfiguration
+		{
+			get
+			{
+				return GetTagArray<byte>("ComponentsConfiguration");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 4);
+				SetTagValueUndefined("ComponentsConfiguration", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets compression mode used for a compressed image is indicated
+		/// in unit bits per pixel.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? CompressedBitsPerPixel
+		{
+			get
+			{
+				return GetTagValue<FIURational>("CompressedBitsPerPixel");
+			}
+			set
+			{
+				SetTagValue("CompressedBitsPerPixel", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a tag for manufacturers of Exif writers to record any desired information.
+		/// The contents are up to the manufacturer, but this tag should not be used for any other
+		/// than its intended purpose.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] MakerNote
+		{
+			get
+			{
+				return GetTagArray<byte>("FlashpixVersion");
+			}
+			set
+			{
+				SetTagValueUndefined("FlashpixVersion", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a tag for Exif users to write keywords or comments on the image besides
+		/// those in ImageDescription, and without the character code limitations of the ImageDescription tag.
+		/// Minimum length of 8. See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The character code used in the UserComment tag is identified based on an ID code in a fixed 8-byte
+		/// area at the start of the tag data area. The unused portion of the area is padded with NULL.
+		/// The ID code for the UserComment area may be a Defined code such as JIS or ASCII, or may be Undefined.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] UserComment
+		{
+			get
+			{
+				return GetTagArray<byte>("UserComment");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 8, int.MaxValue);
+				SetTagValueUndefined("UserComment", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the name of an audio file related to the image data.
+		/// The format is 8.3.
+		/// Constant length of 12
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string RelatedSoundFile
+		{
+			get
+			{
+				string text = GetTagText("RelatedSoundFile");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					FreeImage.Resize(ref value, 12);
+					value += '\0';
+				}
+				SetTagValue("RelatedSoundFile", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the date and time when the original image data was generated.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DateTime? DateTimeOriginal
+		{
+			get
+			{
+				DateTime? result = null;
+				string text = GetTagText("DateTimeOriginal");
+				if (text != null)
+				{
+					try
+					{
+						result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
+					}
+					catch
+					{
+					}
+				}
+				return result;
+			}
+			set
+			{
+				string val = null;
+				if (value.HasValue)
+				{
+					try
+					{
+						val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
+					}
+					catch
+					{
+					}
+				}
+				SetTagValue("DateTimeOriginal", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the date and time when the image was stored as digital data.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DateTime? DateTimeDigitized
+		{
+			get
+			{
+				DateTime? result = null;
+				string text = GetTagText("DateTimeDigitized");
+				if (text != null)
+				{
+					try
+					{
+						result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
+					}
+					catch
+					{
+					}
+				}
+				return result;
+			}
+			set
+			{
+				string val = null;
+				if (value.HasValue)
+				{
+					try
+					{
+						val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
+					}
+					catch
+					{
+					}
+				}
+				SetTagValue("DateTimeDigitized", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a tag used to record fractions of seconds for the DateTime tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SubsecTime
+		{
+			get
+			{
+				string text = GetTagText("SubsecTime");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("SubsecTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a tag used to record fractions of seconds for the DateTimeOriginal tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SubsecTimeOriginal
+		{
+			get
+			{
+				string text = GetTagText("SubsecTimeOriginal");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("SubsecTimeOriginal", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a tag used to record fractions of seconds for the DateTimeDigitized tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SubsecTimeDigitized
+		{
+			get
+			{
+				string text = GetTagText("SubsecTimeDigitized");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("SubsecTimeDigitized", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or the exposure time, given in seconds (sec).
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? ExposureTime
+		{
+			get
+			{
+				return GetTagValue<FIURational>("ExposureTime");
+			}
+			set
+			{
+				SetTagValue("ExposureTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or the F number.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? FNumber
+		{
+			get
+			{
+				return GetTagValue<FIURational>("FNumber");
+			}
+			set
+			{
+				SetTagValue("FNumber", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the class of the program used by the camera to set exposure when the
+		/// picture is taken.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>not defined</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>manual</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>normal program</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>aperture priority</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>shutter priority</description>
+		///		</item>
+		///		<item>
+		///			<term>5</term>
+		///			<description>create program</description>
+		///		</item>
+		///		<item>
+		///			<term>6</term>
+		///			<description>action program</description>
+		///		</item>
+		///		<item>
+		///			<term>7</term>
+		///			<description>portrait mode</description>
+		///		</item>
+		///		<item>
+		///			<term>8</term>
+		///			<description>landscape mode</description>
+		///		</item>
+		///		<item>
+		///			<term>others</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? ExposureProgram
+		{
+			get
+			{
+				return GetTagValue<ushort>("ExposureProgram");
+			}
+			set
+			{
+				SetTagValue("ExposureProgram", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the spectral sensitivity of each channel of the camera used.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SpectralSensitivity
+		{
+			get
+			{
+				string text = GetTagText("SpectralSensitivity");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("SpectralSensitivity", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the the ISO Speed and ISO Latitude of the camera or input device as
+		/// specified in ISO 12232.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] ISOSpeedRatings
+		{
+			get
+			{
+				return GetTagArray<ushort>("ISOSpeedRatings");
+			}
+			set
+			{
+				SetTagValue("ISOSpeedRatings", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the Opto-Electric Conversion Function (OECF) specified in ISO 14524.
+		/// OECF is the relationship between the camera optical input and the image values.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] OECF
+		{
+			get
+			{
+				return GetTagArray<byte>("OECF");
+			}
+			set
+			{
+				SetTagValueUndefined("OECF", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the shutter speed. The unit is the APEX (Additive System of Photographic Exposure).
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIRational? ShutterSpeedValue
+		{
+			get
+			{
+				return GetTagValue<FIRational>("ShutterSpeedValue");
+			}
+			set
+			{
+				SetTagValue("ShutterSpeedValue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the lens aperture. The unit is the APEX value.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? ApertureValue
+		{
+			get
+			{
+				return GetTagValue<FIURational>("ApertureValue");
+			}
+			set
+			{
+				SetTagValue("ApertureValue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of brightness. The unit is the APEX value.
+		/// Ordinarily it is given in the range of -99.99 to 99.99.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIRational? BrightnessValue
+		{
+			get
+			{
+				return GetTagValue<FIRational>("BrightnessValue");
+			}
+			set
+			{
+				SetTagValue("BrightnessValue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the exposure bias. The unit is the APEX value.
+		/// Ordinarily it is given in the range of –99.99 to 99.99.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIRational? ExposureBiasValue
+		{
+			get
+			{
+				return GetTagValue<FIRational>("ExposureBiasValue");
+			}
+			set
+			{
+				SetTagValue("ExposureBiasValue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the smallest F number of the lens. The unit is the APEX value.
+		/// Ordinarily it is given in the range of 00.00 to 99.99,
+		/// but it is not limited to this range.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? MaxApertureValue
+		{
+			get
+			{
+				return GetTagValue<FIURational>("MaxApertureValue");
+			}
+			set
+			{
+				SetTagValue("MaxApertureValue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets distance to the subject, given in meters.
+		/// Note that if the numerator of the recorded value is FFFFFFFF, infinity shall be indicated;
+		/// and if the numerator is 0, distance unknown shall be indicated.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? SubjectDistance
+		{
+			get
+			{
+				return GetTagValue<FIURational>("SubjectDistance");
+			}
+			set
+			{
+				SetTagValue("SubjectDistance", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the metering mode. See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>unknown</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>average</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>center-weighted-average</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>spot</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>multi-spot</description>
+		///		</item>
+		///		<item>
+		///			<term>5</term>
+		///			<description>pattern</description>
+		///		</item>
+		///		<item>
+		///			<term>6</term>
+		///			<description>partial</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		///		<item>
+		///			<term>255</term>
+		///			<description>other</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? MeteringMode
+		{
+			get
+			{
+				return GetTagValue<ushort>("MeteringMode");
+			}
+			set
+			{
+				SetTagValue("MeteringMode", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the kind of light source.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>unknown</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>daylight</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>fluorescent</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>tungsten</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>flash</description>
+		///		</item>
+		///		<item>
+		///			<term>9</term>
+		///			<description>fine weather</description>
+		///		</item>
+		///		<item>
+		///			<term>10</term>
+		///			<description>cloudy weather</description>
+		///		</item>
+		///		<item>
+		///			<term>11</term>
+		///			<description>shade</description>
+		///		</item>
+		///		<item>
+		///			<term>12</term>
+		///			<description>daylight fluorecent (D 5700 - 7100K)</description>
+		///		</item>
+		///		<item>
+		///			<term>13</term>
+		///			<description>day white fluorescent (N 4600 - 5400K)</description>
+		///		</item>
+		///		<item>
+		///			<term>14</term>
+		///			<description>cool white fluorescent (W 3900 - 4500K)</description>
+		///		</item>
+		///		<item>
+		///			<term>15</term>
+		///			<description>white fluorescent (WW 3200 - 3700K)</description>
+		///		</item>
+		///		<item>
+		///			<term>17</term>
+		///			<description>standard light A</description>
+		///		</item>
+		///		<item>
+		///			<term>18</term>
+		///			<description>standard light B</description>
+		///		</item>
+		///		<item>
+		///			<term>19</term>
+		///			<description>standard light C</description>
+		///		</item>
+		///		<item>
+		///			<term>20</term>
+		///			<description>D55</description>
+		///		</item>
+		///		<item>
+		///			<term>21</term>
+		///			<description>D65</description>
+		///		</item>
+		///		<item>
+		///			<term>22</term>
+		///			<description>D75</description>
+		///		</item>
+		///		<item>
+		///			<term>23</term>
+		///			<description>D50</description>
+		///		</item>
+		///		<item>
+		///			<term>24</term>
+		///			<description>ISO studio tungsten</description>
+		///		</item>
+		///		<item>
+		///			<term>255</term>
+		///			<description>other light source</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? LightSource
+		{
+			get
+			{
+				return GetTagValue<ushort>("LightSource");
+			}
+			set
+			{
+				SetTagValue("LightSource", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating the status of flash when the image was shot.
+		/// Bit 0 indicates the flash firing status, bits 1 and 2 indicate the flash return
+		/// status, bits 3 and 4 indicate the flash mode, bit 5 indicates whether the flash
+		/// function is present, and bit 6 indicates "red eye" mode.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? Flash
+		{
+			get
+			{
+				return GetTagValue<ushort>("Flash");
+			}
+			set
+			{
+				SetTagValue("Flash", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating the location and area of the main subject in
+		/// the overall scene. Variable length between 2 and 4.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] SubjectArea
+		{
+			get
+			{
+				return GetTagArray<ushort>("SubjectArea");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 2, 4);
+				SetTagValue("SubjectArea", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the actual focal length of the lens, in mm.
+		/// Conversion is not made to the focal length of a 35 mm film camera.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? FocalLength
+		{
+			get
+			{
+				return GetTagValue<FIURational>("FocalLength");
+			}
+			set
+			{
+				SetTagValue("FocalLength", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the strobe energy at the time the image is captured,
+		/// as measured in Beam Candle Power Seconds (BCPS).
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? FlashEnergy
+		{
+			get
+			{
+				return GetTagValue<FIURational>("FlashEnergy");
+			}
+			set
+			{
+				SetTagValue("FlashEnergy", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the camera or input device spatial frequency table and SFR values
+		/// in the direction of image width, image height, and diagonal direction,
+		/// as specified in ISO 12233.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] SpatialFrequencyResponse
+		{
+			get
+			{
+				return GetTagArray<byte>("SpatialFrequencyResponse");
+			}
+			set
+			{
+				SetTagValueUndefined("SpatialFrequencyResponse", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of pixels in the image width (X) direction per
+		/// FocalPlaneResolutionUnit on the camera focal plane.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? FocalPlaneXResolution
+		{
+			get
+			{
+				return GetTagValue<FIURational>("FocalPlaneXResolution");
+			}
+			set
+			{
+				SetTagValue("FocalPlaneXResolution", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of pixels in the image height (Y) direction per
+		/// FocalPlaneResolutionUnit on the camera focal plane.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? FocalPlaneYResolution
+		{
+			get
+			{
+				return GetTagValue<FIURational>("FocalPlaneYResolution");
+			}
+			set
+			{
+				SetTagValue("FocalPlaneYResolution", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the unit for measuring FocalPlaneXResolution and FocalPlaneYResolution.
+		/// This value is the same as the ResolutionUnit.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? FocalPlaneResolutionUnit
+		{
+			get
+			{
+				return GetTagValue<ushort>("FocalPlaneResolutionUnit");
+			}
+			set
+			{
+				SetTagValue("FocalPlaneResolutionUnit", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the location of the main subject in the scene.
+		/// The value of this tag represents the pixel at the center of the main subject
+		/// relative to the left edge, prior to rotation processing as per the Rotation tag.
+		/// The first value indicates the X column number and second indicates the Y row number.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? SubjectLocation
+		{
+			get
+			{
+				return GetTagValue<ushort>("SubjectLocation");
+			}
+			set
+			{
+				SetTagValue("SubjectLocation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the exposure index selected on the camera or input device at the
+		/// time the image was captured.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? ExposureIndex
+		{
+			get
+			{
+				return GetTagValue<FIURational>("ExposureIndex");
+			}
+			set
+			{
+				SetTagValue("ExposureIndex", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the image sensor type on the camera or input device.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are defined:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>1</term>
+		///			<description>not defined</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>one-chip color area sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>two-chip color area sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>three-chip color area sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>5</term>
+		///			<description>color sequential area sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>7</term>
+		///			<description>trilinear sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>8</term>
+		///			<description>color sequential linear sensor</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? SensingMethod
+		{
+			get
+			{
+				return GetTagValue<ushort>("SensingMethod");
+			}
+			set
+			{
+				SetTagValue("SensingMethod", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the image source. If a DSC recorded the image, this tag value of this
+		/// tag always be set to 3, indicating that the image was recorded on a DSC.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte? FileSource
+		{
+			get
+			{
+				return GetTagValue<byte>("FileSource");
+			}
+			set
+			{
+				SetTagValueUndefined("FileSource", value.HasValue ? new byte[] { value.Value } : null);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the type of scene. If a DSC recorded the image, this tag value shall
+		/// always be set to 1, indicating that the image was directly photographed.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte? SceneType
+		{
+			get
+			{
+				return GetTagValue<byte>("SceneType");
+			}
+			set
+			{
+				SetTagValueUndefined("SceneType", value.HasValue ? new byte[] { value.Value } : null);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the color filter array (CFA) geometric pattern of the image sensor
+		/// when a one-chip color area sensor is used. It does not apply to all sensing methods.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] CFAPattern
+		{
+			get
+			{
+				return GetTagArray<byte>("CFAPattern");
+			}
+			set
+			{
+				SetTagValueUndefined("CFAPattern", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the use of special processing on image data, such as rendering geared to output.
+		/// When special processing is performed, the reader is expected to disable or minimize any
+		/// further processing. See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>normal process</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>custom process</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? CustomRendered
+		{
+			get
+			{
+				return GetTagValue<ushort>("CustomRendered");
+			}
+			set
+			{
+				SetTagValue("CustomRendered", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the exposure mode set when the image was shot.
+		/// In auto-bracketing mode, the camera shoots a series of frames of the same scene
+		/// at different exposure settings. See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>auto exposure</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>manual exposure</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>auto bracket</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? ExposureMode
+		{
+			get
+			{
+				return GetTagValue<ushort>("ExposureMode");
+			}
+			set
+			{
+				SetTagValue("ExposureMode", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the white balance mode set when the image was shot.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>auto white balance</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>manual white balance</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? WhiteBalance
+		{
+			get
+			{
+				return GetTagValue<ushort>("WhiteBalance");
+			}
+			set
+			{
+				SetTagValue("WhiteBalance", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the digital zoom ratio when the image was shot.
+		/// If the numerator of the recorded value is 0, this indicates that digital zoom was not used.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? DigitalZoomRatio
+		{
+			get
+			{
+				return GetTagValue<FIURational>("DigitalZoomRatio");
+			}
+			set
+			{
+				SetTagValue("DigitalZoomRatio", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the equivalent focal length assuming a 35mm film camera, in mm.
+		/// A value of 0 means the focal length is unknown. Note that this tag differs
+		/// from the FocalLength tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? FocalLengthIn35mmFilm
+		{
+			get
+			{
+				return GetTagValue<ushort>("DigitalZoomRatio");
+			}
+			set
+			{
+				SetTagValue("DigitalZoomRatio", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the type of scene that was shot.
+		/// It can also be used to record the mode in which the image was shot.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>standard</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>landscape</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>portrait</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>night scene</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? SceneCaptureType
+		{
+			get
+			{
+				return GetTagValue<ushort>("SceneCaptureType");
+			}
+			set
+			{
+				SetTagValue("SceneCaptureType", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the degree of overall image gain adjustment.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>none</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>low gain up</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>high gain up</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>low gain down</description>
+		///		</item>
+		///		<item>
+		///			<term>4</term>
+		///			<description>high gain down</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? GainControl
+		{
+			get
+			{
+				return GetTagValue<ushort>("GainControl");
+			}
+			set
+			{
+				SetTagValue("GainControl", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the direction of contrast processing applied by the camera
+		/// when the image was shot.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>normal</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>soft</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>hard</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? Contrast
+		{
+			get
+			{
+				return GetTagValue<ushort>("Contrast");
+			}
+			set
+			{
+				SetTagValue("Contrast", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the direction of saturation processing applied by the camera
+		/// when the image was shot.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>normal</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>low saturation</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>high saturation</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? Saturation
+		{
+			get
+			{
+				return GetTagValue<ushort>("Saturation");
+			}
+			set
+			{
+				SetTagValue("Saturation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the direction of sharpness processing applied by the camera
+		/// when the image was shot.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>normal</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>soft</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>hard</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? Sharpness
+		{
+			get
+			{
+				return GetTagValue<ushort>("Sharpness");
+			}
+			set
+			{
+				SetTagValue("Sharpness", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets information on the picture-taking conditions of a particular camera model.
+		/// The tag is used only to indicate the picture-taking conditions in the reader.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] DeviceSettingDescription
+		{
+			get
+			{
+				return GetTagArray<byte>("DeviceSettingDescription");
+			}
+			set
+			{
+				SetTagValueUndefined("DeviceSettingDescription", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the distance to the subject.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>0</term>
+		///			<description>unknown</description>
+		///		</item>
+		///		<item>
+		///			<term>1</term>
+		///			<description>macro</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>close view</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>distant view</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? SubjectDistanceRange
+		{
+			get
+			{
+				return GetTagValue<ushort>("SubjectDistanceRange");
+			}
+			set
+			{
+				SetTagValue("SubjectDistanceRange", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets an identifier assigned uniquely to each image.
+		/// It is recorded as an ASCII string equivalent to hexadecimal notation and 128-bit fixed length.
+		/// Constant length of 32.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ImageUniqueID
+		{
+			get
+			{
+				string text = GetTagText("ImageUniqueID");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					FreeImage.Resize(ref value, 32);
+					value += '\0';
+				}
+				SetTagValue("ImageUniqueID", value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_GPS"/>.
+	/// </summary>
+	public class MDM_EXIF_GPS : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_EXIF_GPS(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_GPS; }
+		}
+
+		/// <summary>
+		/// Gets or sets the GPS version ID. Constant length of 4.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] VersionID
+		{
+			get
+			{
+				return GetTagArray<byte>("GPSVersionID");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 4);
+				SetTagValue("GPSVersionID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the <see cref="Latitude"/>
+		/// is north or south latitude.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public LatitudeType? LatitudeDirection
+		{
+			get
+			{
+				return ToLatitudeType(GetTagText("GPSLatitudeRef"));
+			}
+			set
+			{
+				SetTagValue("GPSLatitudeRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the latitude of the image. The latitude is expressed as three rational
+		/// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="LatitudeDirection"/>
+		public FIURational[] Latitude
+		{
+			get
+			{
+				return GetTagArray<FIURational>("GPSLatitude");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("GPSLatitude", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether <see cref="Longitude"/>
+		/// is east or west longitude.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public LongitudeType? LongitudeDirection
+		{
+			get
+			{
+				return ToLongitudeType(GetTagText("GPSLongitudeRef"));
+			}
+			set
+			{
+				SetTagValue("GPSLongitudeRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the longitude of the image. The longitude is expressed as three rational
+		/// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="LongitudeDirection"/>
+		public FIURational[] Longitude
+		{
+			get
+			{
+				return GetTagArray<FIURational>("GPSLongitude");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("GPSLongitude", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether <see cref="Altitude"/> is sea level and the altitude
+		/// is above sea level. If the altitude is below sea level <see cref="Altitude"/> is
+		/// indicated as an absolute value.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public AltitudeType? AltitudeDirection
+		{
+			get
+			{
+				byte? flag = GetTagValue<byte>("GPSAltitudeRef");
+				if (flag.HasValue)
+				{
+					switch (flag.Value)
+					{
+						case 0:
+							return AltitudeType.AboveSeaLevel;
+						case 1:
+							return AltitudeType.BelowSeaLevel;
+						default:
+							return AltitudeType.Undefined;
+					}
+				}
+				return null;
+			}
+			set
+			{
+				byte? val = null;
+				if (value.HasValue)
+				{
+					switch (value.Value)
+					{
+						case AltitudeType.AboveSeaLevel:
+							val = 0;
+							break;
+
+						case AltitudeType.BelowSeaLevel:
+							val = 1;
+							break;
+
+						default:
+							val = 2;
+							break;
+					}
+				}
+				SetTagValue("GPSAltitudeRef", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the altitude based on the reference in <see cref="AltitudeDirection"/>.
+		/// Altitude is expressed as one rational value. The reference unit is meters.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? Altitude
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSAltitude");
+			}
+			set
+			{
+				SetTagValue("GPSAltitude", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the sign of the <see cref="SignedAltitude"/>.
+		/// </summary>
+		/// <remarks>
+		/// This is a derived property. There is no metadata tag directly associated
+		/// with this property value.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public int? AltitudeSign
+		{
+			get
+			{
+				AltitudeType? seaLevel = AltitudeDirection;
+				if (seaLevel.HasValue)
+				{
+					return (seaLevel.Value == AltitudeType.BelowSeaLevel) ? -1 : 1;
+				}
+				return null;
+			}
+			set
+			{
+				if (value.HasValue)
+				{
+					AltitudeDirection = value.Value >= 0 ? AltitudeType.AboveSeaLevel : AltitudeType.BelowSeaLevel;
+				}
+				else
+				{
+					AltitudeDirection = null;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the signed altitude.
+		/// Altitude is expressed as one rational value. The reference unit is meters.
+		/// </summary>
+		/// <exception cref="OverflowException">
+		/// Altitude is too large to fit into a FIRational.
+		/// </exception>
+		/// <remarks>
+		/// This is a derived property. There is no metadata tag directly associated
+		/// with this property value.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIRational? SignedAltitude
+		{
+			get
+			{
+				FIRational? result = null;
+				FIURational? altitude = Altitude;
+				if (altitude.HasValue)
+				{
+					int sign = AltitudeSign ?? 1;
+					if (((int)altitude.Value.Numerator < 0) || ((int)altitude.Value.Denominator < 0))
+						throw new OverflowException();
+					result = new FIRational((int)altitude.Value.Numerator * sign, (int)altitude.Value.Denominator);
+				}
+				return result;
+			}
+			set
+			{
+				FIURational? val = null;
+				if (value.HasValue)
+				{
+					if (value.Value < 0)
+					{
+						AltitudeSign = -1;
+						value = -value.Value;
+					}
+					else
+					{
+						AltitudeSign = 1;
+					}
+					val = new FIURational((uint)value.Value.Numerator, (uint)value.Value.Denominator);
+				}
+				Altitude = val;
+			}
+		}
+
+
+		/// <summary>
+		/// Gets or sets the time as UTC (Coordinated Universal Time). Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public TimeSpan? TimeStamp
+		{
+			get
+			{
+				FIURational[] stamp = GetTagArray<FIURational>("GPSTimeStamp");
+				if ((stamp == null) || stamp.Length != 3)
+				{
+					return null;
+				}
+				else
+				{
+					return new TimeSpan((int)stamp[0], (int)stamp[1], (int)stamp[2]);
+				}
+			}
+			set
+			{
+				FIURational[] stamp = null;
+				if (value.HasValue)
+				{
+					TimeSpan span = value.Value;
+					stamp = new FIURational[3];
+					stamp[0] = span.Hours;
+					stamp[1] = span.Minutes;
+					stamp[2] = span.Seconds;
+				}
+				SetTagValue("GPSTimeStamp", stamp);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the GPS satellites used for measurements. This tag can be used to describe
+		/// the number of satellites, their ID number, angle of elevation, azimuth, SNR and other
+		/// information in ASCII notation. The format is not specified.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Satellites
+		{
+			get
+			{
+				string result = GetTagText("GPSSatellites");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("GPSTimeStamp", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating the status of the GPS receiver when the image was recorded.
+		/// <b>true</b> indicates measurement was in progress;
+		/// <b>false</b> indicates measurement was Interoperability.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public bool? Status
+		{
+			get
+			{
+				string text = GetTagText("GPSStatus");
+				return string.IsNullOrEmpty(text) ? default(bool?) : text[0] == 'A';
+			}
+			set
+			{
+				SetTagValue("GPSStatus", value.HasValue ? (value.Value ? "A\0" : "V\0") : null);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating the GPS measurement mode.
+		/// <b>true</b> indicates three-dimensional measurement;
+		/// <b>false</b> indicated two-dimensional measurement was in progress.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public bool? MeasureMode3D
+		{
+			get
+			{
+				string text = GetTagText("GPSMeasureMode");
+				return string.IsNullOrEmpty(text) ? default(bool?) : text[0] == '3';
+			}
+			set
+			{
+				SetTagValue("GPSMeasureMode", value.HasValue ? (value.Value ? "3\0" : "2\0") : null);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the GPS DOP (data degree of precision). An HDOP value is written during
+		/// two-dimensional measurement, and PDOP during three-dimensional measurement.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? DOP
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSDOP");
+			}
+			set
+			{
+				SetTagValue("GPSDOP", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the unit used to express the GPS receiver <see cref="Speed"/> of movement.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="Speed"/>
+		public VelocityUnit? SpeedUnit
+		{
+			get
+			{
+				return ToUnitType(GetTagText("GPSSpeedRef"));
+			}
+			set
+			{
+				SetTagValue("GPSSpeedRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the speed of GPS receiver movement.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="SpeedUnit"/>
+		public FIURational? Speed
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSSpeed");
+			}
+			set
+			{
+				SetTagValue("GPSSpeed", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the reference for giving the direction of GPS receiver movement.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="Track"/>
+		public DirectionReference? TrackDirectionReference
+		{
+			get
+			{
+				return ToDirectionType(GetTagText("GPSTrackRef"));
+			}
+			set
+			{
+				SetTagValue("GPSTrackRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the direction of GPS receiver movement.
+		/// The range of values is from 0.00 to 359.99.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="TrackDirectionReference"/>
+		public FIURational? Track
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSTrack");
+			}
+			set
+			{
+				SetTagValue("GPSTrack", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the reference for giving the direction of GPS receiver movement.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="ImageDirection"/>
+		public DirectionReference? ImageDirectionReference
+		{
+			get
+			{
+				return ToDirectionType(GetTagText("GPSImgDirectionRef"));
+			}
+			set
+			{
+				SetTagValue("GPSImgDirectionRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the direction of the image when it was captured.
+		/// The range of values is from 0.00 to 359.99.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="ImageDirectionReference"/>
+		public FIURational? ImageDirection
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSImgDirection");
+			}
+			set
+			{
+				SetTagValue("GPSImgDirection", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the geodetic survey data used by the GPS receiver. If the survey data
+		/// is restricted to Japan, the value of this tag is 'TOKYO' or 'WGS-84'.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string MapDatum
+		{
+			get
+			{
+				string result = GetTagText("GPSMapDatum");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				SetTagValue("GPSMapDatum", value + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the destination point
+		/// is north or south latitude.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="Latitude"/>
+		public LatitudeType? DestinationLatitudeDirection
+		{
+			get
+			{
+				return ToLatitudeType(GetTagText("GPSDestLatitudeRef"));
+			}
+			set
+			{
+				SetTagValue("GPSDestLatitudeRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the latitude of the destination point. The latitude is expressed as three rational
+		/// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="DestinationLatitudeDirection"/>
+		public FIURational[] DestinationLatitude
+		{
+			get
+			{
+				return GetTagArray<FIURational>("GPSDestLatitude");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("GPSDestLatitude", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the destination point
+		/// is east or west longitude.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="Latitude"/>
+		public LongitudeType? DestinationLongitudeDirection
+		{
+			get
+			{
+				return ToLongitudeType(GetTagText("GPSDestLongitudeRef"));
+			}
+			set
+			{
+				SetTagValue("GPSDestLongitudeRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the longitude of the destination point. The longitude is expressed as three rational
+		/// values giving the degrees, minutes, and seconds, respectively. Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational[] DestinationLongitude
+		{
+			get
+			{
+				return GetTagArray<FIURational>("GPSDestLongitude");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("GPSDestLongitude", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the reference used for giving the bearing to the destination point.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="DestinationBearing"/>
+		public DirectionReference? DestinationDirectionReference
+		{
+			get
+			{
+				return ToDirectionType(GetTagText("GPSDestBearingRef"));
+			}
+			set
+			{
+				SetTagValue("GPSDestBearingRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the bearing to the destination point.
+		/// The range of values is from 0.00 to 359.99.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="DestinationDirectionReference"/>
+		public FIURational? DestinationBearing
+		{
+			get
+			{
+				return GetTagValue<FIURational>("GPSDestBearing");
+			}
+			set
+			{
+				SetTagValue("GPSDestBearing", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the unit used to express the distance to the destination point.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="DestinationBearing"/>
+		public VelocityUnit? DestinationUnit
+		{
+			get
+			{
+				return ToUnitType(GetTagText("GPSDestDistanceRef"));
+			}
+			set
+			{
+				SetTagValue("GPSDestDistanceRef", ToString(value) + '\0');
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a character string recording the name of the method used
+		/// for location finding. The first byte indicates the character code used,
+		/// and this is followed by the name of the method. Since the Type is not ASCII,
+		/// NULL termination is not necessary.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] ProcessingMethod
+		{
+			get
+			{
+				return GetTagArray<byte>("GPSProcessingMethod");
+			}
+			set
+			{
+				SetTagValue("GPSProcessingMethod", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a character string recording the name of the GPS area.
+		/// The first byte indicates the character code used, and this is followed by
+		/// the name of the GPS area. Since the Type is not ASCII, NULL termination is
+		/// not necessary. 
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public byte[] AreaInformation
+		{
+			get
+			{
+				return GetTagArray<byte>("GPSAreaInformation");
+			}
+			set
+			{
+				SetTagValue("GPSAreaInformation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets date and time information relative to UTC (Coordinated Universal Time). 
+		/// </summary>
+		/// <remarks>
+		/// This is a derived property. There is no metadata tag directly associated
+		/// with this property value.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DateTime? DateTimeStamp
+		{
+			get
+			{
+				DateTime? date = DateStamp;
+				TimeSpan? time = TimeStamp;
+				if ((date == null) && (time == null))
+				{
+					return null;
+				}
+				else
+				{
+					if (date == null)
+					{
+						date = DateTime.MinValue;
+					}
+					if (time == null)
+					{
+						time = TimeSpan.MinValue;
+					}
+					return date.Value.Add(time.Value);
+				}
+			}
+			set
+			{
+				if (value.HasValue)
+				{
+					DateStamp = value.Value.Date;
+					TimeStamp = value.Value.TimeOfDay;
+				}
+				else
+				{
+					DateStamp = null;
+					TimeStamp = null;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets date information relative to UTC (Coordinated Universal Time).
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DateTime? DateStamp
+		{
+			get
+			{
+				string stamp = GetTagText("GPSDateStamp");
+				if (stamp != null)
+				{
+					try
+					{
+						return DateTime.ParseExact(stamp, "yyyy:MM:dd\0", null);
+					}
+					catch
+					{
+					}
+				}
+				return null;
+			}
+			set
+			{
+				string val = null;
+				if (value.HasValue)
+				{
+					try
+					{
+						val = value.Value.ToString("yyyy:MM:dd\0");
+					}
+					catch
+					{
+					}
+				}
+				SetTagValue("GPSDateStamp", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether differential correction was applied to
+		/// the GPS receiver. 
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public bool? IsDifferential
+		{
+			get
+			{
+				ushort? value = GetTagValue<ushort>("GPSDifferential");
+				return value.HasValue ? (value != 0) : (default(bool?));
+			}
+			set
+			{
+				SetTagValue("GPSDifferential", value.HasValue ? (object)(value.Value ? (ushort)1 : (ushort)0) : (null));
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_INTEROP"/>.
+	/// </summary>
+	public class MDM_INTEROP : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_INTEROP(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_INTEROP; }
+		}
+
+		/// <summary>
+		/// Gets or sets the identification of the Interoperability rule.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public InteroperabilityMode? Identification
+		{
+			get
+			{
+				return ToInteroperabilityType(GetTagText("InteroperabilityIndex"));
+			}
+			set
+			{
+				SetTagValue("InteroperabilityIndex", ToString(value) + '\0');
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN"/>.
+	/// <para/>
+	/// <b>This class is obsolete. Use class <see cref="MDM_EXIF_MAIN"/> instead.</b>
+	/// </summary>
+	[Obsolete("To be removed in future releases. Use MDM_EXIF_MAIN instead.")]
+	public class MDM_MAIN : MDM_EXIF_MAIN
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_MAIN(FIBITMAP dib) : base(dib) { }
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN"/>.
+	/// </summary>
+	public class MDM_EXIF_MAIN : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_EXIF_MAIN(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN; }
+		}
+
+		/// <summary>
+		/// Gets or sets the number of columns of image data, equal to the number
+		/// of pixels per row. In JPEG compressed data a JPEG marker is used
+		/// instead of this tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? ImageWidth
+		{
+			get
+			{
+				return GetUInt32Value("ImageWidth");
+			}
+			set
+			{
+				RemoveTag("ImageWidth");
+				if (value.HasValue)
+				{
+					SetTagValue("ImageWidth", value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets number of rows of image data. In JPEG compressed data a JPEG marker
+		/// is used instead of this tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? ImageHeight
+		{
+			get
+			{
+				return GetUInt32Value("ImageLength");
+			}
+			set
+			{
+				RemoveTag("ImageLength");
+				if (value.HasValue)
+				{
+					SetTagValue("ImageLength", value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets number of bits per image component. In this standard
+		/// each component of the image is 8 bits, so the value for this tag is 8.
+		/// Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] BitsPerSample
+		{
+			get
+			{
+				return GetTagArray<ushort>("BitsPerSample");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("BitsPerSample", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets compression scheme used for the image data. When a primary image
+		/// is JPEG compressed, this designation is not necessary and is omitted.
+		/// When thumbnails use JPEG compression, this tag value is set to 6.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? Compression
+		{
+			get
+			{
+				return GetTagValue<ushort>("Compression");
+			}
+			set
+			{
+				SetTagValue("Compression", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets pixel composition. In JPEG compressed data a JPEG marker is
+		/// used instead of this tag. See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>2</term>
+		///			<description>RGB</description>
+		///		</item>
+		///		<item>
+		///			<term>6</term>
+		///			<description>YCbCr</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? PhotometricInterpretation
+		{
+			get
+			{
+				return GetTagValue<ushort>("PhotometricInterpretation");
+			}
+			set
+			{
+				SetTagValue("PhotometricInterpretation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the image orientation viewed in terms of rows and columns.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ExifImageOrientation? Orientation
+		{
+			get
+			{
+				return (ExifImageOrientation?)GetTagValue<ushort>("Orientation");
+			}
+			set
+			{
+				SetTagValue("Orientation", (ushort?)value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of components per pixel. Since this standard applies
+		/// to RGB and YCbCr images, the value set for this tag is 3. In JPEG compressed
+		/// data a JPEG marker is used instead of this tag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? SamplesPerPixel
+		{
+			get
+			{
+				return GetTagValue<ushort>("SamplesPerPixel");
+			}
+			set
+			{
+				SetTagValue("SamplesPerPixel", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value that indicates whether pixel components are recorded in
+		/// chunky or planar format. In JPEG compressed files a JPEG marker is used instead
+		/// of this tag. If this field does not exist, the TIFF default of 1 (chunky) is assumed.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>1</term>
+		///			<description>chunky format</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>planar format</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? PlanarConfiguration
+		{
+			get
+			{
+				return GetTagValue<ushort>("PlanarConfiguration");
+			}
+			set
+			{
+				SetTagValue("PlanarConfiguration", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the sampling ratio of chrominance components in relation to
+		/// the luminance component. In JPEG compressed dat a JPEG marker is used
+		/// instead of this tag.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>[2,1]</term>
+		///			<description>YCbCr4:2:2</description>
+		///		</item>
+		///		<item>
+		///			<term>[2,2]</term>
+		///			<description>YCbCr4:2:0</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] YCbCrSubSampling
+		{
+			get
+			{
+				return GetTagArray<ushort>("YCbCrSubSampling");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 2);
+				SetTagValue("YCbCrSubSampling", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets position of chrominance components in relation to the luminance component.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// This field is designated only for JPEG compressed data or uncompressed YCbCr data.
+		/// The TIFF default is 1 (centered); but when Y:Cb:Cr = 4:2:2 it is recommended in
+		/// this standard that 2 (co-sited) be used to record data, in order to improve the
+		/// image quality when viewed on TV systems.
+		/// <para/>
+		/// When this field does not exist, the reader shall assume the TIFF default.
+		/// In the case of Y:Cb:Cr = 4:2:0, the TIFF default (centered) is recommended.
+		/// If the reader does not have the capability of supporting both kinds of YCbCrPositioning,
+		/// it shall follow the TIFF default regardless of the value in this field.
+		/// It is preferable that readers be able to support both centered and co-sited positioning.
+		/// <para/>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>1</term>
+		///			<description>centered</description>
+		///		</item>
+		///		<item>
+		///			<term>2</term>
+		///			<description>co-sited</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>reserved</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? YCbCrPositioning
+		{
+			get
+			{
+				return GetTagValue<ushort>("YCbCrPositioning");
+			}
+			set
+			{
+				SetTagValue("YCbCrPositioning", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of pixels per <see cref="ResolutionUnit"/>
+		/// in the <see cref="ImageWidth"/> direction. When the image resolution is unknown,
+		/// 72 [dpi] is designated.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? XResolution
+		{
+			get
+			{
+				return GetTagValue<FIURational>("XResolution");
+			}
+			set
+			{
+				SetTagValue("XResolution", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of pixels per <see cref="ResolutionUnit"/>
+		/// in the <see cref="ImageHeight"/> direction. When the image resolution is unknown,
+		/// 72 [dpi] is designated.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational? YResolution
+		{
+			get
+			{
+				return GetTagValue<FIURational>("YResolution");
+			}
+			set
+			{
+				SetTagValue("YResolution", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the unit for measuring <see cref="XResolution"/> and <see cref="YResolution"/>.
+		/// The same unit is used for both <see cref="XResolution"/> and <see cref="YResolution"/>.
+		/// If the image resolution in unknown, 2 (inches) is designated.
+		/// See remarks for further information.
+		/// </summary>
+		/// <remarks>
+		/// The following values are definied:<para/>
+		/// <list type="table">
+		///		<listheader>
+		///			<term>ID</term>
+		///			<description>Description</description>
+		///		</listheader>
+		///		<item>
+		///			<term>2</term>
+		///			<description>inches</description>
+		///		</item>
+		///		<item>
+		///			<term>3</term>
+		///			<description>YCbCr4:2:0</description>
+		///		</item>
+		///		<item>
+		///			<term>other</term>
+		///			<description>centimeters</description>
+		///		</item>
+		/// </list>
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort? ResolutionUnit
+		{
+			get
+			{
+				return GetTagValue<ushort>("ResolutionUnit");
+			}
+			set
+			{
+				SetTagValue("ResolutionUnit", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the byte offset of that strip.
+		/// It is recommended that this be selected so the number of strip bytes
+		/// does not exceed 64 Kbytes.
+		/// With JPEG compressed data this designation is not needed and is omitted.
+		/// Constant length of <see cref="SamplesPerPixel"/> * StripsPerImage.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="RowsPerStrip"/>
+		/// <see cref="StripByteCounts"/>
+		public uint[] StripOffsets
+		{
+			get
+			{
+				return GetUInt32Array("StripOffsets");
+			}
+			set
+			{
+				RemoveTag("StripOffsets");
+				if (value != null)
+				{
+					SetTagValue("StripOffsets", value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets number of rows per strip. This is the number of rows in the image of
+		/// one strip when an image is divided into strips. With JPEG compressed data this
+		/// designation is not needed and is omitted.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		/// <seealso cref="StripByteCounts"/>
+		public uint? RowsPerStrip
+		{
+			get
+			{
+				return GetUInt32Value("RowsPerStrip");
+			}
+			set
+			{
+				RemoveTag("RowsPerStrip");
+				if (value.HasValue)
+				{
+					SetTagValue("RowsPerStrip", value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the total number of bytes in each strip.
+		/// With JPEG compressed data this designation is not needed and is omitted.
+		/// Constant length of <see cref="SamplesPerPixel"/> * StripsPerImage.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint[] StripByteCounts
+		{
+			get
+			{
+				return GetUInt32Array("StripByteCounts");
+			}
+			set
+			{
+				RemoveTag("StripByteCounts");
+				if (value != null)
+				{
+					SetTagValue("StripByteCounts", value);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the offset to the start byte (SOI) of JPEG compressed thumbnail data.
+		/// This is not used for primary image JPEG data.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? JPEGInterchangeFormat
+		{
+			get
+			{
+				return GetTagValue<uint>("JPEGInterchangeFormat");
+			}
+			set
+			{
+				SetTagValue("JPEGInterchangeFormat", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the number of bytes of JPEG compressed thumbnail data.
+		/// </summary>
+		/// <remarks>
+		/// This is not used for primary image JPEG data.
+		/// JPEG thumbnails are not divided but are recorded as a continuous
+		/// JPEG bitstream from SOI to EOI. APPn and COM markers should not be recorded.
+		/// Compressed thumbnails shall be recorded in no more than 64 Kbytes,
+		/// including all other data to be recorded in APP1.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? JPEGInterchangeFormatLength
+		{
+			get
+			{
+				return GetTagValue<uint>("JPEGInterchangeFormatLength");
+			}
+			set
+			{
+				SetTagValue("JPEGInterchangeFormatLength", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a transfer function for the image, described in tabular style.
+		/// Constant length of 3 * 256.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] TransferFunction
+		{
+			get
+			{
+				return GetTagArray<ushort>("TransferFunction");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3 * 256);
+				SetTagValue("TransferFunction", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the chromaticity of the white point of the image.
+		/// Constant length of 2.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational[] WhitePoint
+		{
+			get
+			{
+				return GetTagArray<FIURational>("WhitePoint");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 2);
+				SetTagValue("WhitePoint", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the chromaticity of the three primary colors of the image.
+		/// Constant length of 6.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational[] PrimaryChromaticities
+		{
+			get
+			{
+				return GetTagArray<FIURational>("PrimaryChromaticities");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 6);
+				SetTagValue("PrimaryChromaticities", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the matrix coefficients for transformation from RGB to YCbCr image data.
+		/// Constant length of 3.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational[] YCbCrCoefficients
+		{
+			get
+			{
+				return GetTagArray<FIURational>("YCbCrCoefficients");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 3);
+				SetTagValue("PrimaryChromaticities", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the reference black point value and reference white point value.
+		/// Constant length of 6.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public FIURational[] ReferenceBlackWhite
+		{
+			get
+			{
+				return GetTagArray<FIURational>("ReferenceBlackWhite");
+			}
+			set
+			{
+				FreeImage.Resize(ref value, 6);
+				SetTagValue("ReferenceBlackWhite", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the date and time of image creation.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public DateTime? DateTime
+		{
+			get
+			{
+				DateTime? result = null;
+				string text = GetTagText("DateTime");
+				if (text != null)
+				{
+					try
+					{
+						result = System.DateTime.ParseExact(text, "yyyy:MM:dd HH:mm:ss\0", null);
+					}
+					catch
+					{
+					}
+				}
+				return result;
+			}
+			set
+			{
+				string val = null;
+				if (value.HasValue)
+				{
+					try
+					{
+						val = value.Value.ToString("yyyy:MM:dd HH:mm:ss\0");
+					}
+					catch
+					{
+					}
+				}
+				SetTagValue("DateTime", val);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a string giving the title of the image.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ImageDescription
+		{
+			get
+			{
+				string result = GetTagText("ImageDescription");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("ImageDescription", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the manufacturer of the recording equipment.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Make
+		{
+			get
+			{
+				string result = GetTagText("Make");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("Make", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the model name or model number of the equipment.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string EquipmentModel
+		{
+			get
+			{
+				string result = GetTagText("Model");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("Model", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the name and version of the software or firmware of the camera
+		/// or image input device used to generate the image.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Software
+		{
+			get
+			{
+				string result = GetTagText("Software");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("Software", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the name of the camera owner, photographer or image creator.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Artist
+		{
+			get
+			{
+				string result = GetTagText("Artist");
+				if (!string.IsNullOrEmpty(result))
+				{
+					result = result.Substring(0, result.Length - 1);
+				}
+				return result;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("Artist", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the photographer and editor copyrights.
+		/// Constant length of 1-2.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string[] Copyright
+		{
+			get
+			{
+				string[] result = null;
+				string text = GetTagText("Copyright");
+				if (!string.IsNullOrEmpty(text))
+				{
+					result = text.Split(new char[] { '\0' }, StringSplitOptions.RemoveEmptyEntries);
+				}
+				return result;
+			}
+			set
+			{
+				string val = null;
+				if (value != null)
+				{
+					if (value.Length == 1)
+					{
+						if (value[0] != null)
+						{
+							val = value[0] + '\0';
+						}
+					}
+					else if (value.Length == 2)
+					{
+						if ((value[0] != null) && (value[1] != null))
+						{
+							val = value[0] + '\0' + value[1] + '\0';
+						}
+					}
+				}
+				SetTagValue("Copyright", val);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_MAKERNOTE"/>.
+	/// </summary>
+	public class MDM_MAKERNOTE : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_MAKERNOTE(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_MAKERNOTE; }
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_GEOTIFF"/>.
+	/// </summary>
+	public class MDM_GEOTIFF : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_GEOTIFF(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_GEOTIFF; }
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF GeoASCIIParamsTag.
+		/// </summary>
+		/// <remarks>
+		/// The GeoASCIIParamsTag is used to store all of the <see cref="String"/> valued
+		/// GeoKeys, referenced by the <see cref="GeoKeyDirectory"/> property. Since keys
+		/// defined in the GeoKeyDirectoryTag use offsets into this tag, any special
+		/// comments may be placed at the beginning of this tag.
+		/// For the most part, the only keys that are <see cref="String"/> valued are
+		/// <i>Citation</i> keys, giving documentation and references for obscure
+		/// projections, datums, etc.
+		/// <para/>
+		/// Special handling is required for <see cref="String"/>-valued keys. While it
+		/// is true that TIFF 6.0 permits multiple NULL-delimited strings within a single
+		/// ASCII tag, the secondary strings might not appear in the output of naive
+		/// <i>tiffdump</i> programs. For this reason, the NULL delimiter of each ASCII key
+		/// value shall be converted to a "|" (pipe) character before being installed
+		/// back into the <see cref="String"/> holding tag, so that a dump of the tag
+		/// will look like this.
+		/// <para/>
+		/// AsciiTag="first_value|second_value|etc...last_value|"
+		/// <para/>
+		/// A baseline GeoTIFF-reader must check for and convert the final "|" pipe 
+		/// character of a key back into a NULL before returning it to the client 
+		/// software.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string GeoASCIIParams
+		{
+			get
+			{
+				string text = GetTagText("GeoASCIIParams");
+				if (!string.IsNullOrEmpty(text))
+				{
+					text = text.Substring(0, text.Length - 1);
+				}
+				return text;
+			}
+			set
+			{
+				if (value != null)
+				{
+					value += '\0';
+				}
+				SetTagValue("GeoASCIIParams", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF GeoDoubleParamsTag.
+		/// </summary>
+		/// <remarks>
+		/// The GeoDoubleParamsTag is used to store all of the <see cref="Double"/> valued
+		/// GeoKeys, referenced by the <see cref="GeoKeyDirectory"/> property. The meaning of
+		/// any value of this double array is determined from the GeoKeyDirectoryTag reference
+		/// pointing to it. <see cref="Single"/> values should first be converted to
+		/// <see cref="Double"/> and stored here.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public double[] GeoDoubleParams
+		{
+			get
+			{
+				return GetTagArray<double>("GeoDoubleParams");
+			}
+			set
+			{
+				SetTagValue("GeoDoubleParams", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF GeoKeyDirectoryTag.
+		/// </summary>
+		/// <remarks>
+		/// The GeoKeyDirectoryTag may be used to store the GeoKey Directory, which defines and
+		/// references the <i>GeoKeys</i>.
+		/// <para/>
+		/// The tag is an array of unsigned <see cref="UInt16"/> values, which are primarily
+		/// grouped into blocks of 4. The first 4 values are special, and contain GeoKey directory
+		/// header information. The header values consist of the following information, in order:
+		/// <para/>
+		/// Header={KeyDirectoryVersion, KeyRevision, MinorRevision, NumberOfKeys}
+		/// <para/>
+		/// where
+		/// <para/>
+		/// <i>KeyDirectoryVersion</i> indicates the current version of Key implementation, and will
+		/// only change if this Tag's Key structure is changed. (Similar to the TIFFVersion (42)).
+		/// The current DirectoryVersion number is 1. This value will most likely never change,
+		/// and may be used to ensure that this is a valid Key-implementation.
+		/// <para/>
+		/// <i>KeyRevision</i> indicates what revision of Key-Sets are used.
+		/// <para/>
+		/// <i>MinorRevision</i> indicates what set of Key-Codes are used. The complete revision number
+		/// is denoted &lt;KeyRevision&gt;.&lt;MinorRevision&gt;.
+		/// <para/>
+		/// <i>NumberOfKeys</i> indicates how many Keys are defined by the rest of this Tag.
+		/// <para/>
+		/// This header is immediately followed by a collection of &lt;NumberOfKeys&gt; KeyEntry
+		/// sets, each of which is also 4-<see cref="UInt16"/> long. Each KeyEntry is modeled on the
+		/// <i>TIFFEntry</i> format of the TIFF directory header, and is of the form:
+		/// <para/>
+		/// KeyEntry = { KeyID, TIFFTagLocation, Count, Value_Offset }
+		/// <para/>
+		/// where
+		/// <para/>
+		/// <i>KeyID</i> gives the Key-ID value of the Key (identical in function to TIFF tag ID,
+		/// but completely independent of TIFF tag-space),
+		/// <para/>
+		/// <i>TIFFTagLocation</i> indicates which TIFF tag contains the value(s) of the Key: if
+		/// TIFFTagLocation is 0, then the value is <see cref="UInt16"/>, and is contained in the
+		/// <i>Value_Offset</i> entry. Otherwise, the type (format) of the value is implied by the
+		/// TIFF-Type of the tag containing the value.
+		/// <para/>
+		/// <i>Count</i> indicates the number of values in this key.
+		/// <para/>
+		/// <i>Value_Offset</i> Value_Offset indicates the index-offset into the TagArray indicated
+		/// by TIFFTagLocation, if it is nonzero. If TIFFTagLocation is 0 (zero) , then Value_Offset 
+		/// contains the actual (<see cref="UInt16"/>) value of the Key, and Count=1 is implied.
+		/// Note that the offset is not a byte-offset, but rather an index based on the natural data
+		/// type of the specified tag array.
+		/// <para/>
+		/// Following the KeyEntry definitions, the KeyDirectory tag may also contain additional
+		/// values. For example, if a key requires multiple <see cref="UInt16"/> values, they shall
+		/// be placed at the end of this tag, and the KeyEntry will set
+		/// TIFFTagLocation=GeoKeyDirectoryTag, with the Value_Offset pointing to the location of the
+		/// value(s).
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public ushort[] GeoKeyDirectory
+		{
+			get
+			{
+				return GetTagArray<ushort>("GeoKeyDirectory");
+			}
+			set
+			{
+				SetTagValue("GeoKeyDirectory", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF ModelPixelScaleTag.
+		/// </summary>
+		/// <remarks>
+		/// The ModelPixelScaleTag tag may be used to specify the size of raster pixel spacing
+		/// in the model space units, when the raster space can be embedded in the model space
+		/// coordinate system without rotation, and consists of the following 3 values:
+		/// <para/>
+		/// ModelPixelScaleTag = (ScaleX, ScaleY, ScaleZ)
+		/// <para/>
+		/// where <i>ScaleX</i> and <i>ScaleY</i> give the horizontal and vertical spacing of
+		/// raster pixels. The <i>ScaleZ</i> is primarily used to map the pixel value of a
+		/// digital elevation model into the correct Z-scale, and so for most other purposes
+		/// this value should be zero (since most model spaces are 2-D, with Z=0).
+		/// <para/>
+		/// A single tiepoint in the <see cref="ModelTiePoints"/> tag, together with this tag,
+		/// completely determine the relationship between raster and model space; thus they
+		/// comprise the two tags which Baseline GeoTIFF files most often will use to place a
+		/// raster image into a "standard position" in model space.
+		/// <para/>
+		/// Like the <see cref="ModelTiePoints"/> tag, this tag information is independent of the
+		/// XPosition, YPosition, Resolution and Orientation tags of the standard TIFF 6.0 spec.
+		/// However, simple reversals of orientation between raster and model space
+		/// (e.g. horizontal or vertical flips) may be indicated by reversal of sign in the
+		/// corresponding component of the ModelPixelScaleTag. GeoTIFF compliant readers must
+		/// honor this signreversal convention.
+		/// <para/>
+		/// This tag must not be used if the raster image requires rotation or shearing to place
+		/// it into the standard model space. In such cases the transformation shall be defined
+		/// with the more general <see cref="ModelTransformationMatrix"/>.
+		/// <para/>
+		/// <br/><b>Naming differences</b><para/>
+		/// In the native FreeImage library and thus, in the FreeImage API documentation, this
+		/// property's key is named <i>GeoPixelScale</i>. Since the GeoTIFF specification
+		/// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
+		/// <see cref="ModelPixelScale"/>, this property was renamed accordingly.
+		/// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
+		/// the native FreeImage tag key <i>GeoPixelScale</i> must be used.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public double[] ModelPixelScale
+		{
+			get
+			{
+				return GetTagArray<double>("GeoPixelScale");
+			}
+			set
+			{
+				SetTagValue("GeoPixelScale", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF GeoTiePointsTag.
+		/// </summary>
+		/// <remarks>
+		/// The GeoTiePointsTag stores raster -> model tiepoint pairs in the order
+		/// <para/>
+		/// ModelTiePoints = (...,I,J,K, X,Y,Z...),
+		/// <para/>
+		/// where <i>(I,J,K)</i> is the point at location <i>(I,J)</i> in raster space with 
+		/// pixel-value <i>K</i>, and <i>(X,Y,Z)</i> is a vector in model space. In most cases
+		/// the model space is only two-dimensional, in which case both K and Z should be set
+		/// to zero; this third dimension is provided in anticipation of future support for 3D
+		/// digital elevation models and vertical coordinate systems.
+		/// <para/>
+		/// A raster image may be georeferenced simply by specifying its location, size and
+		/// orientation in the model coordinate space M. This may be done by specifying the
+		/// location of three of the four bounding corner points. However, tiepoints are only
+		/// to be considered exact at the points specified; thus defining such a set of
+		/// bounding tiepoints does not imply that the model space locations of the interior
+		/// of the image may be exactly computed by a linear interpolation of these tiepoints.
+		/// <para/>
+		/// However, since the relationship between the Raster space and the model space will
+		/// often be an exact, affine transformation, this relationship can be defined using
+		/// one set of tiepoints and the <see cref="ModelPixelScale"/>, described below, which
+		/// gives the vertical and horizontal raster grid cell size, specified in model units.
+		/// <para/>
+		/// If possible, the first tiepoint placed in this tag shall be the one establishing
+		/// the location of the point (0,0) in raster space. However, if this is not possible
+		/// (for example, if (0,0) is goes to a part of model space in which the projection is
+		/// ill-defined), then there is no particular order in which the tiepoints need be
+		/// listed.
+		/// <para/>
+		/// For orthorectification or mosaicking applications a large number of tiepoints may
+		/// be specified on a mesh over the raster image. However, the definition of associated
+		/// grid interpolation methods is not in the scope of the current GeoTIFF spec.
+		/// <para/>
+		/// <br/><b>Naming differences</b><para/>
+		/// In the native FreeImage library and thus, in the FreeImage API documentation, this
+		/// property's key is named <i>GeoTiePoints</i>. Since the GeoTIFF specification
+		/// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
+		/// <see cref="ModelTiePoints"/>, this property was renamed accordingly.
+		/// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
+		/// the native FreeImage tag key <i>GeoTiePoints</i> must be used.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public double[] ModelTiePoints
+		{
+			get
+			{
+				return GetTagArray<double>("GeoTiePoints");
+			}
+			set
+			{
+				SetTagValue("GeoTiePoints", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF ModelTransformationMatrixTag.
+		/// </summary>
+		/// <remarks>
+		/// This tag may be used to specify the transformation matrix between the raster space
+		/// (and its dependent pixel-value space) and the (possibly 3D) model space.
+		/// <para/>
+		/// <br/><b>Naming differences</b><para/>
+		/// In the native FreeImage library and thus, in the FreeImage API documentation, this
+		/// property's key is named <i>GeoTransformationMatrix</i>. Since the GeoTIFF specification
+		/// as well as Java's <c>EXIFTIFFTagSet</c> class call this tag
+		/// <see cref="ModelTransformationMatrix"/>, this property was renamed accordingly.
+		/// However, when accessing this property's tag by its <see cref="MetadataTag"/> object,
+		/// the native FreeImage tag key <i>GeoTransformationMatrix</i> must be used.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public double[] ModelTransformationMatrix
+		{
+			get
+			{
+				return GetTagArray<double>("GeoTransformationMatrix");
+			}
+			set
+			{
+				SetTagValue("GeoTransformationMatrix", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF IntergraphTransformationMatrixTag.
+		/// </summary>
+		/// <remarks>
+		/// The IntergraphTransformationMatrixTag conflicts with an internal software implementation
+		/// at Intergraph, and so its use is no longer encouraged. A GeoTIFF reader should look first
+		/// for the new tag, and only if it is not found should it check for this older tag. If found,
+		/// it should only consider it to be contain valid GeoTIFF matrix information if the tag-count
+		/// is 16; the Intergraph version uses 17 values.
+		/// <para/>
+		/// <br/><b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public double[] IntergraphTransformationMatrix
+		{
+			get
+			{
+				return GetTagArray<double>("Intergraph TransformationMatrix");
+			}
+			set
+			{
+				SetTagValue("Intergraph TransformationMatrix", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the GeoTIFF JPLCartoIFDOffsetTag.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public uint? JPLCartoIFDOffset
+		{
+			get
+			{
+				return GetTagValue<uint>("JPL Carto IFD offset");
+			}
+			set
+			{
+				SetTagValue("JPL Carto IFD offset", value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_IPTC"/>.
+	/// </summary>
+	public class MDM_IPTC : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_IPTC(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_IPTC; }
+		}
+
+		/// <summary>
+		/// Gets the Application Record Version.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public short? ApplicationRecordVersion
+		{
+			get
+			{
+				return GetTagValue<short>("ApplicationRecordVersion");
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Type Reference.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectTypeReference
+		{
+			get
+			{
+				return GetTagText("ObjectTypeReference");
+			}
+			set
+			{
+				SetTagValue("ObjectTypeReference", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Attribute Reference.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectAttributeReference
+		{
+			get
+			{
+				return GetTagText("ObjectAttributeReference");
+			}
+			set
+			{
+				SetTagValue("ObjectAttributeReference", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Name.
+		/// This is also referred to as Title.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectName
+		{
+			get
+			{
+				return GetTagText("ObjectName");
+			}
+			set
+			{
+				SetTagValue("ObjectName", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Edit Status.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string EditStatus
+		{
+			get
+			{
+				return GetTagText("EditStatus");
+			}
+			set
+			{
+				SetTagValue("EditStatus", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Editorial Update.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string EditorialUpdate
+		{
+			get
+			{
+				return GetTagText("EditorialUpdate");
+			}
+			set
+			{
+				SetTagValue("EditorialUpdate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Urgency.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Urgency
+		{
+			get
+			{
+				return GetTagText("Urgency");
+			}
+			set
+			{
+				SetTagValue("Urgency", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Subject Reference.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SubjectReference
+		{
+			get
+			{
+				return GetTagText("SubjectReference");
+			}
+			set
+			{
+				SetTagValue("SubjectReference", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Category.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Category
+		{
+			get
+			{
+				return GetTagText("Category");
+			}
+			set
+			{
+				SetTagValue("Category", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Supplemental Categories.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SupplementalCategories
+		{
+			get
+			{
+				return GetTagText("SupplementalCategories");
+			}
+			set
+			{
+				SetTagValue("SupplementalCategories", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Fixture Identifier.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string FixtureIdentifier
+		{
+			get
+			{
+				return GetTagText("FixtureIdentifier");
+			}
+			set
+			{
+				SetTagValue("FixtureIdentifier", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Keywords.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Keywords
+		{
+			get
+			{
+				return GetTagText("Keywords");
+			}
+			set
+			{
+				SetTagValue("Keywords", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Content Location Code.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ContentLocationCode
+		{
+			get
+			{
+				return GetTagText("ContentLocationCode");
+			}
+			set
+			{
+				SetTagValue("ContentLocationCode", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Content Location Name.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ContentLocationName
+		{
+			get
+			{
+				return GetTagText("ContentLocationName");
+			}
+			set
+			{
+				SetTagValue("ContentLocationName", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Release Date.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ReleaseDate
+		{
+			get
+			{
+				return GetTagText("ReleaseDate");
+			}
+			set
+			{
+				SetTagValue("ReleaseDate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Release Time.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ReleaseTime
+		{
+			get
+			{
+				return GetTagText("ReleaseTime");
+			}
+			set
+			{
+				SetTagValue("ReleaseTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Expiration Date.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ExpirationDate
+		{
+			get
+			{
+				return GetTagText("ExpirationDate");
+			}
+			set
+			{
+				SetTagValue("ExpirationDate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Expiration Time.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ExpirationTime
+		{
+			get
+			{
+				return GetTagText("ExpirationTime");
+			}
+			set
+			{
+				SetTagValue("ExpirationTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Special Instructions.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SpecialInstructions
+		{
+			get
+			{
+				return GetTagText("SpecialInstructions");
+			}
+			set
+			{
+				SetTagValue("SpecialInstructions", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Action Advised.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ActionAdvised
+		{
+			get
+			{
+				return GetTagText("ActionAdvised");
+			}
+			set
+			{
+				SetTagValue("ActionAdvised", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Reference Service.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ReferenceService
+		{
+			get
+			{
+				return GetTagText("ReferenceService");
+			}
+			set
+			{
+				SetTagValue("ReferenceService", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Reference Date.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ReferenceDate
+		{
+			get
+			{
+				return GetTagText("ReferenceDate");
+			}
+			set
+			{
+				SetTagValue("ReferenceDate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Reference Number.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ReferenceNumber
+		{
+			get
+			{
+				return GetTagText("ReferenceNumber");
+			}
+			set
+			{
+				SetTagValue("ReferenceNumber", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Date Created.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string DateCreated
+		{
+			get
+			{
+				return GetTagText("DateCreated");
+			}
+			set
+			{
+				SetTagValue("DateCreated", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Time Created.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string TimeCreated
+		{
+			get
+			{
+				return GetTagText("TimeCreated");
+			}
+			set
+			{
+				SetTagValue("TimeCreated", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Digital Creation Date.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string DigitalCreationDate
+		{
+			get
+			{
+				return GetTagText("DigitalCreationDate");
+			}
+			set
+			{
+				SetTagValue("DigitalCreationDate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Digital Creation Time.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string DigitalCreationTime
+		{
+			get
+			{
+				return GetTagText("DigitalCreationTime");
+			}
+			set
+			{
+				SetTagValue("DigitalCreationTime", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Originating Program.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string OriginatingProgram
+		{
+			get
+			{
+				return GetTagText("OriginatingProgram");
+			}
+			set
+			{
+				SetTagValue("OriginatingProgram", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Program Version.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ProgramVersion
+		{
+			get
+			{
+				return GetTagText("ProgramVersion");
+			}
+			set
+			{
+				SetTagValue("ProgramVersion", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Cycle.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectCycle
+		{
+			get
+			{
+				return GetTagText("ObjectCycle");
+			}
+			set
+			{
+				SetTagValue("ObjectCycle", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag By Line.
+		/// This is the author's name.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ByLine
+		{
+			get
+			{
+				return GetTagText("By-line");
+			}
+			set
+			{
+				SetTagValue("By-line", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag By Line Title.
+		/// This is the author's position.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ByLineTitle
+		{
+			get
+			{
+				return GetTagText("By-lineTitle");
+			}
+			set
+			{
+				SetTagValue("By-lineTitle", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag City.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string City
+		{
+			get
+			{
+				return GetTagText("City");
+			}
+			set
+			{
+				SetTagValue("City", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Sub Location.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SubLocation
+		{
+			get
+			{
+				return GetTagText("SubLocation");
+			}
+			set
+			{
+				SetTagValue("SubLocation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Province State.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ProvinceState
+		{
+			get
+			{
+				return GetTagText("ProvinceState");
+			}
+			set
+			{
+				SetTagValue("ProvinceState", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Country Primary Location Code.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string CountryPrimaryLocationCode
+		{
+			get
+			{
+				return GetTagText("Country-PrimaryLocationCode");
+			}
+			set
+			{
+				SetTagValue("Country-PrimaryLocationCode", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Country Primary Location Name.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string CountryPrimaryLocationName
+		{
+			get
+			{
+				return GetTagText("Country-PrimaryLocationName");
+			}
+			set
+			{
+				SetTagValue("Country-PrimaryLocationName", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Original Transmission Reference.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string OriginalTransmissionReference
+		{
+			get
+			{
+				return GetTagText("OriginalTransmissionReference");
+			}
+			set
+			{
+				SetTagValue("OriginalTransmissionReference", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Headline.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Headline
+		{
+			get
+			{
+				return GetTagText("Headline");
+			}
+			set
+			{
+				SetTagValue("Headline", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Credit.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Credit
+		{
+			get
+			{
+				return GetTagText("Credit");
+			}
+			set
+			{
+				SetTagValue("Credit", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Source.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Source
+		{
+			get
+			{
+				return GetTagText("Source");
+			}
+			set
+			{
+				SetTagValue("Source", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Copyright Notice.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string CopyrightNotice
+		{
+			get
+			{
+				return GetTagText("CopyrightNotice");
+			}
+			set
+			{
+				SetTagValue("CopyrightNotice", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Contact.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Contact
+		{
+			get
+			{
+				return GetTagText("Contact");
+			}
+			set
+			{
+				SetTagValue("Contact", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Caption Abstract.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string CaptionAbstract
+		{
+			get
+			{
+				return GetTagText("CaptionAbstract");
+			}
+			set
+			{
+				SetTagValue("CaptionAbstract", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Writer Editor.
+		/// This is also referred to as Caption Writer.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string WriterEditor
+		{
+			get
+			{
+				return GetTagText("WriterEditor");
+			}
+			set
+			{
+				SetTagValue("WriterEditor", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Rasterized Caption.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string RasterizedCaption
+		{
+			get
+			{
+				return GetTagText("RasterizedCaption");
+			}
+			set
+			{
+				SetTagValue("RasterizedCaption", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Image Type.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ImageType
+		{
+			get
+			{
+				return GetTagText("ImageType");
+			}
+			set
+			{
+				SetTagValue("ImageType", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Image Orientation.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ImageOrientation
+		{
+			get
+			{
+				return GetTagText("ImageOrientation");
+			}
+			set
+			{
+				SetTagValue("ImageOrientation", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Language Identifier.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string LanguageIdentifier
+		{
+			get
+			{
+				return GetTagText("LanguageIdentifier");
+			}
+			set
+			{
+				SetTagValue("LanguageIdentifier", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Audio Type.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string AudioType
+		{
+			get
+			{
+				return GetTagText("AudioType");
+			}
+			set
+			{
+				SetTagValue("AudioType", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Audio Sampling Rate.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string AudioSamplingRate
+		{
+			get
+			{
+				return GetTagText("AudioSamplingRate");
+			}
+			set
+			{
+				SetTagValue("AudioSamplingRate", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Audio Sampling Resolution.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string AudioSamplingResolution
+		{
+			get
+			{
+				return GetTagText("AudioSamplingResolution");
+			}
+			set
+			{
+				SetTagValue("AudioSamplingResolution", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Audio Duration.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string AudioDuration
+		{
+			get
+			{
+				return GetTagText("AudioDuration");
+			}
+			set
+			{
+				SetTagValue("AudioDuration", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Audio Outcue.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string AudioOutcue
+		{
+			get
+			{
+				return GetTagText("AudioOutcue");
+			}
+			set
+			{
+				SetTagValue("AudioOutcue", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Job I D.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string JobID
+		{
+			get
+			{
+				return GetTagText("JobID");
+			}
+			set
+			{
+				SetTagValue("JobID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Master Document I D.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string MasterDocumentID
+		{
+			get
+			{
+				return GetTagText("MasterDocumentID");
+			}
+			set
+			{
+				SetTagValue("MasterDocumentID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Short Document I D.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ShortDocumentID
+		{
+			get
+			{
+				return GetTagText("ShortDocumentID");
+			}
+			set
+			{
+				SetTagValue("ShortDocumentID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Unique Document I D.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string UniqueDocumentID
+		{
+			get
+			{
+				return GetTagText("UniqueDocumentID");
+			}
+			set
+			{
+				SetTagValue("UniqueDocumentID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Owner I D.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string OwnerID
+		{
+			get
+			{
+				return GetTagText("OwnerID");
+			}
+			set
+			{
+				SetTagValue("OwnerID", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Preview File Format.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectPreviewFileFormat
+		{
+			get
+			{
+				return GetTagText("ObjectPreviewFileFormat");
+			}
+			set
+			{
+				SetTagValue("ObjectPreviewFileFormat", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Preview File Version.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectPreviewFileVersion
+		{
+			get
+			{
+				return GetTagText("ObjectPreviewFileVersion");
+			}
+			set
+			{
+				SetTagValue("ObjectPreviewFileVersion", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Object Preview Data.
+		/// This is also referred to as Audio Outcue.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ObjectPreviewData
+		{
+			get
+			{
+				return GetTagText("ObjectPreviewData");
+			}
+			set
+			{
+				SetTagValue("ObjectPreviewData", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Prefs.
+		/// This is also referred to as photo-mechanic preferences.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Prefs
+		{
+			get
+			{
+				return GetTagText("Prefs");
+			}
+			set
+			{
+				SetTagValue("Prefs", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Classify State.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ClassifyState
+		{
+			get
+			{
+				return GetTagText("ClassifyState");
+			}
+			set
+			{
+				SetTagValue("ClassifyState", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Similarity Index.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string SimilarityIndex
+		{
+			get
+			{
+				return GetTagText("SimilarityIndex");
+			}
+			set
+			{
+				SetTagValue("SimilarityIndex", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Document Notes.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string DocumentNotes
+		{
+			get
+			{
+				return GetTagText("DocumentNotes");
+			}
+			set
+			{
+				SetTagValue("DocumentNotes", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Document History.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string DocumentHistory
+		{
+			get
+			{
+				return GetTagText("DocumentHistory");
+			}
+			set
+			{
+				SetTagValue("DocumentHistory", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the value of the IPTC/NAA tag Exif Camera Info.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string ExifCameraInfo
+		{
+			get
+			{
+				return GetTagText("ExifCameraInfo");
+			}
+			set
+			{
+				SetTagValue("ExifCameraInfo", value);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_NODATA"/>.
+	/// </summary>
+	public class MDM_NODATA : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_NODATA(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_NODATA; }
+		}
+	}
+
+	/// <summary>
+	/// Represents a collection of all tags contained in the metadata model
+	/// <see cref="FREE_IMAGE_MDMODEL.FIMD_XMP"/>.
+	/// </summary>
+	public class MDM_XMP : MetadataModel
+	{
+		/// <summary>
+		/// Initializes a new instance of this class.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public MDM_XMP(FIBITMAP dib) : base(dib) { }
+
+		/// <summary>
+		/// Retrieves the datamodel that this instance represents.
+		/// </summary>
+		public override FREE_IMAGE_MDMODEL Model
+		{
+			get { return FREE_IMAGE_MDMODEL.FIMD_XMP; }
+		}
+
+		/// <summary>
+		/// Gets or sets the XMP XML content.
+		/// </summary>
+		/// <remarks>
+		/// <b>Handling of null values</b><para/>
+		/// A null value indicates, that the corresponding metadata tag is not
+		/// present in the metadata model.
+		/// Setting this property's value to a non-null reference creates the
+		/// metadata tag if necessary.
+		/// Setting this property's value to a null reference deletes the
+		/// metadata tag from the metadata model.
+		/// </remarks>
+		public string Xml
+		{
+			get
+			{
+				return GetTagText("XMLPacket");
+			}
+			set
+			{
+				SetTagValue("XMLPacket", value);
+			}
+		}
+
+		/// <summary>
+		/// Gets an <see cref="XmlReader"/> initialized to read the XMP XML content.
+		/// Returns null, if the metadata tag <i>XMLPacket</i> is not present in
+		/// this model.
+		/// </summary>
+		public XmlReader XmlReader
+		{
+			get
+			{
+				string xmlString = Xml;
+				if (xmlString == null)
+				{
+					return null;
+				}
+				else
+				{
+					MemoryStream stream = new MemoryStream();
+					StreamWriter writer = new StreamWriter(stream);
+					writer.Write(xmlString);
+					return XmlReader.Create(stream);
+				}
+			}
+		}
+	}
 }

--- a/src/FreeImage.Standard/Classes/PluginRepository.cs
+++ b/src/FreeImage.Standard/Classes/PluginRepository.cs
@@ -12,7 +12,7 @@ namespace FreeImageAPI.Plugins
 	{
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private static readonly List<FreeImagePlugin> plugins = null;
-		
+
 		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 		private static readonly List<FreeImagePlugin> localPlugins = null;
 
@@ -149,9 +149,9 @@ namespace FreeImageAPI.Plugins
 				List<FreeImagePlugin> list = new List<FreeImagePlugin>();
 				foreach (FreeImagePlugin p in plugins)
 				{
-					if (p.SupportsReading && !p.SupportsWriting) 
+					if (p.SupportsReading && !p.SupportsWriting)
 					{
-						list.Add(p); 
+						list.Add(p);
 					}
 				}
 				return list;
@@ -243,7 +243,7 @@ namespace FreeImageAPI.Plugins
 		{
 			get
 			{
-				return localPlugins.AsReadOnly();  
+				return localPlugins.AsReadOnly();
 			}
 		}
 
@@ -265,7 +265,7 @@ namespace FreeImageAPI.Plugins
 				return list;
 			}
 		}
-		
+
 		/// <summary>
 		/// Windows or OS/2 Bitmap File (*.BMP)
 		/// </summary>

--- a/src/FreeImage.Standard/Classes/StreamWrapper.cs
+++ b/src/FreeImage.Standard/Classes/StreamWrapper.cs
@@ -306,7 +306,8 @@ namespace FreeImageAPI.IO
 
 		private void checkDisposed()
 		{
-			if (disposed) throw new ObjectDisposedException("StreamWrapper");
+			if (disposed)
+				throw new ObjectDisposedException("StreamWrapper");
 		}
 	}
 }

--- a/src/FreeImage.Standard/Enumerations/FREE_IMAGE_SAVE_FLAGS.cs
+++ b/src/FreeImage.Standard/Enumerations/FREE_IMAGE_SAVE_FLAGS.cs
@@ -117,14 +117,14 @@ namespace FreeImageAPI
 		/// Save with no chroma subsampling (4:4:4).
 		/// </summary>
 		JPEG_SUBSAMPLING_444 = 0x10000,
-        /// <summary>
-        /// On saving, compute optimal Huffman coding tables (can reduce a few percent of file size).
-        /// </summary>
-        JPEG_OPTIMIZE = 0x20000,
-        /// <summary>
-        /// save basic JPEG, without metadata or any markers.
-        /// </summary>
-        JPEG_BASELINE = 0x40000,
+		/// <summary>
+		/// On saving, compute optimal Huffman coding tables (can reduce a few percent of file size).
+		/// </summary>
+		JPEG_OPTIMIZE = 0x20000,
+		/// <summary>
+		/// save basic JPEG, without metadata or any markers.
+		/// </summary>
+		JPEG_BASELINE = 0x40000,
 		/// <summary>
 		/// Save using ZLib level 1 compression flag
 		/// (default value is <see cref="PNG_Z_DEFAULT_COMPRESSION"/>).

--- a/src/FreeImage.Standard/FreeImageStaticImports.cs
+++ b/src/FreeImage.Standard/FreeImageStaticImports.cs
@@ -40,2474 +40,2474 @@ using FreeImageAPI.IO;
 
 namespace FreeImageAPI
 {
-    public static partial class FreeImage
-    {
-        public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        public static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+	public static partial class FreeImage
+	{
+		public static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		public static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
-        private static readonly bool SupportsUnicode = IsWindows;
+		private static readonly bool SupportsUnicode = IsWindows;
 
-        #region Constants
+		#region Constants
 
-        /// <summary>
-        /// Number of bytes to shift left within a 4 byte block.
-        /// </summary>
-        public const int FI_RGBA_RED = 2;
+		/// <summary>
+		/// Number of bytes to shift left within a 4 byte block.
+		/// </summary>
+		public const int FI_RGBA_RED = 2;
 
-        /// <summary>
-        /// Number of bytes to shift left within a 4 byte block.
-        /// </summary>
-        public const int FI_RGBA_GREEN = 1;
+		/// <summary>
+		/// Number of bytes to shift left within a 4 byte block.
+		/// </summary>
+		public const int FI_RGBA_GREEN = 1;
 
-        /// <summary>
-        /// Number of bytes to shift left within a 4 byte block.
-        /// </summary>
-        public const int FI_RGBA_BLUE = 0;
+		/// <summary>
+		/// Number of bytes to shift left within a 4 byte block.
+		/// </summary>
+		public const int FI_RGBA_BLUE = 0;
 
-        /// <summary>
-        /// Number of bytes to shift left within a 4 byte block.
-        /// </summary>
-        public const int FI_RGBA_ALPHA = 3;
+		/// <summary>
+		/// Number of bytes to shift left within a 4 byte block.
+		/// </summary>
+		public const int FI_RGBA_ALPHA = 3;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const uint FI_RGBA_RED_MASK = 0x00FF0000;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const uint FI_RGBA_RED_MASK = 0x00FF0000;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const uint FI_RGBA_GREEN_MASK = 0x0000FF00;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const uint FI_RGBA_GREEN_MASK = 0x0000FF00;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const uint FI_RGBA_BLUE_MASK = 0x000000FF;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const uint FI_RGBA_BLUE_MASK = 0x000000FF;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const uint FI_RGBA_ALPHA_MASK = 0xFF000000;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const uint FI_RGBA_ALPHA_MASK = 0xFF000000;
 
-        /// <summary>
-        /// Number of bits to shift left within a 32 bit block.
-        /// </summary>
-        public const int FI_RGBA_RED_SHIFT = 16;
+		/// <summary>
+		/// Number of bits to shift left within a 32 bit block.
+		/// </summary>
+		public const int FI_RGBA_RED_SHIFT = 16;
 
-        /// <summary>
-        /// Number of bits to shift left within a 32 bit block.
-        /// </summary>
-        public const int FI_RGBA_GREEN_SHIFT = 8;
+		/// <summary>
+		/// Number of bits to shift left within a 32 bit block.
+		/// </summary>
+		public const int FI_RGBA_GREEN_SHIFT = 8;
 
-        /// <summary>
-        /// Number of bits to shift left within a 32 bit block.
-        /// </summary>
-        public const int FI_RGBA_BLUE_SHIFT = 0;
+		/// <summary>
+		/// Number of bits to shift left within a 32 bit block.
+		/// </summary>
+		public const int FI_RGBA_BLUE_SHIFT = 0;
 
-        /// <summary>
-        /// Number of bits to shift left within a 32 bit block.
-        /// </summary>
-        public const int FI_RGBA_ALPHA_SHIFT = 24;
+		/// <summary>
+		/// Number of bits to shift left within a 32 bit block.
+		/// </summary>
+		public const int FI_RGBA_ALPHA_SHIFT = 24;
 
-        /// <summary>
-        /// Mask indicating the position of color components of a 32 bit color.
-        /// </summary>
-        public const uint FI_RGBA_RGB_MASK = (FI_RGBA_RED_MASK | FI_RGBA_GREEN_MASK | FI_RGBA_BLUE_MASK);
+		/// <summary>
+		/// Mask indicating the position of color components of a 32 bit color.
+		/// </summary>
+		public const uint FI_RGBA_RGB_MASK = (FI_RGBA_RED_MASK | FI_RGBA_GREEN_MASK | FI_RGBA_BLUE_MASK);
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_555_RED_MASK = 0x7C00;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_555_RED_MASK = 0x7C00;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_555_GREEN_MASK = 0x03E0;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_555_GREEN_MASK = 0x03E0;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_555_BLUE_MASK = 0x001F;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_555_BLUE_MASK = 0x001F;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_555_RED_SHIFT = 10;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_555_RED_SHIFT = 10;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_555_GREEN_SHIFT = 5;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_555_GREEN_SHIFT = 5;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_555_BLUE_SHIFT = 0;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_555_BLUE_SHIFT = 0;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_565_RED_MASK = 0xF800;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_565_RED_MASK = 0xF800;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_565_GREEN_MASK = 0x07E0;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_565_GREEN_MASK = 0x07E0;
 
-        /// <summary>
-        /// Mask indicating the position of the given color.
-        /// </summary>
-        public const int FI16_565_BLUE_MASK = 0x001F;
+		/// <summary>
+		/// Mask indicating the position of the given color.
+		/// </summary>
+		public const int FI16_565_BLUE_MASK = 0x001F;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_565_RED_SHIFT = 11;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_565_RED_SHIFT = 11;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_565_GREEN_SHIFT = 5;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_565_GREEN_SHIFT = 5;
 
-        /// <summary>
-        /// Number of bits to shift left within a 16 bit block.
-        /// </summary>
-        public const int FI16_565_BLUE_SHIFT = 0;
+		/// <summary>
+		/// Number of bits to shift left within a 16 bit block.
+		/// </summary>
+		public const int FI16_565_BLUE_SHIFT = 0;
 
-        #endregion
+		#endregion
 
-        #region General functions
+		#region General functions
 
-        /// <summary>
-        /// Initialises the library.
-        /// </summary>
-        /// <param name="load_local_plugins_only">
-        /// When the <paramref name="load_local_plugins_only"/> is true, FreeImage won't make use of external plugins.
-        /// </param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Initialise")]
-        private static extern void Initialise(bool load_local_plugins_only);
+		/// <summary>
+		/// Initialises the library.
+		/// </summary>
+		/// <param name="load_local_plugins_only">
+		/// When the <paramref name="load_local_plugins_only"/> is true, FreeImage won't make use of external plugins.
+		/// </param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Initialise")]
+		private static extern void Initialise(bool load_local_plugins_only);
 
-        /// <summary>
-        /// Deinitialises the library.
-        /// </summary>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeInitialise")]
-        private static extern void DeInitialise();
+		/// <summary>
+		/// Deinitialises the library.
+		/// </summary>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeInitialise")]
+		private static extern void DeInitialise();
 
-        /// <summary>
-        /// Returns a string containing the current version of the library.
-        /// </summary>
-        /// <returns>The current version of the library.</returns>
-        public static unsafe string GetVersion() { return PtrToStr(GetVersion_()); }
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetVersion")]
-        private static unsafe extern byte* GetVersion_();
+		/// <summary>
+		/// Returns a string containing the current version of the library.
+		/// </summary>
+		/// <returns>The current version of the library.</returns>
+		public static unsafe string GetVersion() { return PtrToStr(GetVersion_()); }
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetVersion")]
+		private static unsafe extern byte* GetVersion_();
 
-        /// <summary>
-        /// Returns a string containing a standard copyright message.
-        /// </summary>
-        /// <returns>A standard copyright message.</returns>
-        public static unsafe string GetCopyrightMessage() { return PtrToStr(GetCopyrightMessage_()); }
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetCopyrightMessage")]
-        private static unsafe extern byte* GetCopyrightMessage_();
+		/// <summary>
+		/// Returns a string containing a standard copyright message.
+		/// </summary>
+		/// <returns>A standard copyright message.</returns>
+		public static unsafe string GetCopyrightMessage() { return PtrToStr(GetCopyrightMessage_()); }
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetCopyrightMessage")]
+		private static unsafe extern byte* GetCopyrightMessage_();
 
-        /// <summary>
-        /// Calls the set error message function in FreeImage.
-        /// </summary>
-        /// <param name="fif">Format of the bitmaps.</param>
-        /// <param name="message">The error message.</param>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_OutputMessageProc")]
-        public static extern void OutputMessageProc(FREE_IMAGE_FORMAT fif, string message);
+		/// <summary>
+		/// Calls the set error message function in FreeImage.
+		/// </summary>
+		/// <param name="fif">Format of the bitmaps.</param>
+		/// <param name="message">The error message.</param>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_OutputMessageProc")]
+		public static extern void OutputMessageProc(FREE_IMAGE_FORMAT fif, string message);
 
-        /// <summary>
-        /// You use the function FreeImage_SetOutputMessage to capture the log string
-        /// so that you can show it to the user of the program.
-        /// The callback is implemented in the <see cref="FreeImageEngine.Message"/> event of this class.
-        /// </summary>
-        /// <remarks>The function is private because FreeImage can only have a single
-        /// callback function. To use the callback use the <see cref="FreeImageEngine.Message"/>
-        /// event of this class.</remarks>
-        /// <param name="omf">Handler to the callback function.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetOutputMessage")]
-        internal static extern void SetOutputMessage(OutputMessageFunction omf);
+		/// <summary>
+		/// You use the function FreeImage_SetOutputMessage to capture the log string
+		/// so that you can show it to the user of the program.
+		/// The callback is implemented in the <see cref="FreeImageEngine.Message"/> event of this class.
+		/// </summary>
+		/// <remarks>The function is private because FreeImage can only have a single
+		/// callback function. To use the callback use the <see cref="FreeImageEngine.Message"/>
+		/// event of this class.</remarks>
+		/// <param name="omf">Handler to the callback function.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetOutputMessage")]
+		internal static extern void SetOutputMessage(OutputMessageFunction omf);
 
-        #endregion
+		#endregion
 
-        #region Bitmap management functions
+		#region Bitmap management functions
 
-        /// <summary>
-        /// Creates a new bitmap in memory.
-        /// </summary>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new Bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <param name="red_mask">Red part of the color layout.
-        /// eg: 0xFF0000</param>
-        /// <param name="green_mask">Green part of the color layout.
-        /// eg: 0x00FF00</param>
-        /// <param name="blue_mask">Blue part of the color layout.
-        /// eg: 0x0000FF</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Allocate")]
-        public static extern FIBITMAP Allocate(int width, int height, int bpp,
-            uint red_mask, uint green_mask, uint blue_mask);
+		/// <summary>
+		/// Creates a new bitmap in memory.
+		/// </summary>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new Bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <param name="red_mask">Red part of the color layout.
+		/// eg: 0xFF0000</param>
+		/// <param name="green_mask">Green part of the color layout.
+		/// eg: 0x00FF00</param>
+		/// <param name="blue_mask">Blue part of the color layout.
+		/// eg: 0x0000FF</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Allocate")]
+		public static extern FIBITMAP Allocate(int width, int height, int bpp,
+			uint red_mask, uint green_mask, uint blue_mask);
 
-        /// <summary>
-        /// Creates a new bitmap in memory.
-        /// </summary>
-        /// <param name="type">Type of the image.</param>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new Bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <param name="red_mask">Red part of the color layout.
-        /// eg: 0xFF0000</param>
-        /// <param name="green_mask">Green part of the color layout.
-        /// eg: 0x00FF00</param>
-        /// <param name="blue_mask">Blue part of the color layout.
-        /// eg: 0x0000FF</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateT")]
-        public static extern FIBITMAP AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp,
-            uint red_mask, uint green_mask, uint blue_mask);
+		/// <summary>
+		/// Creates a new bitmap in memory.
+		/// </summary>
+		/// <param name="type">Type of the image.</param>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new Bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <param name="red_mask">Red part of the color layout.
+		/// eg: 0xFF0000</param>
+		/// <param name="green_mask">Green part of the color layout.
+		/// eg: 0x00FF00</param>
+		/// <param name="blue_mask">Blue part of the color layout.
+		/// eg: 0x0000FF</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateT")]
+		public static extern FIBITMAP AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp,
+			uint red_mask, uint green_mask, uint blue_mask);
 
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateEx")]
-        internal static extern FIBITMAP AllocateEx(int width, int height, int bpp,
-            IntPtr color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
-            uint red_mask, uint green_mask, uint blue_mask);
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateEx")]
+		internal static extern FIBITMAP AllocateEx(int width, int height, int bpp,
+			IntPtr color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
+			uint red_mask, uint green_mask, uint blue_mask);
 
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateExT")]
-        internal static extern FIBITMAP AllocateExT(FREE_IMAGE_TYPE type, int width, int height, int bpp,
-            IntPtr color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
-            uint red_mask, uint green_mask, uint blue_mask);
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AllocateExT")]
+		internal static extern FIBITMAP AllocateExT(FREE_IMAGE_TYPE type, int width, int height, int bpp,
+			IntPtr color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
+			uint red_mask, uint green_mask, uint blue_mask);
 
-        /// <summary>
-        /// Makes an exact reproduction of an existing bitmap, including metadata and attached profile if any.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Clone")]
-        public static extern FIBITMAP Clone(FIBITMAP dib);
+		/// <summary>
+		/// Makes an exact reproduction of an existing bitmap, including metadata and attached profile if any.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Clone")]
+		public static extern FIBITMAP Clone(FIBITMAP dib);
 
-        /// <summary>
-        /// Deletes a previously loaded FIBITMAP from memory.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Unload")]
-        public static extern void Unload(FIBITMAP dib);
+		/// <summary>
+		/// Deletes a previously loaded FIBITMAP from memory.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Unload")]
+		public static extern void Unload(FIBITMAP dib);
 
-        /// <summary>
-        /// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="filename">Name of the file to decode.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <summary>
+		/// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="filename">Name of the file to decode.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
 		public static FIBITMAP Load(FREE_IMAGE_FORMAT fif, string filename, FREE_IMAGE_LOAD_FLAGS flags)
-        {
-            if (SupportsUnicode)
-            {
-                return LoadU(fif, filename, flags);
-            }
-            else
-            {
-                return LoadA(fif, filename, flags);
-            }
-        }
-
-        /// <summary>
-        /// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="filename">Name of the file to decode.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_Load")]
-        private static extern FIBITMAP LoadA(FREE_IMAGE_FORMAT fif, string filename, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="filename">Name of the file to decode.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_LoadU")]
-        private static extern FIBITMAP LoadU(FREE_IMAGE_FORMAT fif, string filename, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Loads a bitmap from an arbitrary source.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="io">A FreeImageIO structure with functionpointers to handle the source.</param>
-        /// <param name="handle">A handle to the source.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadFromHandle")]
-        public static extern FIBITMAP LoadFromHandle(FREE_IMAGE_FORMAT fif, ref FreeImageIO io, fi_handle handle, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Saves a previosly loaded FIBITMAP to a file.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">Name of the file to save to.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool Save(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            if (SupportsUnicode)
-            {
-                return SaveU(fif, dib, filename, flags);
-            }
-            else
-            {
-                return SaveA(fif, dib, filename, flags);
-            }
-        }
-
-        /// <summary>
-        /// Saves a previosly loaded FIBITMAP to a file.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">Name of the file to save to.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_Save")]
-        private static extern bool SaveA(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags);
-
-        /// <summary>
-        /// Saves a previosly loaded FIBITMAP to a file.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">Name of the file to save to.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_SaveU")]
-        private static extern bool SaveU(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags);
-
-        /// <summary>
-        /// Saves a bitmap to an arbitrary source.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="io">A FreeImageIO structure with functionpointers to handle the source.</param>
-        /// <param name="handle">A handle to the source.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SaveToHandle")]
-        public static extern bool SaveToHandle(FREE_IMAGE_FORMAT fif, FIBITMAP dib, ref FreeImageIO io, fi_handle handle,
-            FREE_IMAGE_SAVE_FLAGS flags);
-
-        #endregion
-
-        #region Memory I/O streams
-
-        /// <summary>
-        /// Open a memory stream.
-        /// </summary>
-        /// <param name="data">Pointer to the data in memory.</param>
-        /// <param name="size_in_bytes">Length of the data in byte.</param>
-        /// <returns>Handle to a memory stream.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMemory")]
-        public static extern FIMEMORY OpenMemory(IntPtr data, uint size_in_bytes);
-
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMemory")]
-        internal static extern FIMEMORY OpenMemoryEx(byte[] data, uint size_in_bytes);
-
-        /// <summary>
-        /// Close and free a memory stream.
-        /// </summary>
-        /// <param name="stream">Handle to a memory stream.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloseMemory")]
-        public static extern void CloseMemory(FIMEMORY stream);
-
-        /// <summary>
-        /// Decodes a bitmap from a stream, allocates memory for it and returns it as a FIBITMAP.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="stream">Handle to a memory stream.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadFromMemory")]
-        public static extern FIBITMAP LoadFromMemory(FREE_IMAGE_FORMAT fif, FIMEMORY stream, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Saves a previosly loaded FIBITMAP to a stream.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">Handle to a memory stream.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SaveToMemory")]
-        public static extern bool SaveToMemory(FREE_IMAGE_FORMAT fif, FIBITMAP dib, FIMEMORY stream, FREE_IMAGE_SAVE_FLAGS flags);
-
-        /// <summary>
-        /// Gets the current position of a memory handle.
-        /// </summary>
-        /// <param name="stream">Handle to a memory stream.</param>
-        /// <returns>The current file position if successful, -1 otherwise.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TellMemory")]
-        public static extern int TellMemory(FIMEMORY stream);
-
-        /// <summary>
-        /// Moves the memory handle to a specified location.
-        /// </summary>
-        /// <param name="stream">Handle to a memory stream.</param>
-        /// <param name="offset">Number of bytes from origin.</param>
-        /// <param name="origin">Initial position.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SeekMemory")]
-        public static extern bool SeekMemory(FIMEMORY stream, int offset, System.IO.SeekOrigin origin);
-
-        /// <summary>
-        /// Provides a direct buffer access to a memory stream.
-        /// </summary>
-        /// <param name="stream">The target memory stream.</param>
-        /// <param name="data">Pointer to the data in memory.</param>
-        /// <param name="size_in_bytes">Size of the data in bytes.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AcquireMemory")]
-        public static extern bool AcquireMemory(FIMEMORY stream, ref IntPtr data, ref uint size_in_bytes);
-
-        /// <summary>
-        /// Reads data from a memory stream.
-        /// </summary>
-        /// <param name="buffer">The buffer to store the data in.</param>
-        /// <param name="size">Size in bytes of the items.</param>
-        /// <param name="count">Number of items to read.</param>
-        /// <param name="stream">The stream to read from.
-        /// The memory pointer associated with stream is increased by the number of bytes actually read.</param>
-        /// <returns>The number of full items actually read.
-        /// May be less than count on error or stream-end.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ReadMemory")]
-        public static extern uint ReadMemory(byte[] buffer, uint size, uint count, FIMEMORY stream);
-
-        /// <summary>
-        /// Writes data to a memory stream.
-        /// </summary>
-        /// <param name="buffer">The buffer to read the data from.</param>
-        /// <param name="size">Size in bytes of the items.</param>
-        /// <param name="count">Number of items to write.</param>
-        /// <param name="stream">The stream to write to.
-        /// The memory pointer associated with stream is increased by the number of bytes actually written.</param>
-        /// <returns>The number of full items actually written.
-        /// May be less than count on error or stream-end.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_WriteMemory")]
-        public static extern uint WriteMemory(byte[] buffer, uint size, uint count, FIMEMORY stream);
-
-        /// <summary>
-        /// Open a multi-page bitmap from a memory stream.
-        /// </summary>
-        /// <param name="fif">Type of the bitmap.</param>
-        /// <param name="stream">The stream to decode.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadMultiBitmapFromMemory")]
-        public static extern FIMULTIBITMAP LoadMultiBitmapFromMemory(FREE_IMAGE_FORMAT fif, FIMEMORY stream, FREE_IMAGE_LOAD_FLAGS flags);
-
-        #endregion
-
-        #region Plugin functions
-
-        /// <summary>
-        /// Registers a new plugin to be used in FreeImage.
-        /// </summary>
-        /// <param name="proc_address">Pointer to the function that initialises the plugin.</param>
-        /// <param name="format">A string describing the format of the plugin.</param>
-        /// <param name="description">A string describing the plugin.</param>
-        /// <param name="extension">A string witha comma sperated list of extensions. f.e: "pl,pl2,pl4"</param>
-        /// <param name="regexpr">A regular expression used to identify the bitmap.</param>
-        /// <returns>The format idientifier assigned by FreeImage.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_RegisterLocalPlugin")]
-        public static extern FREE_IMAGE_FORMAT RegisterLocalPlugin(InitProc proc_address,
-            string format, string description, string extension, string regexpr);
-
-        /// <summary>
-        /// Registers a new plugin to be used in FreeImage. The plugin is residing in a DLL.
-        /// The Init function must be called “Init” and must use the stdcall calling convention.
-        /// </summary>
-        /// <param name="path">Complete path to the dll file hosting the plugin.</param>
-        /// <param name="format">A string describing the format of the plugin.</param>
-        /// <param name="description">A string describing the plugin.</param>
-        /// <param name="extension">A string witha comma sperated list of extensions. f.e: "pl,pl2,pl4"</param>
-        /// <param name="regexpr">A regular expression used to identify the bitmap.</param>
-        /// <returns>The format idientifier assigned by FreeImage.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_RegisterExternalPlugin")]
-        public static extern FREE_IMAGE_FORMAT RegisterExternalPlugin(string path,
-            string format, string description, string extension, string regexpr);
-
-        /// <summary>
-        /// Retrieves the number of FREE_IMAGE_FORMAT identifiers being currently registered.
-        /// </summary>
-        /// <returns>The number of registered formats.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFCount")]
-        public static extern int GetFIFCount();
-
-        /// <summary>
-        /// Enables or disables a plugin.
-        /// </summary>
-        /// <param name="fif">The plugin to enable or disable.</param>
-        /// <param name="enable">True: enable the plugin. false: disable the plugin.</param>
-        /// <returns>The previous state of the plugin.
-        /// 1 - enabled. 0 - disables. -1 plugin does not exist.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPluginEnabled")]
-        public static extern int SetPluginEnabled(FREE_IMAGE_FORMAT fif, bool enable);
-
-        /// <summary>
-        /// Retrieves the state of a plugin.
-        /// </summary>
-        /// <param name="fif">The plugin to check.</param>
-        /// <returns>1 - enabled. 0 - disables. -1 plugin does not exist.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsPluginEnabled")]
-        public static extern int IsPluginEnabled(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Returns a <see cref="FREE_IMAGE_FORMAT"/> identifier from the format string that was used to register the FIF.
-        /// </summary>
-        /// <param name="format">The string that was used to register the plugin.</param>
-        /// <returns>A <see cref="FREE_IMAGE_FORMAT"/> identifier from the format.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromFormat")]
-        public static extern FREE_IMAGE_FORMAT GetFIFFromFormat(string format);
-
-        /// <summary>
-        /// Returns a <see cref="FREE_IMAGE_FORMAT"/> identifier from a MIME content type string
-        /// (MIME stands for Multipurpose Internet Mail Extension).
-        /// </summary>
-        /// <param name="mime">A MIME content type.</param>
-        /// <returns>A <see cref="FREE_IMAGE_FORMAT"/> identifier from the MIME.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromMime")]
-        public static extern FREE_IMAGE_FORMAT GetFIFFromMime(string mime);
-
-        /// <summary>
-        /// Returns the string that was used to register a plugin from the system assigned <see cref="FREE_IMAGE_FORMAT"/>.
-        /// </summary>
-        /// <param name="fif">The assigned <see cref="FREE_IMAGE_FORMAT"/>.</param>
-        /// <returns>The string that was used to register the plugin.</returns>
-        public static unsafe string GetFormatFromFIF(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFormatFromFIF_(fif)); }
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFormatFromFIF")]
-        private static unsafe extern byte* GetFormatFromFIF_(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Returns a comma-delimited file extension list describing the bitmap formats the given plugin can read and/or write.
-        /// </summary>
-        /// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
-        /// <returns>A comma-delimited file extension list.</returns>
-        public static unsafe string GetFIFExtensionList(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFExtensionList_(fif)); }
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFExtensionList")]
-        private static unsafe extern byte* GetFIFExtensionList_(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Returns a descriptive string that describes the bitmap formats the given plugin can read and/or write.
-        /// </summary>
-        /// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
-        /// <returns>A descriptive string that describes the bitmap formats.</returns>
-        public static unsafe string GetFIFDescription(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFDescription_(fif)); }
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFDescription")]
-        private static unsafe extern byte* GetFIFDescription_(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Returns a regular expression string that can be used by a regular expression engine to identify the bitmap.
-        /// FreeImageQt makes use of this function.
-        /// </summary>
-        /// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
-        /// <returns>A regular expression string.</returns>
-        public static unsafe string GetFIFRegExpr(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFRegExpr_(fif)); }
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFRegExpr")]
-        private static unsafe extern byte* GetFIFRegExpr_(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Given a <see cref="FREE_IMAGE_FORMAT"/> identifier, returns a MIME content type string (MIME stands for Multipurpose Internet Mail Extension).
-        /// </summary>
-        /// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
-        /// <returns>A MIME content type string.</returns>
-        public static unsafe string GetFIFMimeType(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFMimeType_(fif)); }
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFMimeType")]
-        private static unsafe extern byte* GetFIFMimeType_(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// This function takes a filename or a file-extension and returns the plugin that can
-        /// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
-        /// </summary>
-        /// <param name="filename">The filename or -extension.</param>
-        /// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
-        public static FREE_IMAGE_FORMAT GetFIFFromFilename(string filename)
-        {
-            if (SupportsUnicode)
-            {
-                return GetFIFFromFilenameU(filename);
-            }
-            else
-            {
-                return GetFIFFromFilenameA(filename);
-            }
-        }
-
-        /// <summary>
-        /// This function takes a filename or a file-extension and returns the plugin that can
-        /// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
-        /// </summary>
-        /// <param name="filename">The filename or -extension.</param>
-        /// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromFilename")]
-        private static extern FREE_IMAGE_FORMAT GetFIFFromFilenameA(string filename);
-
-        /// <summary>
-        /// This function takes a filename or a file-extension and returns the plugin that can
-        /// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="filename">The filename or -extension.</param>
-        /// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFIFFromFilenameU")]
-        private static extern FREE_IMAGE_FORMAT GetFIFFromFilenameU(string filename);
-
-        /// <summary>
-        /// Checks if a plugin can load bitmaps.
-        /// </summary>
-        /// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
-        /// <returns>True if the plugin can load bitmaps, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsReading")]
-        public static extern bool FIFSupportsReading(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Checks if a plugin can save bitmaps.
-        /// </summary>
-        /// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
-        /// <returns>True if the plugin can save bitmaps, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsWriting")]
-        public static extern bool FIFSupportsWriting(FREE_IMAGE_FORMAT fif);
-
-        /// <summary>
-        /// Checks if a plugin can save bitmaps in the desired bit depth.
-        /// </summary>
-        /// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
-        /// <param name="bpp">The desired bit depth.</param>
-        /// <returns>True if the plugin can save bitmaps in the desired bit depth, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsExportBPP")]
-        public static extern bool FIFSupportsExportBPP(FREE_IMAGE_FORMAT fif, int bpp);
-
-        /// <summary>
-        /// Checks if a plugin can save a bitmap in the desired data type.
-        /// </summary>
-        /// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
-        /// <param name="type">The desired image type.</param>
-        /// <returns>True if the plugin can save bitmaps as the desired type, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsExportType")]
-        public static extern bool FIFSupportsExportType(FREE_IMAGE_FORMAT fif, FREE_IMAGE_TYPE type);
-
-        /// <summary>
-        /// Checks if a plugin can load or save an ICC profile.
-        /// </summary>
-        /// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
-        /// <returns>True if the plugin can load or save an ICC profile, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsICCProfiles")]
-        public static extern bool FIFSupportsICCProfiles(FREE_IMAGE_FORMAT fif);
-
-        #endregion
-
-        #region Multipage functions
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="fif">Format of the image.</param>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="create_new">When true a new bitmap is created.</param>
-        /// <param name="read_only">When true the bitmap will be loaded read only.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMultiBitmap")]
-        public static extern FIMULTIBITMAP OpenMultiBitmap(FREE_IMAGE_FORMAT fif, string filename, bool create_new,
-            bool read_only, bool keep_cache_in_memory, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Loads a FreeImage multi-pages bitmap from the specified handle
-        /// using the specified functions.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="fif">Format of the image.</param>
-        /// <param name="io">IO functions used to read from the specified handle.</param>
-        /// <param name="handle">The handle to load the bitmap from.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMultiBitmapFromHandle")]
-        public static extern FIMULTIBITMAP OpenMultiBitmapFromHandle(FREE_IMAGE_FORMAT fif, ref FreeImageIO io,
-            fi_handle handle, FREE_IMAGE_LOAD_FLAGS flags);
-
-        /// <summary>
-        /// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only, applies any changes made to it.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloseMultiBitmap")]
-        private static extern bool CloseMultiBitmap_(FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags);
-
-        /// <summary>
-        /// Returns the number of pages currently available in the multi-paged bitmap.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <returns>Number of pages.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPageCount")]
-        public static extern int GetPageCount(FIMULTIBITMAP bitmap);
-
-        /// <summary>
-        /// Appends a new page to the end of the bitmap.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="data">Handle to a FreeImage bitmap.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AppendPage")]
-        public static extern void AppendPage(FIMULTIBITMAP bitmap, FIBITMAP data);
-
-        /// <summary>
-        /// Inserts a new page before the given position in the bitmap.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="page">Page has to be a number smaller than the current number of pages available in the bitmap.</param>
-        /// <param name="data">Handle to a FreeImage bitmap.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_InsertPage")]
-        public static extern void InsertPage(FIMULTIBITMAP bitmap, int page, FIBITMAP data);
-
-        /// <summary>
-        /// Deletes the page on the given position.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="page">Number of the page to delete.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeletePage")]
-        public static extern void DeletePage(FIMULTIBITMAP bitmap, int page);
-
-        /// <summary>
-        /// Locks a page in memory for editing.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="page">Number of the page to lock.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LockPage")]
-        public static extern FIBITMAP LockPage(FIMULTIBITMAP bitmap, int page);
-
-        /// <summary>
-        /// Unlocks a previously locked page and gives it back to the multi-page engine.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="data">Handle to a FreeImage bitmap.</param>
-        /// <param name="changed">If true, the page is applied to the multi-page bitmap.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_UnlockPage")]
-        public static extern void UnlockPage(FIMULTIBITMAP bitmap, FIBITMAP data, bool changed);
-
-        /// <summary>
-        /// Moves the source page to the position of the target page.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="target">New position of the page.</param>
-        /// <param name="source">Old position of the page.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MovePage")]
-        public static extern bool MovePage(FIMULTIBITMAP bitmap, int target, int source);
-
-        /// <summary>
-        /// Returns an array of page-numbers that are currently locked in memory.
-        /// When the pages parameter is null, the size of the array is returned in the count variable.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// int[] lockedPages = null;
-        /// int count = 0;
-        /// GetLockedPageNumbers(dib, lockedPages, ref count);
-        /// lockedPages = new int[count];
-        /// GetLockedPageNumbers(dib, lockedPages, ref count);
-        /// </code>
-        /// </example>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="pages">The list of locked pages in the multi-pages bitmap.
-        /// If set to null, count will contain the number of pages.</param>
-        /// <param name="count">If <paramref name="pages"/> is set to null count will contain the number of locked pages.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetLockedPageNumbers")]
-        public static extern bool GetLockedPageNumbers(FIMULTIBITMAP bitmap, int[] pages, ref int count);
-
-        #endregion
-
-        #region Filetype functions
-
-        /// <summary>
-        /// Orders FreeImage to analyze the bitmap signature.
-        /// </summary>
-        /// <param name="filename">Name of the file to analyze.</param>
-        /// <param name="size">Reserved parameter - use 0.</param>
-        /// <returns>Type of the bitmap.</returns>
-        public static FREE_IMAGE_FORMAT GetFileType(string filename, int size)
-        {
-            if (SupportsUnicode)
-            {
-                return GetFileTypeU(filename, size);
-            }
-            else
-            {
-                return GetFileTypeA(filename, size);
-            }
-        }
-
-        /// <summary>
-        /// Orders FreeImage to analyze the bitmap signature.
-        /// </summary>
-        /// <param name="filename">Name of the file to analyze.</param>
-        /// <param name="size">Reserved parameter - use 0.</param>
-        /// <returns>Type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFileType")]
-        private static extern FREE_IMAGE_FORMAT GetFileTypeA(string filename, int size);
-
-        /// <summary>
-        /// Orders FreeImage to analyze the bitmap signature.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="filename">Name of the file to analyze.</param>
-        /// <param name="size">Reserved parameter - use 0.</param>
-        /// <returns>Type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFileTypeU")]
-        private static extern FREE_IMAGE_FORMAT GetFileTypeU(string filename, int size);
-
-        /// <summary>
-        /// Uses the <see cref="FreeImageIO"/> structure as described in the topic bitmap management functions
-        /// to identify a bitmap type.
-        /// </summary>
-        /// <param name="io">A <see cref="FreeImageIO"/> structure with functionpointers to handle the source.</param>
-        /// <param name="handle">A handle to the source.</param>
-        /// <param name="size">Size in bytes of the source.</param>
-        /// <returns>Type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFileTypeFromHandle")]
-        public static extern FREE_IMAGE_FORMAT GetFileTypeFromHandle(ref FreeImageIO io, fi_handle handle, int size);
-
-        /// <summary>
-        /// Uses a memory handle to identify a bitmap type.
-        /// </summary>
-        /// <param name="stream">Pointer to the stream.</param>
-        /// <param name="size">Size in bytes of the source.</param>
-        /// <returns>Type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFileTypeFromMemory")]
-        public static extern FREE_IMAGE_FORMAT GetFileTypeFromMemory(FIMEMORY stream, int size);
-
-        #endregion
-
-        #region Helper functions
-
-        /// <summary>
-        /// Returns whether the platform is using Little Endian.
-        /// </summary>
-        /// <returns>Returns true if the platform is using Litte Endian, else false.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsLittleEndian")]
-        public static extern bool IsLittleEndian();
-
-        /// <summary>
-        /// Converts a X11 color name into a corresponding RGB value.
-        /// </summary>
-        /// <param name="szColor">Name of the color to convert.</param>
-        /// <param name="nRed">Red component.</param>
-        /// <param name="nGreen">Green component.</param>
-        /// <param name="nBlue">Blue component.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_LookupX11Color")]
-        public static extern bool LookupX11Color(string szColor, out byte nRed, out byte nGreen, out byte nBlue);
-
-        /// <summary>
-        /// Converts a SVG color name into a corresponding RGB value.
-        /// </summary>
-        /// <param name="szColor">Name of the color to convert.</param>
-        /// <param name="nRed">Red component.</param>
-        /// <param name="nGreen">Green component.</param>
-        /// <param name="nBlue">Blue component.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_LookupSVGColor")]
-        public static extern bool LookupSVGColor(string szColor, out byte nRed, out byte nGreen, out byte nBlue);
-
-        #endregion
-
-        #region Pixel access functions
-
-        /// <summary>
-        /// Returns a pointer to the data-bits of the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Pointer to the data-bits.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBits")]
-        public static extern IntPtr GetBits(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a pointer to the start of the given scanline in the bitmap's data-bits.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="scanline">Number of the scanline.</param>
-        /// <returns>Pointer to the scanline.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetScanLine")]
-        public static extern IntPtr GetScanLine(FIBITMAP dib, int scanline);
-
-        /// <summary>
-        /// Get the pixel index of a palettized image at position (x, y), including range check (slow access).
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="x">Pixel position in horizontal direction.</param>
-        /// <param name="y">Pixel position in vertical direction.</param>
-        /// <param name="value">The pixel index.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPixelIndex")]
-        public static extern bool GetPixelIndex(FIBITMAP dib, uint x, uint y, out byte value);
-
-        /// <summary>
-        /// Get the pixel color of a 16-, 24- or 32-bit image at position (x, y), including range check (slow access).
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="x">Pixel position in horizontal direction.</param>
-        /// <param name="y">Pixel position in vertical direction.</param>
-        /// <param name="value">The pixel color.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPixelColor")]
-        public static extern bool GetPixelColor(FIBITMAP dib, uint x, uint y, out RGBQUAD value);
-
-        /// <summary>
-        /// Set the pixel index of a palettized image at position (x, y), including range check (slow access).
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="x">Pixel position in horizontal direction.</param>
-        /// <param name="y">Pixel position in vertical direction.</param>
-        /// <param name="value">The new pixel index.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPixelIndex")]
-        public static extern bool SetPixelIndex(FIBITMAP dib, uint x, uint y, ref byte value);
-
-        /// <summary>
-        /// Set the pixel color of a 16-, 24- or 32-bit image at position (x, y), including range check (slow access).
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="x">Pixel position in horizontal direction.</param>
-        /// <param name="y">Pixel position in vertical direction.</param>
-        /// <param name="value">The new pixel color.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPixelColor")]
-        public static extern bool SetPixelColor(FIBITMAP dib, uint x, uint y, ref RGBQUAD value);
-
-        #endregion
-
-        #region Bitmap information functions
-
-        /// <summary>
-        /// Retrieves the type of the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetImageType")]
-        public static extern FREE_IMAGE_TYPE GetImageType(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the number of colors used in a bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Palette-size for palletised bitmaps, and 0 for high-colour bitmaps.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetColorsUsed")]
-        public static extern uint GetColorsUsed(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the size of one pixel in the bitmap in bits.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Size of one pixel in the bitmap in bits.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBPP")]
-        public static extern uint GetBPP(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the width of the bitmap in pixel units.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>With of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetWidth")]
-        public static extern uint GetWidth(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the height of the bitmap in pixel units.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Height of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetHeight")]
-        public static extern uint GetHeight(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the width of the bitmap in bytes.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>With of the bitmap in bytes.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetLine")]
-        public static extern uint GetLine(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the width of the bitmap in bytes, rounded to the next 32-bit boundary,
-        /// also known as pitch or stride or scan width.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>With of the bitmap in bytes.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPitch")]
-        public static extern uint GetPitch(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the size of the DIB-element of a FIBITMAP in memory.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Size of the DIB-element</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDIBSize")]
-        public static extern uint GetDIBSize(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a pointer to the bitmap's palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Pointer to the bitmap's palette.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPalette")]
-        public static extern IntPtr GetPalette(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the horizontal resolution, in pixels-per-meter, of the target device for the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The horizontal resolution, in pixels-per-meter.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDotsPerMeterX")]
-        public static extern uint GetDotsPerMeterX(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the vertical resolution, in pixels-per-meter, of the target device for the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The vertical resolution, in pixels-per-meter.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDotsPerMeterY")]
-        public static extern uint GetDotsPerMeterY(FIBITMAP dib);
-
-        /// <summary>
-        /// Set the horizontal resolution, in pixels-per-meter, of the target device for the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="res">The new horizontal resolution.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetDotsPerMeterX")]
-        public static extern void SetDotsPerMeterX(FIBITMAP dib, uint res);
-
-        /// <summary>
-        /// Set the vertical resolution, in pixels-per-meter, of the target device for the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="res">The new vertical resolution.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetDotsPerMeterY")]
-        public static extern void SetDotsPerMeterY(FIBITMAP dib, uint res);
-
-        /// <summary>
-        /// Returns a pointer to the <see cref="BITMAPINFOHEADER"/> of the DIB-element in a FIBITMAP.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Poiter to the header of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetInfoHeader")]
-        public static extern IntPtr GetInfoHeader(FIBITMAP dib);
-
-        /// <summary>
-        /// Alias for FreeImage_GetInfoHeader that returns a pointer to a <see cref="BITMAPINFO"/>
-        /// rather than to a <see cref="BITMAPINFOHEADER"/>.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Pointer to the <see cref="BITMAPINFO"/> structure for the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetInfo")]
-        public static extern IntPtr GetInfo(FIBITMAP dib);
-
-        /// <summary>
-        /// Investigates the color type of the bitmap by reading the bitmap's pixel bits and analysing them.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The color type of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetColorType")]
-        public static extern FREE_IMAGE_COLOR_TYPE GetColorType(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a bit pattern describing the red color component of a pixel in a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The bit pattern for RED.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetRedMask")]
-        public static extern uint GetRedMask(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a bit pattern describing the green color component of a pixel in a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The bit pattern for green.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetGreenMask")]
-        public static extern uint GetGreenMask(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a bit pattern describing the blue color component of a pixel in a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The bit pattern for blue.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBlueMask")]
-        public static extern uint GetBlueMask(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the number of transparent colors in a palletised bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The number of transparent colors in a palletised bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparencyCount")]
-        public static extern uint GetTransparencyCount(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns a pointer to the bitmap's transparency table.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Pointer to the bitmap's transparency table.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparencyTable")]
-        public static extern IntPtr GetTransparencyTable(FIBITMAP dib);
-
-        /// <summary>
-        /// Tells FreeImage if it should make use of the transparency table
-        /// or the alpha channel that may accompany a bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="enabled">True to enable the transparency, false to disable.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparent")]
-        public static extern void SetTransparent(FIBITMAP dib, bool enabled);
-
-        /// <summary>
-        /// Set the bitmap's transparency table. Only affects palletised bitmaps.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="table">Pointer to the bitmap's new transparency table.</param>
-        /// <param name="count">The number of transparent colors in the new transparency table.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparencyTable")]
-        internal static extern void SetTransparencyTable(FIBITMAP dib, byte[] table, int count);
-
-        /// <summary>
-        /// Returns whether the transparency table is enabled.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true when the transparency table is enabled (1-, 4- or 8-bit images)
-        /// or when the input dib contains alpha values (32-bit images). Returns false otherwise.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsTransparent")]
-        public static extern bool IsTransparent(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns whether the bitmap has a file background color.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true when the image has a file background color, false otherwise.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_HasBackgroundColor")]
-        public static extern bool HasBackgroundColor(FIBITMAP dib);
-
-        /// <summary>
-        /// Returns the file background color of an image.
-        /// For 8-bit images, the color index in the palette is returned in the
-        /// rgbReserved member of the bkcolor parameter.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="bkcolor">The background color.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBackgroundColor")]
-        public static extern bool GetBackgroundColor(FIBITMAP dib, out RGBQUAD bkcolor);
-
-        /// <summary>
-        /// Set the file background color of an image.
-        /// When saving an image to PNG, this background color is transparently saved to the PNG file.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="bkcolor">The new background color.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetBackgroundColor")]
-        public static unsafe extern bool SetBackgroundColor(FIBITMAP dib, ref RGBQUAD bkcolor);
-
-        /// <summary>
-        /// Set the file background color of an image.
-        /// When saving an image to PNG, this background color is transparently saved to the PNG file.
-        /// When the bkcolor parameter is null, the background color is removed from the image.
-        /// <para>
-        /// This overloaded version of the function with an array parameter is provided to allow
-        /// passing <c>null</c> in the <paramref name="bkcolor"/> parameter. This is similar to the
-        /// original C/C++ function. Passing <c>null</c> as <paramref name="bkcolor"/> parameter will
-        /// unset the dib's previously set background color.
-        /// </para> 
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="bkcolor">The new background color.
-        /// The first entry in the array is used.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <example>
-        /// <code>
-        /// // create a RGBQUAD color
-        /// RGBQUAD color = new RGBQUAD(Color.Green);
-        /// 
-        /// // set the dib's background color (using the other version of the function)
-        /// FreeImage.SetBackgroundColor(dib, ref color);
-        /// 
-        /// // remove it again (this only works due to the array parameter RGBQUAD[])
-        /// FreeImage.SetBackgroundColor(dib, null);
-        /// </code>
-        /// </example>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetBackgroundColor")]
-        public static unsafe extern bool SetBackgroundColor(FIBITMAP dib, RGBQUAD[] bkcolor);
-
-        /// <summary>
-        /// Sets the index of the palette entry to be used as transparent color
-        /// for the image specified. Does nothing on high color images.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="index">The index of the palette entry to be set as transparent color.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparentIndex")]
-        public static extern void SetTransparentIndex(FIBITMAP dib, int index);
-
-        /// <summary>
-        /// Returns the palette entry used as transparent color for the image specified.
-        /// Works for palletised images only and returns -1 for high color
-        /// images or if the image has no color set to be transparent.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>the index of the palette entry used as transparent color for
-        /// the image specified or -1 if there is no transparent color found
-        /// (e.g. the image is a high color image).</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparentIndex")]
-        public static extern int GetTransparentIndex(FIBITMAP dib);
-
-        #endregion
-
-        #region ICC profile functions
-
-        /// <summary>
-        /// Retrieves the <see cref="FIICCPROFILE"/> data of the bitmap.
-        /// This function can also be called safely, when the original format does not support profiles.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The <see cref="FIICCPROFILE"/> data of the bitmap.</returns>
-        public static FIICCPROFILE GetICCProfileEx(FIBITMAP dib) { unsafe { return *(FIICCPROFILE*)FreeImage.GetICCProfile(dib); } }
-
-        /// <summary>
-        /// Retrieves a pointer to the <see cref="FIICCPROFILE"/> data of the bitmap.
-        /// This function can also be called safely, when the original format does not support profiles.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Pointer to the <see cref="FIICCPROFILE"/> data of the bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetICCProfile")]
-        public static extern IntPtr GetICCProfile(FIBITMAP dib);
-
-        /// <summary>
-        /// Creates a new <see cref="FIICCPROFILE"/> block from ICC profile data previously read from a file
-        /// or built by a color management system. The profile data is attached to the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="data">Pointer to the new <see cref="FIICCPROFILE"/> data.</param>
-        /// <param name="size">Size of the <see cref="FIICCPROFILE"/> data.</param>
-        /// <returns>Pointer to the created <see cref="FIICCPROFILE"/> structure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CreateICCProfile")]
-        public static extern IntPtr CreateICCProfile(FIBITMAP dib, byte[] data, int size);
-
-        /// <summary>
-        /// This function destroys an <see cref="FIICCPROFILE"/> previously created by <see cref="CreateICCProfile(FIBITMAP,byte[],int)"/>.
-        /// After this call the bitmap will contain no profile information.
-        /// This function should be called to ensure that a stored bitmap will not contain any profile information.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DestroyICCProfile")]
-        public static extern void DestroyICCProfile(FIBITMAP dib);
-
-        #endregion
-
-        #region Conversion functions
-
-        /// <summary>
-        /// Converts a bitmap to 4 bits.
-        /// If the bitmap was a high-color bitmap (16, 24 or 32-bit) or if it was a
-        /// monochrome or greyscale bitmap (1 or 8-bit), the end result will be a
-        /// greyscale bitmap, otherwise (1-bit palletised bitmaps) it will be a palletised bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo4Bits")]
-        public static extern FIBITMAP ConvertTo4Bits(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to 8 bits. If the bitmap was a high-color bitmap (16, 24 or 32-bit)
-        /// or if it was a monochrome or greyscale bitmap (1 or 4-bit), the end result will be a
-        /// greyscale bitmap, otherwise (1 or 4-bit palletised bitmaps) it will be a palletised bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo8Bits")]
-        public static extern FIBITMAP ConvertTo8Bits(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to a 8-bit greyscale image with a linear ramp.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToGreyscale")]
-        public static extern FIBITMAP ConvertToGreyscale(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to 16 bits, where each pixel has a color pattern of
-        /// 5 bits red, 5 bits green and 5 bits blue. One bit in each pixel is unused.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo16Bits555")]
-        public static extern FIBITMAP ConvertTo16Bits555(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to 16 bits, where each pixel has a color pattern of
-        /// 5 bits red, 6 bits green and 5 bits blue.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo16Bits565")]
-        public static extern FIBITMAP ConvertTo16Bits565(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to 24 bits. A clone of the input bitmap is returned for 24-bit bitmaps.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo24Bits")]
-        public static extern FIBITMAP ConvertTo24Bits(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a bitmap to 32 bits. A clone of the input bitmap is returned for 32-bit bitmaps.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo32Bits")]
-        public static extern FIBITMAP ConvertTo32Bits(FIBITMAP dib);
-
-        /// <summary>
-        /// Quantizes a high-color 24-bit bitmap to an 8-bit palette color bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ColorQuantize")]
-        public static extern FIBITMAP ColorQuantize(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize);
-
-        /// <summary>
-        /// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/> method that
-        /// provides additional options used to quantize a 24-bit image to any
-        /// number of colors (up to 256), as well as quantize a 24-bit image using a
-        /// partial or full provided palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
-        /// <param name="PaletteSize">Size of the desired output palette.</param>
-        /// <param name="ReserveSize">Size of the provided palette of ReservePalette.</param>
-        /// <param name="ReservePalette">The provided palette.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ColorQuantizeEx")]
-        public static extern FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, int ReserveSize, RGBQUAD[] ReservePalette);
-
-        /// <summary>
-        /// Converts a bitmap to 1-bit monochrome bitmap using a threshold T between [0..255].
-        /// The function first converts the bitmap to a 8-bit greyscale bitmap.
-        /// Then, any brightness level that is less than T is set to zero, otherwise to 1.
-        /// For 1-bit input bitmaps, the function clones the input bitmap and builds a monochrome palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="t">The threshold.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Threshold")]
-        public static extern FIBITMAP Threshold(FIBITMAP dib, byte t);
-
-        /// <summary>
-        /// Converts a bitmap to 1-bit monochrome bitmap using a dithering algorithm.
-        /// For 1-bit input bitmaps, the function clones the input bitmap and builds a monochrome palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="algorithm">The dithering algorithm to use.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Dither")]
-        public static extern FIBITMAP Dither(FIBITMAP dib, FREE_IMAGE_DITHER algorithm);
-
-        /// <summary>
-        /// Converts a raw bitmap to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="bits">Pointer to the memory block containing the raw bitmap.</param>
-        /// <param name="width">The width in pixels of the raw bitmap.</param>
-        /// <param name="height">The height in pixels of the raw bitmap.</param>
-        /// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
-        /// including padding bytes.</param>
-        /// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertFromRawBits")]
-        public static extern FIBITMAP ConvertFromRawBits(IntPtr bits, int width, int height, int pitch,
-            uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
-
-        /// <summary>
-        /// Converts a raw bitmap to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="bits">Array of bytes containing the raw bitmap.</param>
-        /// <param name="width">The width in pixels of the raw bitmap.</param>
-        /// <param name="height">The height in pixels of the raw bitmap.</param>
-        /// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
-        /// including padding bytes.</param>
-        /// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertFromRawBits")]
-        public static extern FIBITMAP ConvertFromRawBits(byte[] bits, int width, int height, int pitch,
-            uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
-
-        /// <summary>
-        /// Converts a FreeImage bitmap to a raw bitmap, that is a raw piece of memory.
-        /// </summary>
-        /// <param name="bits">Pointer to the memory block receiving the raw bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="pitch">The desired total width in bytes of a scanline in the raw bitmap,
-        /// including any padding bytes.</param>
-        /// <param name="bpp">The desired bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The desired bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The desired bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The desired bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap will be stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRawBits")]
-        public static extern void ConvertToRawBits(IntPtr bits, FIBITMAP dib, int pitch, uint bpp,
-            uint red_mask, uint green_mask, uint blue_mask, bool topdown);
-
-        /// <summary>
-        /// Converts a FreeImage bitmap to a raw bitmap, that is a raw piece of memory.
-        /// </summary>
-        /// <param name="bits">Array of bytes receiving the raw bitmap.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="pitch">The desired total width in bytes of a scanline in the raw bitmap,
-        /// including any padding bytes.</param>
-        /// <param name="bpp">The desired bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The desired bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The desired bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The desired bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap will be stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRawBits")]
-        public static extern void ConvertToRawBits(byte[] bits, FIBITMAP dib, int pitch, uint bpp,
-            uint red_mask, uint green_mask, uint blue_mask, bool topdown);
-
-        /// <summary>
-        /// Converts a 24- or 32-bit RGB(A) standard image or a 48-bit RGB image to a FIT_RGBF type image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRGBF")]
-        public static extern FIBITMAP ConvertToRGBF(FIBITMAP dib);
-
-        /// <summary>
-        /// Converts a non standard image whose color type is FIC_MINISBLACK
-        /// to a standard 8-bit greyscale image.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="scale_linear">When true the conversion is done by scaling linearly
-        /// each pixel value from [min, max] to an integer value between [0..255],
-        /// where min and max are the minimum and maximum pixel values in the image.
-        /// When false the conversion is done by rounding each pixel value to an integer between [0..255].
-        ///
-        /// Rounding is done using the following formula:
-        ///
-        /// dst_pixel = (BYTE) MIN(255, MAX(0, q)) where int q = int(src_pixel + 0.5);</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToStandardType")]
-        public static extern FIBITMAP ConvertToStandardType(FIBITMAP src, bool scale_linear);
-
-        /// <summary>
-        /// Converts an image of any type to type dst_type.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="dst_type">Destination type.</param>
-        /// <param name="scale_linear">True to scale linear, else false.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToType")]
-        public static extern FIBITMAP ConvertToType(FIBITMAP src, FREE_IMAGE_TYPE dst_type, bool scale_linear);
-
-        #endregion
-
-        #region Tone mapping operators
-
-        /// <summary>
-        /// Converts a High Dynamic Range image (48-bit RGB or 96-bit RGBF) to a 24-bit RGB image, suitable for display.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="tmo">The tone mapping operator to be used.</param>
-        /// <param name="first_param">Parmeter depending on the used algorithm</param>
-        /// <param name="second_param">Parmeter depending on the used algorithm</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ToneMapping")]
-        public static extern FIBITMAP ToneMapping(FIBITMAP dib, FREE_IMAGE_TMO tmo, double first_param, double second_param);
-
-        /// <summary>
-        /// Converts a High Dynamic Range image to a 24-bit RGB image using a global
-        /// operator based on logarithmic compression of luminance values, imitating the human response to light.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="gamma">A gamma correction that is applied after the tone mapping.
-        /// A value of 1 means no correction.</param>
-        /// <param name="exposure">Scale factor allowing to adjust the brightness of the output image.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoDrago03")]
-        public static extern FIBITMAP TmoDrago03(FIBITMAP src, double gamma, double exposure);
-
-        /// <summary>
-        /// Converts a High Dynamic Range image to a 24-bit RGB image using a global operator inspired
-        /// by photoreceptor physiology of the human visual system.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="intensity">Controls the overall image intensity in the range [-8, 8].</param>
-        /// <param name="contrast">Controls the overall image contrast in the range [0.3, 1.0[.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoReinhard05")]
-        public static extern FIBITMAP TmoReinhard05(FIBITMAP src, double intensity, double contrast);
-
-        /// <summary>
-        /// Apply the Gradient Domain High Dynamic Range Compression to a RGBF image and convert to 24-bit RGB.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="color_saturation">Color saturation (s parameter in the paper) in [0.4..0.6]</param>
-        /// <param name="attenuation">Atenuation factor (beta parameter in the paper) in [0.8..0.9]</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoFattal02")]
-        public static extern FIBITMAP TmoFattal02(FIBITMAP src, double color_saturation, double attenuation);
-
-        #endregion
-
-        #region Compression functions
-
-        /// <summary>
-        /// Compresses a source buffer into a target buffer, using the ZLib library.
-        /// </summary>
-        /// <param name="target">Pointer to the target buffer.</param>
-        /// <param name="target_size">Size of the target buffer.
-        /// Must be at least 0.1% larger than source_size plus 12 bytes.</param>
-        /// <param name="source">Pointer to the source buffer.</param>
-        /// <param name="source_size">Size of the source buffer.</param>
-        /// <returns>The actual size of the compressed buffer, or 0 if an error occurred.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibCompress")]
-        public static extern uint ZLibCompress(byte[] target, uint target_size, byte[] source, uint source_size);
-
-        /// <summary>
-        /// Decompresses a source buffer into a target buffer, using the ZLib library.
-        /// </summary>
-        /// <param name="target">Pointer to the target buffer.</param>
-        /// <param name="target_size">Size of the target buffer.
-        /// Must have been saved outlide of zlib.</param>
-        /// <param name="source">Pointer to the source buffer.</param>
-        /// <param name="source_size">Size of the source buffer.</param>
-        /// <returns>The actual size of the uncompressed buffer, or 0 if an error occurred.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibUncompress")]
-        public static extern uint ZLibUncompress(byte[] target, uint target_size, byte[] source, uint source_size);
-
-        /// <summary>
-        /// Compresses a source buffer into a target buffer, using the ZLib library.
-        /// </summary>
-        /// <param name="target">Pointer to the target buffer.</param>
-        /// <param name="target_size">Size of the target buffer.
-        /// Must be at least 0.1% larger than source_size plus 24 bytes.</param>
-        /// <param name="source">Pointer to the source buffer.</param>
-        /// <param name="source_size">Size of the source buffer.</param>
-        /// <returns>The actual size of the compressed buffer, or 0 if an error occurred.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibGZip")]
-        public static extern uint ZLibGZip(byte[] target, uint target_size, byte[] source, uint source_size);
-
-        /// <summary>
-        /// Decompresses a source buffer into a target buffer, using the ZLib library.
-        /// </summary>
-        /// <param name="target">Pointer to the target buffer.</param>
-        /// <param name="target_size">Size of the target buffer.
-        /// Must have been saved outlide of zlib.</param>
-        /// <param name="source">Pointer to the source buffer.</param>
-        /// <param name="source_size">Size of the source buffer.</param>
-        /// <returns>The actual size of the uncompressed buffer, or 0 if an error occurred.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibGUnzip")]
-        public static extern uint ZLibGUnzip(byte[] target, uint target_size, byte[] source, uint source_size);
-
-        /// <summary>
-        /// Generates a CRC32 checksum.
-        /// </summary>
-        /// <param name="crc">The CRC32 checksum to begin with.</param>
-        /// <param name="source">Pointer to the source buffer.
-        /// If the value is 0, the function returns the required initial value for the crc.</param>
-        /// <param name="source_size">Size of the source buffer.</param>
-        /// <returns></returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibCRC32")]
-        public static extern uint ZLibCRC32(uint crc, byte[] source, uint source_size);
-
-        #endregion
-
-        #region Tag creation and destruction
-
-        /// <summary>
-        /// Allocates a new <see cref="FITAG"/> object.
-        /// This object must be destroyed with a call to
-        /// <see cref="FreeImageAPI.FreeImage.DeleteTag(FITAG)"/> when no longer in use.
-        /// </summary>
-        /// <returns>The new <see cref="FITAG"/>.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CreateTag")]
-        public static extern FITAG CreateTag();
-
-        /// <summary>
-        /// Delete a previously allocated <see cref="FITAG"/> object.
-        /// </summary>
-        /// <param name="tag">The <see cref="FITAG"/> to destroy.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeleteTag")]
-        public static extern void DeleteTag(FITAG tag);
-
-        /// <summary>
-        /// Creates and returns a copy of a <see cref="FITAG"/> object.
-        /// </summary>
-        /// <param name="tag">The <see cref="FITAG"/> to clone.</param>
-        /// <returns>The new <see cref="FITAG"/>.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloneTag")]
-        public static extern FITAG CloneTag(FITAG tag);
-
-        #endregion
-
-        #region Tag accessors
-
-        /// <summary>
-        /// Returns the tag field name (unique inside a metadata model).
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The field name.</returns>
-        public static unsafe string GetTagKey(FITAG tag) { return PtrToStr(GetTagKey_(tag)); }
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetTagKey")]
-        private static unsafe extern byte* GetTagKey_(FITAG tag);
-
-        /// <summary>
-        /// Returns the tag description.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The description or NULL if unavailable.</returns>
-        public static unsafe string GetTagDescription(FITAG tag) { return PtrToStr(GetTagDescription_(tag)); }
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetTagDescription")]
-        private static unsafe extern byte* GetTagDescription_(FITAG tag);
-
-        /// <summary>
-        /// Returns the tag ID.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The ID or 0 if unavailable.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagID")]
-        public static extern ushort GetTagID(FITAG tag);
-
-        /// <summary>
-        /// Returns the tag data type.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The tag type.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagType")]
-        public static extern FREE_IMAGE_MDTYPE GetTagType(FITAG tag);
-
-        /// <summary>
-        /// Returns the number of components in the tag (in tag type units).
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The number of components.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagCount")]
-        public static extern uint GetTagCount(FITAG tag);
-
-        /// <summary>
-        /// Returns the length of the tag value in bytes.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>The length of the tag value.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagLength")]
-        public static extern uint GetTagLength(FITAG tag);
-
-        /// <summary>
-        /// Returns the tag value.
-        /// It is up to the programmer to interpret the returned pointer correctly,
-        /// according to the results of GetTagType and GetTagCount.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <returns>Pointer to the value.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagValue")]
-        public static extern IntPtr GetTagValue(FITAG tag);
-
-        /// <summary>
-        /// Sets the tag field name.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="key">The new name.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetTagKey")]
-        public static extern bool SetTagKey(FITAG tag, string key);
-
-        /// <summary>
-        /// Sets the tag description.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="description">The new description.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetTagDescription")]
-        public static extern bool SetTagDescription(FITAG tag, string description);
-
-        /// <summary>
-        /// Sets the tag ID.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="id">The new ID.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagID")]
-        public static extern bool SetTagID(FITAG tag, ushort id);
-
-        /// <summary>
-        /// Sets the tag data type.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="type">The new type.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagType")]
-        public static extern bool SetTagType(FITAG tag, FREE_IMAGE_MDTYPE type);
-
-        /// <summary>
-        /// Sets the number of data in the tag.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="count">New number of data.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagCount")]
-        public static extern bool SetTagCount(FITAG tag, uint count);
-
-        /// <summary>
-        /// Sets the length of the tag value in bytes.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="length">The new length.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagLength")]
-        public static extern bool SetTagLength(FITAG tag, uint length);
-
-        /// <summary>
-        /// Sets the tag value.
-        /// </summary>
-        /// <param name="tag">The tag field.</param>
-        /// <param name="value">Pointer to the new value.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagValue")]
-        public static extern bool SetTagValue(FITAG tag, byte[] value);
-
-        #endregion
-
-        #region Metadata iterator
-
-        /// <summary>
-        /// Provides information about the first instance of a tag that matches the metadata model.
-        /// </summary>
-        /// <param name="model">The model to match.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="tag">Tag that matches the metadata model.</param>
-        /// <returns>Unique search handle that can be used to call FindNextMetadata or FindCloseMetadata.
-        /// Null if the metadata model does not exist.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindFirstMetadata")]
-        public static extern FIMETADATA FindFirstMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, out FITAG tag);
-
-        /// <summary>
-        /// Find the next tag, if any, that matches the metadata model argument in a previous call
-        /// to FindFirstMetadata, and then alters the tag object contents accordingly.
-        /// </summary>
-        /// <param name="mdhandle">Unique search handle provided by FindFirstMetadata.</param>
-        /// <param name="tag">Tag that matches the metadata model.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindNextMetadata")]
-        public static extern bool FindNextMetadata(FIMETADATA mdhandle, out FITAG tag);
-
-        /// <summary>
-        /// Closes the specified metadata search handle and releases associated resources.
-        /// </summary>
-        /// <param name="mdhandle">The handle to close.</param>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindCloseMetadata")]
-        private static extern void FindCloseMetadata_(FIMETADATA mdhandle);
-
-        #endregion
-
-        #region Metadata setter and getter
-
-        /// <summary>
-        /// Retrieve a metadata attached to a dib.
-        /// </summary>
-        /// <param name="model">The metadata model to look for.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="key">The metadata field name.</param>
-        /// <param name="tag">A FITAG structure returned by the function.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetMetadata")]
-        public static extern bool GetMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, string key, out FITAG tag);
-
-        /// <summary>
-        /// Attach a new FreeImage tag to a dib.
-        /// </summary>
-        /// <param name="model">The metadata model used to store the tag.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="key">The tag field name.</param>
-        /// <param name="tag">The FreeImage tag to be attached.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetMetadata")]
-        public static extern bool SetMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, string key, FITAG tag);
-
-        #endregion
-
-        #region Metadata helper functions
-
-        /// <summary>
-        /// Returns the number of tags contained in the model metadata model attached to the input dib.
-        /// </summary>
-        /// <param name="model">The metadata model.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Number of tags contained in the metadata model.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetMetadataCount")]
-        public static extern uint GetMetadataCount(FREE_IMAGE_MDMODEL model, FIBITMAP dib);
-
-        /// <summary>
-        /// Copies the metadata of FreeImage bitmap to another.
-        /// </summary>
-        /// <param name="dst">The FreeImage bitmap to copy the metadata to.</param>
-        /// <param name="src">The FreeImage bitmap to copy the metadata from.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloneMetadata")]
-        public static extern bool CloneMetadata(FIBITMAP dst, FIBITMAP src);
-
-        /// <summary>
-        /// Converts a FreeImage tag structure to a string that represents the interpreted tag value.
-        /// The function is not thread safe.
-        /// </summary>
-        /// <param name="model">The metadata model.</param>
-        /// <param name="tag">The interpreted tag value.</param>
-        /// <param name="Make">Reserved.</param>
-        /// <returns>The representing string.</returns>
-        public static unsafe string TagToString(FREE_IMAGE_MDMODEL model, FITAG tag, uint Make) { return PtrToStr(TagToString_(model, tag, Make)); }
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_TagToString")]
-        private static unsafe extern byte* TagToString_(FREE_IMAGE_MDMODEL model, FITAG tag, uint Make);
-
-        #endregion
-
-        #region Rotation and flipping
-
-        /// <summary>
-        /// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
-        /// 1-bit images rotation is limited to integer multiple of 90°.
-        /// <c>null</c> is returned for other values.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="angle">The angle of rotation.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_RotateClassic")]
-        [Obsolete("RotateClassic is deprecated (use Rotate instead).")]
-        public static extern FIBITMAP RotateClassic(FIBITMAP dib, double angle);
-
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Rotate")]
-        internal static extern FIBITMAP Rotate(FIBITMAP dib, double angle, IntPtr backgroundColor);
-
-        /// <summary>
-        /// This function performs a rotation and / or translation of an 8-bit greyscale,
-        /// 24- or 32-bit image, using a 3rd order (cubic) B-Spline.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="angle">The angle of rotation.</param>
-        /// <param name="x_shift">Horizontal image translation.</param>
-        /// <param name="y_shift">Vertical image translation.</param>
-        /// <param name="x_origin">Rotation center x-coordinate.</param>
-        /// <param name="y_origin">Rotation center y-coordinate.</param>
-        /// <param name="use_mask">When true the irrelevant part of the image is set to a black color,
-        /// otherwise, a mirroring technique is used to fill irrelevant pixels.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_RotateEx")]
-        public static extern FIBITMAP RotateEx(FIBITMAP dib, double angle,
-            double x_shift, double y_shift, double x_origin, double y_origin, bool use_mask);
-
-        /// <summary>
-        /// Flip the input dib horizontally along the vertical axis.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FlipHorizontal")]
-        public static extern bool FlipHorizontal(FIBITMAP dib);
-
-        /// <summary>
-        /// Flip the input dib vertically along the horizontal axis.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FlipVertical")]
-        public static extern bool FlipVertical(FIBITMAP dib);
-
-        /// <summary>
-        /// Performs a lossless rotation or flipping on a JPEG file.
-        /// </summary>
-        /// <param name="src_file">Source file.</param>
-        /// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
-        /// <param name="operation">The operation to apply.</param>
-        /// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool JPEGTransform(string src_file, string dst_file,
-            FREE_IMAGE_JPEG_OPERATION operation, bool perfect)
-        {
-            if (SupportsUnicode)
-            {
-                return JPEGTransformU(src_file, dst_file, operation, perfect);
-            }
-            else
-            {
-                return JPEGTransformA(src_file, dst_file, operation, perfect);
-            }
-        }
-
-        /// <summary>
-        /// Performs a lossless rotation or flipping on a JPEG file.
-        /// </summary>
-        /// <param name="src_file">Source file.</param>
-        /// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
-        /// <param name="operation">The operation to apply.</param>
-        /// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_JPEGTransform")]
-        private static extern bool JPEGTransformA(string src_file, string dst_file,
-            FREE_IMAGE_JPEG_OPERATION operation, bool perfect);
-
-        /// <summary>
-        /// Performs a lossless rotation or flipping on a JPEG file.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="src_file">Source file.</param>
-        /// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
-        /// <param name="operation">The operation to apply.</param>
-        /// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_JPEGTransformU")]
-        private static extern bool JPEGTransformU(string src_file, string dst_file,
-            FREE_IMAGE_JPEG_OPERATION operation, bool perfect);
-
-        #endregion
-
-        #region Upsampling / downsampling
-
-        /// <summary>
-        /// Performs resampling (or scaling, zooming) of a greyscale or RGB(A) image
-        /// to the desired destination width and height.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="dst_width">Destination width.</param>
-        /// <param name="dst_height">Destination height.</param>
-        /// <param name="filter">The filter to apply.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Rescale")]
-        public static extern FIBITMAP Rescale(FIBITMAP dib, int dst_width, int dst_height, FREE_IMAGE_FILTER filter);
-
-        /// <summary>
-        /// Creates a thumbnail from a greyscale or RGB(A) image, keeping aspect ratio.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="max_pixel_size">Thumbnail square size.</param>
-        /// <param name="convert">When true HDR images are transperantly converted to standard images.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MakeThumbnail")]
-        public static extern FIBITMAP MakeThumbnail(FIBITMAP dib, int max_pixel_size, bool convert);
-
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_EnlargeCanvas")]
-        internal static extern FIBITMAP EnlargeCanvas(FIBITMAP dib,
-            int left, int top, int right, int bottom, IntPtr color, FREE_IMAGE_COLOR_OPTIONS options);
-
-        #endregion
-
-        #region Color manipulation
-
-        /// <summary>
-        /// Perfoms an histogram transformation on a 8-, 24- or 32-bit image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="lookUpTable">The lookup table.
-        /// It's size is assumed to be 256 in length.</param>
-        /// <param name="channel">The color channel to be transformed.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustCurve")]
-        public static extern bool AdjustCurve(FIBITMAP dib, byte[] lookUpTable, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        /// <summary>
-        /// Performs gamma correction on a 8-, 24- or 32-bit image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="gamma">The parameter represents the gamma value to use (gamma > 0).
-        /// A value of 1.0 leaves the image alone, less than one darkens it, and greater than one lightens it.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustGamma")]
-        public static extern bool AdjustGamma(FIBITMAP dib, double gamma);
-
-        /// <summary>
-        /// Adjusts the brightness of a 8-, 24- or 32-bit image by a certain amount.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="percentage">A value 0 means no change,
-        /// less than 0 will make the image darker and greater than 0 will make the image brighter.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustBrightness")]
-        public static extern bool AdjustBrightness(FIBITMAP dib, double percentage);
-
-        /// <summary>
-        /// Adjusts the contrast of a 8-, 24- or 32-bit image by a certain amount.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="percentage">A value 0 means no change,
-        /// less than 0 will decrease the contrast and greater than 0 will increase the contrast of the image.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustContrast")]
-        public static extern bool AdjustContrast(FIBITMAP dib, double percentage);
-
-        /// <summary>
-        /// Inverts each pixel data.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Invert")]
-        public static extern bool Invert(FIBITMAP dib);
-
-        /// <summary>
-        /// Computes the image histogram.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="histo">Array of integers with a size of 256.</param>
-        /// <param name="channel">Channel to compute from.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetHistogram")]
-        public static extern bool GetHistogram(FIBITMAP dib, int[] histo, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        #endregion
-
-        #region Channel processing
-
-        /// <summary>
-        /// Retrieves the red, green, blue or alpha channel of a 24- or 32-bit image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="channel">The color channel to extract.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetChannel")]
-        public static extern FIBITMAP GetChannel(FIBITMAP dib, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        /// <summary>
-        /// Insert a 8-bit dib into a 24- or 32-bit image.
-        /// Both images must have to same width and height.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="dib8">Handle to the bitmap to insert.</param>
-        /// <param name="channel">The color channel to replace.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetChannel")]
-        public static extern bool SetChannel(FIBITMAP dib, FIBITMAP dib8, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        /// <summary>
-        /// Retrieves the real part, imaginary part, magnitude or phase of a complex image.
-        /// </summary>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="channel">The color channel to extract.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetComplexChannel")]
-        public static extern FIBITMAP GetComplexChannel(FIBITMAP src, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        /// <summary>
-        /// Set the real or imaginary part of a complex image.
-        /// Both images must have to same width and height.
-        /// </summary>
-        /// <param name="dst">Handle to a FreeImage bitmap.</param>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="channel">The color channel to replace.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetComplexChannel")]
-        public static extern bool SetComplexChannel(FIBITMAP dst, FIBITMAP src, FREE_IMAGE_COLOR_CHANNEL channel);
-
-        #endregion
-
-        #region Copy / Paste / Composite routines
-
-        /// <summary>
-        /// Copy a sub part of the current dib image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="left">Specifies the left position of the cropped rectangle.</param>
-        /// <param name="top">Specifies the top position of the cropped rectangle.</param>
-        /// <param name="right">Specifies the right position of the cropped rectangle.</param>
-        /// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Copy")]
-        public static extern FIBITMAP Copy(FIBITMAP dib, int left, int top, int right, int bottom);
-
-        /// <summary>
-        /// Alpha blend or combine a sub part image with the current dib image.
-        /// The bit depth of the dst bitmap must be greater than or equal to the bit depth of the src.
-        /// </summary>
-        /// <param name="dst">Handle to a FreeImage bitmap.</param>
-        /// <param name="src">Handle to a FreeImage bitmap.</param>
-        /// <param name="left">Specifies the left position of the sub image.</param>
-        /// <param name="top">Specifies the top position of the sub image.</param>
-        /// <param name="alpha">alpha blend factor.
-        /// The source and destination images are alpha blended if alpha=0..255.
-        /// If alpha > 255, then the source image is combined to the destination image.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Paste")]
-        public static extern bool Paste(FIBITMAP dst, FIBITMAP src, int left, int top, int alpha);
-
-        /// <summary>
-        /// This function composite a transparent foreground image against a single background color or
-        /// against a background image.
-        /// </summary>
-        /// <param name="fg">Handle to a FreeImage bitmap.</param>
-        /// <param name="useFileBkg">When true the background of fg is used if it contains one.</param>
-        /// <param name="appBkColor">The application background is used if useFileBkg is false.</param>
-        /// <param name="bg">Image used as background when useFileBkg is false or fg has no background
-        /// and appBkColor is null.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Composite")]
-        public static extern FIBITMAP Composite(FIBITMAP fg, bool useFileBkg, ref RGBQUAD appBkColor, FIBITMAP bg);
-
-        /// <summary>
-        /// This function composite a transparent foreground image against a single background color or
-        /// against a background image.
-        /// </summary>
-        /// <param name="fg">Handle to a FreeImage bitmap.</param>
-        /// <param name="useFileBkg">When true the background of fg is used if it contains one.</param>
-        /// <param name="appBkColor">The application background is used if useFileBkg is false
-        /// and 'appBkColor' is not null.</param>
-        /// <param name="bg">Image used as background when useFileBkg is false or fg has no background
-        /// and appBkColor is null.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Composite")]
-        public static extern FIBITMAP Composite(FIBITMAP fg, bool useFileBkg, RGBQUAD[] appBkColor, FIBITMAP bg);
-
-        /// <summary>
-        /// Performs a lossless crop on a JPEG file.
-        /// </summary>
-        /// <param name="src_file">Source filename.</param>
-        /// <param name="dst_file">Destination filename.</param>
-        /// <param name="left">Specifies the left position of the cropped rectangle.</param>
-        /// <param name="top">Specifies the top position of the cropped rectangle.</param>
-        /// <param name="right">Specifies the right position of the cropped rectangle.</param>
-        /// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool JPEGCrop(string src_file, string dst_file, int left, int top, int right, int bottom)
-        {
-            if (SupportsUnicode)
-            {
-                return JPEGCropU(src_file, dst_file, left, top, right, bottom);
-            }
-            else
-            {
-                return JPEGCropA(src_file, dst_file, left, top, right, bottom);
-            }
-        }
-
-        /// <summary>
-        /// Performs a lossless crop on a JPEG file.
-        /// </summary>
-        /// <param name="src_file">Source filename.</param>
-        /// <param name="dst_file">Destination filename.</param>
-        /// <param name="left">Specifies the left position of the cropped rectangle.</param>
-        /// <param name="top">Specifies the top position of the cropped rectangle.</param>
-        /// <param name="right">Specifies the right position of the cropped rectangle.</param>
-        /// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_JPEGCrop")]
-        private static extern bool JPEGCropA(string src_file, string dst_file, int left, int top, int right, int bottom);
-
-        /// <summary>
-        /// Performs a lossless crop on a JPEG file.
-        /// Supports UNICODE filenames.
-        /// </summary>
-        /// <param name="src_file">Source filename.</param>
-        /// <param name="dst_file">Destination filename.</param>
-        /// <param name="left">Specifies the left position of the cropped rectangle.</param>
-        /// <param name="top">Specifies the top position of the cropped rectangle.</param>
-        /// <param name="right">Specifies the right position of the cropped rectangle.</param>
-        /// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_JPEGCropU")]
-        private static extern bool JPEGCropU(string src_file, string dst_file, int left, int top, int right, int bottom);
-
-        /// <summary>
-        /// Applies the alpha value of each pixel to its color components.
-        /// The aplha value stays unchanged.
-        /// Only works with 32-bits color depth.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_PreMultiplyWithAlpha")]
-        public static extern bool PreMultiplyWithAlpha(FIBITMAP dib);
-
-        #endregion
-
-        #region Miscellaneous algorithms
-
-        /// <summary>
-        /// Solves a Poisson equation, remap result pixels to [0..1] and returns the solution.
-        /// </summary>
-        /// <param name="Laplacian">Handle to a FreeImage bitmap.</param>
-        /// <param name="ncycle">Number of cycles in the multigrid algorithm (usually 2 or 3)</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MultigridPoissonSolver")]
-        public static extern FIBITMAP MultigridPoissonSolver(FIBITMAP Laplacian, int ncycle);
-
-        #endregion
-
-        #region Colors
-
-        /// <summary>
-        /// Creates a lookup table to be used with <see cref="AdjustCurve"/> which may adjusts brightness and
-        /// contrast, correct gamma and invert the image with a single call to <see cref="AdjustCurve"/>.
-        /// </summary>
-        /// <param name="lookUpTable">Output lookup table to be used with <see cref="AdjustCurve"/>.
-        /// The size of 'lookUpTable' is assumed to be 256.</param>
-        /// <param name="brightness">Percentage brightness value where -100 &lt;= brightness &lt;= 100.
-        /// <para>A value of 0 means no change, less than 0 will make the image darker and greater
-        /// than 0 will make the image brighter.</para></param>
-        /// <param name="contrast">Percentage contrast value where -100 &lt;= contrast &lt;= 100.
-        /// <para>A value of 0 means no change, less than 0 will decrease the contrast
-        /// and greater than 0 will increase the contrast of the image.</para></param>
-        /// <param name="gamma">Gamma value to be used for gamma correction.
-        /// <para>A value of 1.0 leaves the image alone, less than one darkens it,
-        /// and greater than one lightens it.</para></param>
-        /// <param name="invert">If set to true, the image will be inverted.</param>
-        /// <returns>The number of adjustments applied to the resulting lookup table
-        /// compared to a blind lookup table.</returns>
-        /// <remarks>
-        /// This function creates a lookup table to be used with <see cref="AdjustCurve"/> which may adjust
-        /// brightness and contrast, correct gamma and invert the image with a single call to
-        /// <see cref="AdjustCurve"/>. If more than one of these image display properties need to be adjusted,
-        /// using a combined lookup table should be preferred over calling each adjustment function
-        /// separately. That's particularly true for huge images or if performance is an issue. Then,
-        /// the expensive process of iterating over all pixels of an image is performed only once and
-        /// not up to four times.
-        /// <para/>
-        /// Furthermore, the lookup table created does not depend on the order, in which each single
-        /// adjustment operation is performed. Due to rounding and byte casting issues, it actually
-        /// matters in which order individual adjustment operations are performed. Both of the following
-        /// snippets most likely produce different results:
-        /// <para/>
-        /// <code>
-        /// // snippet 1: contrast, brightness
-        /// AdjustContrast(dib, 15.0);
-        /// AdjustBrightness(dib, 50.0); 
-        /// </code>
-        /// <para/>
-        /// <code>
-        /// // snippet 2: brightness, contrast
-        /// AdjustBrightness(dib, 50.0);
-        /// AdjustContrast(dib, 15.0);
-        /// </code>
-        /// <para/>
-        /// Better and even faster would be snippet 3:
-        /// <para/>
-        /// <code>
-        /// // snippet 3:
-        /// byte[] lut = new byte[256];
-        /// GetAdjustColorsLookupTable(lut, 50.0, 15.0, 1.0, false);
-        /// AdjustCurve(dib, lut, FREE_IMAGE_COLOR_CHANNEL.FICC_RGB);
-        /// </code>
-        /// <para/>
-        /// This function is also used internally by <see cref="AdjustColors"/>, which does not return the
-        /// lookup table, but uses it to call <see cref="AdjustCurve"/> on the passed image.
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetAdjustColorsLookupTable")]
-        public static extern int GetAdjustColorsLookupTable(byte[] lookUpTable, double brightness, double contrast, double gamma, bool invert);
-
-        /// <summary>
-        /// Adjusts an image's brightness, contrast and gamma as well as it may
-        /// optionally invert the image within a single operation.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="brightness">Percentage brightness value where -100 &lt;= brightness &lt;= 100.
-        /// <para>A value of 0 means no change, less than 0 will make the image darker and greater
-        /// than 0 will make the image brighter.</para></param>
-        /// <param name="contrast">Percentage contrast value where -100 &lt;= contrast &lt;= 100.
-        /// <para>A value of 0 means no change, less than 0 will decrease the contrast
-        /// and greater than 0 will increase the contrast of the image.</para></param>
-        /// <param name="gamma">Gamma value to be used for gamma correction.
-        /// <para>A value of 1.0 leaves the image alone, less than one darkens it,
-        /// and greater than one lightens it.</para>
-        /// This parameter must not be zero or smaller than zero.
-        /// If so, it will be ignored and no gamma correction will be performed on the image.</param>
-        /// <param name="invert">If set to true, the image will be inverted.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <remarks>
-        /// This function adjusts an image's brightness, contrast and gamma as well as it
-        /// may optionally invert the image within a single operation. If more than one of
-        /// these image display properties need to be adjusted, using this function should
-        /// be preferred over calling each adjustment function separately. That's particularly
-        /// true for huge images or if performance is an issue.
-        /// <para/>
-        /// This function relies on <see cref="GetAdjustColorsLookupTable"/>,
-        /// which creates a single lookup table, that combines all adjustment operations requested.
-        /// <para/>
-        /// Furthermore, the lookup table created by <see cref="GetAdjustColorsLookupTable"/> does
-        /// not depend on the order, in which each single adjustment operation is performed.
-        /// Due to rounding and byte casting issues, it actually matters in which order individual
-        /// adjustment operations are performed. Both of the following snippets most likely produce
-        /// different results:
-        /// <para/>
-        /// <code>
-        /// // snippet 1: contrast, brightness
-        /// AdjustContrast(dib, 15.0);
-        /// AdjustBrightness(dib, 50.0);
-        /// </code>
-        /// <para/>
-        /// <code>
-        /// // snippet 2: brightness, contrast
-        /// AdjustBrightness(dib, 50.0);
-        /// AdjustContrast(dib, 15.0);
-        /// </code>
-        /// <para/>
-        /// Better and even faster would be snippet 3:
-        /// <para/>
-        /// <code>
-        /// // snippet 3:
-        /// AdjustColors(dib, 50.0, 15.0, 1.0, false);
-        /// </code>
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustColors")]
-        public static extern bool AdjustColors(FIBITMAP dib, double brightness, double contrast, double gamma, bool invert);
-
-        /// <summary>
-        /// Applies color mapping for one or several colors on a 1-, 4- or 8-bit
-        /// palletized or a 16-, 24- or 32-bit high color image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="srccolors">Array of colors to be used as the mapping source.</param>
-        /// <param name="dstcolors">Array of colors to be used as the mapping destination.</param>
-        /// <param name="count">The number of colors to be mapped. This is the size of both
-        /// srccolors and dstcolors.</param>
-        /// <param name="ignore_alpha">If true, 32-bit images and colors are treated as 24-bit.</param>
-        /// <param name="swap">If true, source and destination colors are swapped, that is,
-        /// each destination color is also mapped to the corresponding source color.</param>
-        /// <returns>The total number of pixels changed.</returns>
-        /// <remarks>
-        /// This function maps up to <paramref name="count"/> colors specified in
-        /// <paramref name="srccolors"/> to these specified in <paramref name="dstcolors"/>.
-        /// Thereby, color <i>srccolors[N]</i>, if found in the image, will be replaced by color
-        /// <i>dstcolors[N]</i>. If <paramref name="swap"/> is <b>true</b>, additionally all colors
-        /// specified in <paramref name="dstcolors"/> are also mapped to these specified
-        /// in <paramref name="srccolors"/>. For high color images, the actual image data will be
-        /// modified whereas, for palletized images only the palette will be changed.
-        /// <para/>
-        /// The function returns the number of pixels changed or zero, if no pixels were changed. 
-        /// <para/>
-        /// Both arrays <paramref name="srccolors"/> and <paramref name="dstcolors"/> are assumed
-        /// not to hold less than <paramref name="count"/> colors.
-        /// <para/>
-        /// For 16-bit images, all colors specified are transparently converted to their 
-        /// proper 16-bit representation (either in RGB555 or RGB565 format, which is determined
-        /// by the image's red- green- and blue-mask).
-        /// <para/>
-        /// <b>Note, that this behaviour is different from what <see cref="ApplyPaletteIndexMapping"/> does,
-        /// which modifies the actual image data on palletized images.</b>
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ApplyColorMapping")]
-        public static extern uint ApplyColorMapping(FIBITMAP dib, RGBQUAD[] srccolors, RGBQUAD[] dstcolors, uint count, bool ignore_alpha, bool swap);
-
-        /// <summary>
-        /// Swaps two specified colors on a 1-, 4- or 8-bit palletized
-        /// or a 16-, 24- or 32-bit high color image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="color_a">One of the two colors to be swapped.</param>
-        /// <param name="color_b">The other of the two colors to be swapped.</param>
-        /// <param name="ignore_alpha">If true, 32-bit images and colors are treated as 24-bit.</param>
-        /// <returns>The total number of pixels changed.</returns>
-        /// <remarks>
-        /// This function swaps the two specified colors <paramref name="color_a"/> and
-        /// <paramref name="color_b"/> on a palletized or high color image.
-        /// For high color images, the actual image data will be modified whereas, for palletized
-        /// images only the palette will be changed.
-        /// <para/>
-        /// <b>Note, that this behaviour is different from what <see cref="SwapPaletteIndices"/> does,
-        /// which modifies the actual image data on palletized images.</b>
-        /// <para/>
-        /// This is just a thin wrapper for <see cref="ApplyColorMapping"/> and resolves to:
-        /// <para/>
-        /// <code>
-        /// return ApplyColorMapping(dib, color_a, color_b, 1, ignore_alpha, true);
-        /// </code>
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SwapColors")]
-        public static extern uint SwapColors(FIBITMAP dib, ref RGBQUAD color_a, ref RGBQUAD color_b, bool ignore_alpha);
-
-        /// <summary>
-        /// Applies palette index mapping for one or several indices
-        /// on a 1-, 4- or 8-bit palletized image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="srcindices">Array of palette indices to be used as the mapping source.</param>
-        /// <param name="dstindices">Array of palette indices to be used as the mapping destination.</param>
-        /// <param name="count">The number of palette indices to be mapped. This is the size of both
-        /// srcindices and dstindices</param>
-        /// <param name="swap">If true, source and destination palette indices are swapped, that is,
-        /// each destination index is also mapped to the corresponding source index.</param>
-        /// <returns>The total number of pixels changed.</returns>
-        /// <remarks>
-        /// This function maps up to <paramref name="count"/> palette indices specified in
-        /// <paramref name="srcindices"/> to these specified in <paramref name="dstindices"/>.
-        /// Thereby, index <i>srcindices[N]</i>, if present in the image, will be replaced by index
-        /// <i>dstindices[N]</i>. If <paramref name="swap"/> is <b>true</b>, additionally all indices
-        /// specified in <paramref name="dstindices"/> are also mapped to these specified in 
-        /// <paramref name="srcindices"/>.
-        /// <para/>
-        /// The function returns the number of pixels changed or zero, if no pixels were changed.
-        /// Both arrays <paramref name="srcindices"/> and <paramref name="dstindices"/> are assumed not to
-        /// hold less than <paramref name="count"/> indices.
-        /// <para/>
-        /// <b>Note, that this behaviour is different from what <see cref="ApplyColorMapping"/> does, which
-        /// modifies the actual image data on palletized images.</b>
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ApplyPaletteIndexMapping")]
-        public static extern uint ApplyPaletteIndexMapping(FIBITMAP dib, byte[] srcindices, byte[] dstindices, uint count, bool swap);
-
-        /// <summary>
-        /// Swaps two specified palette indices on a 1-, 4- or 8-bit palletized image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="index_a">One of the two palette indices to be swapped.</param>
-        /// <param name="index_b">The other of the two palette indices to be swapped.</param>
-        /// <returns>The total number of pixels changed.</returns>
-        /// <remarks>
-        /// This function swaps the two specified palette indices <i>index_a</i> and
-        /// <i>index_b</i> on a palletized image. Therefore, not the palette, but the
-        /// actual image data will be modified.
-        /// <para/>
-        /// <b>Note, that this behaviour is different from what <see cref="SwapColors"/> does on palletized images,
-        /// which only swaps the colors in the palette.</b>
-        /// <para/>
-        /// This is just a thin wrapper for <see cref="ApplyColorMapping"/> and resolves to:
-        /// <para/>
-        /// <code>
-        /// return ApplyPaletteIndexMapping(dib, index_a, index_b, 1, true);
-        /// </code>
-        /// </remarks>
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SwapPaletteIndices")]
-        public static extern uint SwapPaletteIndices(FIBITMAP dib, ref byte index_a, ref byte index_b);
-
-        [DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FillBackground")]
-        internal static extern bool FillBackground(FIBITMAP dib, IntPtr color, FREE_IMAGE_COLOR_OPTIONS options);
-
-        #endregion
-    }
+		{
+			if (SupportsUnicode)
+			{
+				return LoadU(fif, filename, flags);
+			}
+			else
+			{
+				return LoadA(fif, filename, flags);
+			}
+		}
+
+		/// <summary>
+		/// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="filename">Name of the file to decode.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_Load")]
+		private static extern FIBITMAP LoadA(FREE_IMAGE_FORMAT fif, string filename, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Decodes a bitmap, allocates memory for it and returns it as a FIBITMAP.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="filename">Name of the file to decode.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_LoadU")]
+		private static extern FIBITMAP LoadU(FREE_IMAGE_FORMAT fif, string filename, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Loads a bitmap from an arbitrary source.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="io">A FreeImageIO structure with functionpointers to handle the source.</param>
+		/// <param name="handle">A handle to the source.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadFromHandle")]
+		public static extern FIBITMAP LoadFromHandle(FREE_IMAGE_FORMAT fif, ref FreeImageIO io, fi_handle handle, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Saves a previosly loaded FIBITMAP to a file.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">Name of the file to save to.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool Save(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			if (SupportsUnicode)
+			{
+				return SaveU(fif, dib, filename, flags);
+			}
+			else
+			{
+				return SaveA(fif, dib, filename, flags);
+			}
+		}
+
+		/// <summary>
+		/// Saves a previosly loaded FIBITMAP to a file.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">Name of the file to save to.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_Save")]
+		private static extern bool SaveA(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags);
+
+		/// <summary>
+		/// Saves a previosly loaded FIBITMAP to a file.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">Name of the file to save to.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_SaveU")]
+		private static extern bool SaveU(FREE_IMAGE_FORMAT fif, FIBITMAP dib, string filename, FREE_IMAGE_SAVE_FLAGS flags);
+
+		/// <summary>
+		/// Saves a bitmap to an arbitrary source.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="io">A FreeImageIO structure with functionpointers to handle the source.</param>
+		/// <param name="handle">A handle to the source.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SaveToHandle")]
+		public static extern bool SaveToHandle(FREE_IMAGE_FORMAT fif, FIBITMAP dib, ref FreeImageIO io, fi_handle handle,
+			FREE_IMAGE_SAVE_FLAGS flags);
+
+		#endregion
+
+		#region Memory I/O streams
+
+		/// <summary>
+		/// Open a memory stream.
+		/// </summary>
+		/// <param name="data">Pointer to the data in memory.</param>
+		/// <param name="size_in_bytes">Length of the data in byte.</param>
+		/// <returns>Handle to a memory stream.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMemory")]
+		public static extern FIMEMORY OpenMemory(IntPtr data, uint size_in_bytes);
+
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMemory")]
+		internal static extern FIMEMORY OpenMemoryEx(byte[] data, uint size_in_bytes);
+
+		/// <summary>
+		/// Close and free a memory stream.
+		/// </summary>
+		/// <param name="stream">Handle to a memory stream.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloseMemory")]
+		public static extern void CloseMemory(FIMEMORY stream);
+
+		/// <summary>
+		/// Decodes a bitmap from a stream, allocates memory for it and returns it as a FIBITMAP.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="stream">Handle to a memory stream.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadFromMemory")]
+		public static extern FIBITMAP LoadFromMemory(FREE_IMAGE_FORMAT fif, FIMEMORY stream, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Saves a previosly loaded FIBITMAP to a stream.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">Handle to a memory stream.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SaveToMemory")]
+		public static extern bool SaveToMemory(FREE_IMAGE_FORMAT fif, FIBITMAP dib, FIMEMORY stream, FREE_IMAGE_SAVE_FLAGS flags);
+
+		/// <summary>
+		/// Gets the current position of a memory handle.
+		/// </summary>
+		/// <param name="stream">Handle to a memory stream.</param>
+		/// <returns>The current file position if successful, -1 otherwise.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TellMemory")]
+		public static extern int TellMemory(FIMEMORY stream);
+
+		/// <summary>
+		/// Moves the memory handle to a specified location.
+		/// </summary>
+		/// <param name="stream">Handle to a memory stream.</param>
+		/// <param name="offset">Number of bytes from origin.</param>
+		/// <param name="origin">Initial position.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SeekMemory")]
+		public static extern bool SeekMemory(FIMEMORY stream, int offset, System.IO.SeekOrigin origin);
+
+		/// <summary>
+		/// Provides a direct buffer access to a memory stream.
+		/// </summary>
+		/// <param name="stream">The target memory stream.</param>
+		/// <param name="data">Pointer to the data in memory.</param>
+		/// <param name="size_in_bytes">Size of the data in bytes.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AcquireMemory")]
+		public static extern bool AcquireMemory(FIMEMORY stream, ref IntPtr data, ref uint size_in_bytes);
+
+		/// <summary>
+		/// Reads data from a memory stream.
+		/// </summary>
+		/// <param name="buffer">The buffer to store the data in.</param>
+		/// <param name="size">Size in bytes of the items.</param>
+		/// <param name="count">Number of items to read.</param>
+		/// <param name="stream">The stream to read from.
+		/// The memory pointer associated with stream is increased by the number of bytes actually read.</param>
+		/// <returns>The number of full items actually read.
+		/// May be less than count on error or stream-end.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ReadMemory")]
+		public static extern uint ReadMemory(byte[] buffer, uint size, uint count, FIMEMORY stream);
+
+		/// <summary>
+		/// Writes data to a memory stream.
+		/// </summary>
+		/// <param name="buffer">The buffer to read the data from.</param>
+		/// <param name="size">Size in bytes of the items.</param>
+		/// <param name="count">Number of items to write.</param>
+		/// <param name="stream">The stream to write to.
+		/// The memory pointer associated with stream is increased by the number of bytes actually written.</param>
+		/// <returns>The number of full items actually written.
+		/// May be less than count on error or stream-end.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_WriteMemory")]
+		public static extern uint WriteMemory(byte[] buffer, uint size, uint count, FIMEMORY stream);
+
+		/// <summary>
+		/// Open a multi-page bitmap from a memory stream.
+		/// </summary>
+		/// <param name="fif">Type of the bitmap.</param>
+		/// <param name="stream">The stream to decode.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LoadMultiBitmapFromMemory")]
+		public static extern FIMULTIBITMAP LoadMultiBitmapFromMemory(FREE_IMAGE_FORMAT fif, FIMEMORY stream, FREE_IMAGE_LOAD_FLAGS flags);
+
+		#endregion
+
+		#region Plugin functions
+
+		/// <summary>
+		/// Registers a new plugin to be used in FreeImage.
+		/// </summary>
+		/// <param name="proc_address">Pointer to the function that initialises the plugin.</param>
+		/// <param name="format">A string describing the format of the plugin.</param>
+		/// <param name="description">A string describing the plugin.</param>
+		/// <param name="extension">A string witha comma sperated list of extensions. f.e: "pl,pl2,pl4"</param>
+		/// <param name="regexpr">A regular expression used to identify the bitmap.</param>
+		/// <returns>The format idientifier assigned by FreeImage.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_RegisterLocalPlugin")]
+		public static extern FREE_IMAGE_FORMAT RegisterLocalPlugin(InitProc proc_address,
+			string format, string description, string extension, string regexpr);
+
+		/// <summary>
+		/// Registers a new plugin to be used in FreeImage. The plugin is residing in a DLL.
+		/// The Init function must be called “Init” and must use the stdcall calling convention.
+		/// </summary>
+		/// <param name="path">Complete path to the dll file hosting the plugin.</param>
+		/// <param name="format">A string describing the format of the plugin.</param>
+		/// <param name="description">A string describing the plugin.</param>
+		/// <param name="extension">A string witha comma sperated list of extensions. f.e: "pl,pl2,pl4"</param>
+		/// <param name="regexpr">A regular expression used to identify the bitmap.</param>
+		/// <returns>The format idientifier assigned by FreeImage.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_RegisterExternalPlugin")]
+		public static extern FREE_IMAGE_FORMAT RegisterExternalPlugin(string path,
+			string format, string description, string extension, string regexpr);
+
+		/// <summary>
+		/// Retrieves the number of FREE_IMAGE_FORMAT identifiers being currently registered.
+		/// </summary>
+		/// <returns>The number of registered formats.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFCount")]
+		public static extern int GetFIFCount();
+
+		/// <summary>
+		/// Enables or disables a plugin.
+		/// </summary>
+		/// <param name="fif">The plugin to enable or disable.</param>
+		/// <param name="enable">True: enable the plugin. false: disable the plugin.</param>
+		/// <returns>The previous state of the plugin.
+		/// 1 - enabled. 0 - disables. -1 plugin does not exist.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPluginEnabled")]
+		public static extern int SetPluginEnabled(FREE_IMAGE_FORMAT fif, bool enable);
+
+		/// <summary>
+		/// Retrieves the state of a plugin.
+		/// </summary>
+		/// <param name="fif">The plugin to check.</param>
+		/// <returns>1 - enabled. 0 - disables. -1 plugin does not exist.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsPluginEnabled")]
+		public static extern int IsPluginEnabled(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Returns a <see cref="FREE_IMAGE_FORMAT"/> identifier from the format string that was used to register the FIF.
+		/// </summary>
+		/// <param name="format">The string that was used to register the plugin.</param>
+		/// <returns>A <see cref="FREE_IMAGE_FORMAT"/> identifier from the format.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromFormat")]
+		public static extern FREE_IMAGE_FORMAT GetFIFFromFormat(string format);
+
+		/// <summary>
+		/// Returns a <see cref="FREE_IMAGE_FORMAT"/> identifier from a MIME content type string
+		/// (MIME stands for Multipurpose Internet Mail Extension).
+		/// </summary>
+		/// <param name="mime">A MIME content type.</param>
+		/// <returns>A <see cref="FREE_IMAGE_FORMAT"/> identifier from the MIME.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromMime")]
+		public static extern FREE_IMAGE_FORMAT GetFIFFromMime(string mime);
+
+		/// <summary>
+		/// Returns the string that was used to register a plugin from the system assigned <see cref="FREE_IMAGE_FORMAT"/>.
+		/// </summary>
+		/// <param name="fif">The assigned <see cref="FREE_IMAGE_FORMAT"/>.</param>
+		/// <returns>The string that was used to register the plugin.</returns>
+		public static unsafe string GetFormatFromFIF(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFormatFromFIF_(fif)); }
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFormatFromFIF")]
+		private static unsafe extern byte* GetFormatFromFIF_(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Returns a comma-delimited file extension list describing the bitmap formats the given plugin can read and/or write.
+		/// </summary>
+		/// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
+		/// <returns>A comma-delimited file extension list.</returns>
+		public static unsafe string GetFIFExtensionList(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFExtensionList_(fif)); }
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFExtensionList")]
+		private static unsafe extern byte* GetFIFExtensionList_(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Returns a descriptive string that describes the bitmap formats the given plugin can read and/or write.
+		/// </summary>
+		/// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
+		/// <returns>A descriptive string that describes the bitmap formats.</returns>
+		public static unsafe string GetFIFDescription(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFDescription_(fif)); }
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFDescription")]
+		private static unsafe extern byte* GetFIFDescription_(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Returns a regular expression string that can be used by a regular expression engine to identify the bitmap.
+		/// FreeImageQt makes use of this function.
+		/// </summary>
+		/// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
+		/// <returns>A regular expression string.</returns>
+		public static unsafe string GetFIFRegExpr(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFRegExpr_(fif)); }
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFRegExpr")]
+		private static unsafe extern byte* GetFIFRegExpr_(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Given a <see cref="FREE_IMAGE_FORMAT"/> identifier, returns a MIME content type string (MIME stands for Multipurpose Internet Mail Extension).
+		/// </summary>
+		/// <param name="fif">The desired <see cref="FREE_IMAGE_FORMAT"/>.</param>
+		/// <returns>A MIME content type string.</returns>
+		public static unsafe string GetFIFMimeType(FREE_IMAGE_FORMAT fif) { return PtrToStr(GetFIFMimeType_(fif)); }
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFIFMimeType")]
+		private static unsafe extern byte* GetFIFMimeType_(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// This function takes a filename or a file-extension and returns the plugin that can
+		/// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
+		/// </summary>
+		/// <param name="filename">The filename or -extension.</param>
+		/// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
+		public static FREE_IMAGE_FORMAT GetFIFFromFilename(string filename)
+		{
+			if (SupportsUnicode)
+			{
+				return GetFIFFromFilenameU(filename);
+			}
+			else
+			{
+				return GetFIFFromFilenameA(filename);
+			}
+		}
+
+		/// <summary>
+		/// This function takes a filename or a file-extension and returns the plugin that can
+		/// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
+		/// </summary>
+		/// <param name="filename">The filename or -extension.</param>
+		/// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFIFFromFilename")]
+		private static extern FREE_IMAGE_FORMAT GetFIFFromFilenameA(string filename);
+
+		/// <summary>
+		/// This function takes a filename or a file-extension and returns the plugin that can
+		/// read/write files with that extension in the form of a <see cref="FREE_IMAGE_FORMAT"/> identifier.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="filename">The filename or -extension.</param>
+		/// <returns>The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFIFFromFilenameU")]
+		private static extern FREE_IMAGE_FORMAT GetFIFFromFilenameU(string filename);
+
+		/// <summary>
+		/// Checks if a plugin can load bitmaps.
+		/// </summary>
+		/// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
+		/// <returns>True if the plugin can load bitmaps, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsReading")]
+		public static extern bool FIFSupportsReading(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Checks if a plugin can save bitmaps.
+		/// </summary>
+		/// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
+		/// <returns>True if the plugin can save bitmaps, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsWriting")]
+		public static extern bool FIFSupportsWriting(FREE_IMAGE_FORMAT fif);
+
+		/// <summary>
+		/// Checks if a plugin can save bitmaps in the desired bit depth.
+		/// </summary>
+		/// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
+		/// <param name="bpp">The desired bit depth.</param>
+		/// <returns>True if the plugin can save bitmaps in the desired bit depth, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsExportBPP")]
+		public static extern bool FIFSupportsExportBPP(FREE_IMAGE_FORMAT fif, int bpp);
+
+		/// <summary>
+		/// Checks if a plugin can save a bitmap in the desired data type.
+		/// </summary>
+		/// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
+		/// <param name="type">The desired image type.</param>
+		/// <returns>True if the plugin can save bitmaps as the desired type, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsExportType")]
+		public static extern bool FIFSupportsExportType(FREE_IMAGE_FORMAT fif, FREE_IMAGE_TYPE type);
+
+		/// <summary>
+		/// Checks if a plugin can load or save an ICC profile.
+		/// </summary>
+		/// <param name="fif">The <see cref="FREE_IMAGE_FORMAT"/> of the plugin.</param>
+		/// <returns>True if the plugin can load or save an ICC profile, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FIFSupportsICCProfiles")]
+		public static extern bool FIFSupportsICCProfiles(FREE_IMAGE_FORMAT fif);
+
+		#endregion
+
+		#region Multipage functions
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="fif">Format of the image.</param>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="create_new">When true a new bitmap is created.</param>
+		/// <param name="read_only">When true the bitmap will be loaded read only.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMultiBitmap")]
+		public static extern FIMULTIBITMAP OpenMultiBitmap(FREE_IMAGE_FORMAT fif, string filename, bool create_new,
+			bool read_only, bool keep_cache_in_memory, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Loads a FreeImage multi-pages bitmap from the specified handle
+		/// using the specified functions.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="fif">Format of the image.</param>
+		/// <param name="io">IO functions used to read from the specified handle.</param>
+		/// <param name="handle">The handle to load the bitmap from.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_OpenMultiBitmapFromHandle")]
+		public static extern FIMULTIBITMAP OpenMultiBitmapFromHandle(FREE_IMAGE_FORMAT fif, ref FreeImageIO io,
+			fi_handle handle, FREE_IMAGE_LOAD_FLAGS flags);
+
+		/// <summary>
+		/// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only, applies any changes made to it.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloseMultiBitmap")]
+		private static extern bool CloseMultiBitmap_(FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags);
+
+		/// <summary>
+		/// Returns the number of pages currently available in the multi-paged bitmap.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <returns>Number of pages.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPageCount")]
+		public static extern int GetPageCount(FIMULTIBITMAP bitmap);
+
+		/// <summary>
+		/// Appends a new page to the end of the bitmap.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="data">Handle to a FreeImage bitmap.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AppendPage")]
+		public static extern void AppendPage(FIMULTIBITMAP bitmap, FIBITMAP data);
+
+		/// <summary>
+		/// Inserts a new page before the given position in the bitmap.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="page">Page has to be a number smaller than the current number of pages available in the bitmap.</param>
+		/// <param name="data">Handle to a FreeImage bitmap.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_InsertPage")]
+		public static extern void InsertPage(FIMULTIBITMAP bitmap, int page, FIBITMAP data);
+
+		/// <summary>
+		/// Deletes the page on the given position.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="page">Number of the page to delete.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeletePage")]
+		public static extern void DeletePage(FIMULTIBITMAP bitmap, int page);
+
+		/// <summary>
+		/// Locks a page in memory for editing.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="page">Number of the page to lock.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_LockPage")]
+		public static extern FIBITMAP LockPage(FIMULTIBITMAP bitmap, int page);
+
+		/// <summary>
+		/// Unlocks a previously locked page and gives it back to the multi-page engine.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="data">Handle to a FreeImage bitmap.</param>
+		/// <param name="changed">If true, the page is applied to the multi-page bitmap.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_UnlockPage")]
+		public static extern void UnlockPage(FIMULTIBITMAP bitmap, FIBITMAP data, bool changed);
+
+		/// <summary>
+		/// Moves the source page to the position of the target page.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="target">New position of the page.</param>
+		/// <param name="source">Old position of the page.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MovePage")]
+		public static extern bool MovePage(FIMULTIBITMAP bitmap, int target, int source);
+
+		/// <summary>
+		/// Returns an array of page-numbers that are currently locked in memory.
+		/// When the pages parameter is null, the size of the array is returned in the count variable.
+		/// </summary>
+		/// <example>
+		/// <code>
+		/// int[] lockedPages = null;
+		/// int count = 0;
+		/// GetLockedPageNumbers(dib, lockedPages, ref count);
+		/// lockedPages = new int[count];
+		/// GetLockedPageNumbers(dib, lockedPages, ref count);
+		/// </code>
+		/// </example>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="pages">The list of locked pages in the multi-pages bitmap.
+		/// If set to null, count will contain the number of pages.</param>
+		/// <param name="count">If <paramref name="pages"/> is set to null count will contain the number of locked pages.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetLockedPageNumbers")]
+		public static extern bool GetLockedPageNumbers(FIMULTIBITMAP bitmap, int[] pages, ref int count);
+
+		#endregion
+
+		#region Filetype functions
+
+		/// <summary>
+		/// Orders FreeImage to analyze the bitmap signature.
+		/// </summary>
+		/// <param name="filename">Name of the file to analyze.</param>
+		/// <param name="size">Reserved parameter - use 0.</param>
+		/// <returns>Type of the bitmap.</returns>
+		public static FREE_IMAGE_FORMAT GetFileType(string filename, int size)
+		{
+			if (SupportsUnicode)
+			{
+				return GetFileTypeU(filename, size);
+			}
+			else
+			{
+				return GetFileTypeA(filename, size);
+			}
+		}
+
+		/// <summary>
+		/// Orders FreeImage to analyze the bitmap signature.
+		/// </summary>
+		/// <param name="filename">Name of the file to analyze.</param>
+		/// <param name="size">Reserved parameter - use 0.</param>
+		/// <returns>Type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetFileType")]
+		private static extern FREE_IMAGE_FORMAT GetFileTypeA(string filename, int size);
+
+		/// <summary>
+		/// Orders FreeImage to analyze the bitmap signature.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="filename">Name of the file to analyze.</param>
+		/// <param name="size">Reserved parameter - use 0.</param>
+		/// <returns>Type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_GetFileTypeU")]
+		private static extern FREE_IMAGE_FORMAT GetFileTypeU(string filename, int size);
+
+		/// <summary>
+		/// Uses the <see cref="FreeImageIO"/> structure as described in the topic bitmap management functions
+		/// to identify a bitmap type.
+		/// </summary>
+		/// <param name="io">A <see cref="FreeImageIO"/> structure with functionpointers to handle the source.</param>
+		/// <param name="handle">A handle to the source.</param>
+		/// <param name="size">Size in bytes of the source.</param>
+		/// <returns>Type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFileTypeFromHandle")]
+		public static extern FREE_IMAGE_FORMAT GetFileTypeFromHandle(ref FreeImageIO io, fi_handle handle, int size);
+
+		/// <summary>
+		/// Uses a memory handle to identify a bitmap type.
+		/// </summary>
+		/// <param name="stream">Pointer to the stream.</param>
+		/// <param name="size">Size in bytes of the source.</param>
+		/// <returns>Type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetFileTypeFromMemory")]
+		public static extern FREE_IMAGE_FORMAT GetFileTypeFromMemory(FIMEMORY stream, int size);
+
+		#endregion
+
+		#region Helper functions
+
+		/// <summary>
+		/// Returns whether the platform is using Little Endian.
+		/// </summary>
+		/// <returns>Returns true if the platform is using Litte Endian, else false.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsLittleEndian")]
+		public static extern bool IsLittleEndian();
+
+		/// <summary>
+		/// Converts a X11 color name into a corresponding RGB value.
+		/// </summary>
+		/// <param name="szColor">Name of the color to convert.</param>
+		/// <param name="nRed">Red component.</param>
+		/// <param name="nGreen">Green component.</param>
+		/// <param name="nBlue">Blue component.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_LookupX11Color")]
+		public static extern bool LookupX11Color(string szColor, out byte nRed, out byte nGreen, out byte nBlue);
+
+		/// <summary>
+		/// Converts a SVG color name into a corresponding RGB value.
+		/// </summary>
+		/// <param name="szColor">Name of the color to convert.</param>
+		/// <param name="nRed">Red component.</param>
+		/// <param name="nGreen">Green component.</param>
+		/// <param name="nBlue">Blue component.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_LookupSVGColor")]
+		public static extern bool LookupSVGColor(string szColor, out byte nRed, out byte nGreen, out byte nBlue);
+
+		#endregion
+
+		#region Pixel access functions
+
+		/// <summary>
+		/// Returns a pointer to the data-bits of the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Pointer to the data-bits.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBits")]
+		public static extern IntPtr GetBits(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a pointer to the start of the given scanline in the bitmap's data-bits.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="scanline">Number of the scanline.</param>
+		/// <returns>Pointer to the scanline.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetScanLine")]
+		public static extern IntPtr GetScanLine(FIBITMAP dib, int scanline);
+
+		/// <summary>
+		/// Get the pixel index of a palettized image at position (x, y), including range check (slow access).
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="x">Pixel position in horizontal direction.</param>
+		/// <param name="y">Pixel position in vertical direction.</param>
+		/// <param name="value">The pixel index.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPixelIndex")]
+		public static extern bool GetPixelIndex(FIBITMAP dib, uint x, uint y, out byte value);
+
+		/// <summary>
+		/// Get the pixel color of a 16-, 24- or 32-bit image at position (x, y), including range check (slow access).
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="x">Pixel position in horizontal direction.</param>
+		/// <param name="y">Pixel position in vertical direction.</param>
+		/// <param name="value">The pixel color.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPixelColor")]
+		public static extern bool GetPixelColor(FIBITMAP dib, uint x, uint y, out RGBQUAD value);
+
+		/// <summary>
+		/// Set the pixel index of a palettized image at position (x, y), including range check (slow access).
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="x">Pixel position in horizontal direction.</param>
+		/// <param name="y">Pixel position in vertical direction.</param>
+		/// <param name="value">The new pixel index.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPixelIndex")]
+		public static extern bool SetPixelIndex(FIBITMAP dib, uint x, uint y, ref byte value);
+
+		/// <summary>
+		/// Set the pixel color of a 16-, 24- or 32-bit image at position (x, y), including range check (slow access).
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="x">Pixel position in horizontal direction.</param>
+		/// <param name="y">Pixel position in vertical direction.</param>
+		/// <param name="value">The new pixel color.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetPixelColor")]
+		public static extern bool SetPixelColor(FIBITMAP dib, uint x, uint y, ref RGBQUAD value);
+
+		#endregion
+
+		#region Bitmap information functions
+
+		/// <summary>
+		/// Retrieves the type of the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetImageType")]
+		public static extern FREE_IMAGE_TYPE GetImageType(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the number of colors used in a bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Palette-size for palletised bitmaps, and 0 for high-colour bitmaps.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetColorsUsed")]
+		public static extern uint GetColorsUsed(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the size of one pixel in the bitmap in bits.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Size of one pixel in the bitmap in bits.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBPP")]
+		public static extern uint GetBPP(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the width of the bitmap in pixel units.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>With of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetWidth")]
+		public static extern uint GetWidth(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the height of the bitmap in pixel units.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Height of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetHeight")]
+		public static extern uint GetHeight(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the width of the bitmap in bytes.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>With of the bitmap in bytes.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetLine")]
+		public static extern uint GetLine(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the width of the bitmap in bytes, rounded to the next 32-bit boundary,
+		/// also known as pitch or stride or scan width.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>With of the bitmap in bytes.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPitch")]
+		public static extern uint GetPitch(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the size of the DIB-element of a FIBITMAP in memory.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Size of the DIB-element</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDIBSize")]
+		public static extern uint GetDIBSize(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a pointer to the bitmap's palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Pointer to the bitmap's palette.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetPalette")]
+		public static extern IntPtr GetPalette(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the horizontal resolution, in pixels-per-meter, of the target device for the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The horizontal resolution, in pixels-per-meter.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDotsPerMeterX")]
+		public static extern uint GetDotsPerMeterX(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the vertical resolution, in pixels-per-meter, of the target device for the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The vertical resolution, in pixels-per-meter.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetDotsPerMeterY")]
+		public static extern uint GetDotsPerMeterY(FIBITMAP dib);
+
+		/// <summary>
+		/// Set the horizontal resolution, in pixels-per-meter, of the target device for the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="res">The new horizontal resolution.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetDotsPerMeterX")]
+		public static extern void SetDotsPerMeterX(FIBITMAP dib, uint res);
+
+		/// <summary>
+		/// Set the vertical resolution, in pixels-per-meter, of the target device for the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="res">The new vertical resolution.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetDotsPerMeterY")]
+		public static extern void SetDotsPerMeterY(FIBITMAP dib, uint res);
+
+		/// <summary>
+		/// Returns a pointer to the <see cref="BITMAPINFOHEADER"/> of the DIB-element in a FIBITMAP.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Poiter to the header of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetInfoHeader")]
+		public static extern IntPtr GetInfoHeader(FIBITMAP dib);
+
+		/// <summary>
+		/// Alias for FreeImage_GetInfoHeader that returns a pointer to a <see cref="BITMAPINFO"/>
+		/// rather than to a <see cref="BITMAPINFOHEADER"/>.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Pointer to the <see cref="BITMAPINFO"/> structure for the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetInfo")]
+		public static extern IntPtr GetInfo(FIBITMAP dib);
+
+		/// <summary>
+		/// Investigates the color type of the bitmap by reading the bitmap's pixel bits and analysing them.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The color type of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetColorType")]
+		public static extern FREE_IMAGE_COLOR_TYPE GetColorType(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a bit pattern describing the red color component of a pixel in a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The bit pattern for RED.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetRedMask")]
+		public static extern uint GetRedMask(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a bit pattern describing the green color component of a pixel in a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The bit pattern for green.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetGreenMask")]
+		public static extern uint GetGreenMask(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a bit pattern describing the blue color component of a pixel in a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The bit pattern for blue.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBlueMask")]
+		public static extern uint GetBlueMask(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the number of transparent colors in a palletised bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The number of transparent colors in a palletised bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparencyCount")]
+		public static extern uint GetTransparencyCount(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns a pointer to the bitmap's transparency table.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Pointer to the bitmap's transparency table.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparencyTable")]
+		public static extern IntPtr GetTransparencyTable(FIBITMAP dib);
+
+		/// <summary>
+		/// Tells FreeImage if it should make use of the transparency table
+		/// or the alpha channel that may accompany a bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="enabled">True to enable the transparency, false to disable.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparent")]
+		public static extern void SetTransparent(FIBITMAP dib, bool enabled);
+
+		/// <summary>
+		/// Set the bitmap's transparency table. Only affects palletised bitmaps.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="table">Pointer to the bitmap's new transparency table.</param>
+		/// <param name="count">The number of transparent colors in the new transparency table.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparencyTable")]
+		internal static extern void SetTransparencyTable(FIBITMAP dib, byte[] table, int count);
+
+		/// <summary>
+		/// Returns whether the transparency table is enabled.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true when the transparency table is enabled (1-, 4- or 8-bit images)
+		/// or when the input dib contains alpha values (32-bit images). Returns false otherwise.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_IsTransparent")]
+		public static extern bool IsTransparent(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns whether the bitmap has a file background color.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true when the image has a file background color, false otherwise.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_HasBackgroundColor")]
+		public static extern bool HasBackgroundColor(FIBITMAP dib);
+
+		/// <summary>
+		/// Returns the file background color of an image.
+		/// For 8-bit images, the color index in the palette is returned in the
+		/// rgbReserved member of the bkcolor parameter.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="bkcolor">The background color.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetBackgroundColor")]
+		public static extern bool GetBackgroundColor(FIBITMAP dib, out RGBQUAD bkcolor);
+
+		/// <summary>
+		/// Set the file background color of an image.
+		/// When saving an image to PNG, this background color is transparently saved to the PNG file.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="bkcolor">The new background color.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetBackgroundColor")]
+		public static unsafe extern bool SetBackgroundColor(FIBITMAP dib, ref RGBQUAD bkcolor);
+
+		/// <summary>
+		/// Set the file background color of an image.
+		/// When saving an image to PNG, this background color is transparently saved to the PNG file.
+		/// When the bkcolor parameter is null, the background color is removed from the image.
+		/// <para>
+		/// This overloaded version of the function with an array parameter is provided to allow
+		/// passing <c>null</c> in the <paramref name="bkcolor"/> parameter. This is similar to the
+		/// original C/C++ function. Passing <c>null</c> as <paramref name="bkcolor"/> parameter will
+		/// unset the dib's previously set background color.
+		/// </para> 
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="bkcolor">The new background color.
+		/// The first entry in the array is used.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <example>
+		/// <code>
+		/// // create a RGBQUAD color
+		/// RGBQUAD color = new RGBQUAD(Color.Green);
+		/// 
+		/// // set the dib's background color (using the other version of the function)
+		/// FreeImage.SetBackgroundColor(dib, ref color);
+		/// 
+		/// // remove it again (this only works due to the array parameter RGBQUAD[])
+		/// FreeImage.SetBackgroundColor(dib, null);
+		/// </code>
+		/// </example>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetBackgroundColor")]
+		public static unsafe extern bool SetBackgroundColor(FIBITMAP dib, RGBQUAD[] bkcolor);
+
+		/// <summary>
+		/// Sets the index of the palette entry to be used as transparent color
+		/// for the image specified. Does nothing on high color images.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="index">The index of the palette entry to be set as transparent color.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTransparentIndex")]
+		public static extern void SetTransparentIndex(FIBITMAP dib, int index);
+
+		/// <summary>
+		/// Returns the palette entry used as transparent color for the image specified.
+		/// Works for palletised images only and returns -1 for high color
+		/// images or if the image has no color set to be transparent.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>the index of the palette entry used as transparent color for
+		/// the image specified or -1 if there is no transparent color found
+		/// (e.g. the image is a high color image).</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTransparentIndex")]
+		public static extern int GetTransparentIndex(FIBITMAP dib);
+
+		#endregion
+
+		#region ICC profile functions
+
+		/// <summary>
+		/// Retrieves the <see cref="FIICCPROFILE"/> data of the bitmap.
+		/// This function can also be called safely, when the original format does not support profiles.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The <see cref="FIICCPROFILE"/> data of the bitmap.</returns>
+		public static FIICCPROFILE GetICCProfileEx(FIBITMAP dib) { unsafe { return *(FIICCPROFILE*)FreeImage.GetICCProfile(dib); } }
+
+		/// <summary>
+		/// Retrieves a pointer to the <see cref="FIICCPROFILE"/> data of the bitmap.
+		/// This function can also be called safely, when the original format does not support profiles.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Pointer to the <see cref="FIICCPROFILE"/> data of the bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetICCProfile")]
+		public static extern IntPtr GetICCProfile(FIBITMAP dib);
+
+		/// <summary>
+		/// Creates a new <see cref="FIICCPROFILE"/> block from ICC profile data previously read from a file
+		/// or built by a color management system. The profile data is attached to the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="data">Pointer to the new <see cref="FIICCPROFILE"/> data.</param>
+		/// <param name="size">Size of the <see cref="FIICCPROFILE"/> data.</param>
+		/// <returns>Pointer to the created <see cref="FIICCPROFILE"/> structure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CreateICCProfile")]
+		public static extern IntPtr CreateICCProfile(FIBITMAP dib, byte[] data, int size);
+
+		/// <summary>
+		/// This function destroys an <see cref="FIICCPROFILE"/> previously created by <see cref="CreateICCProfile(FIBITMAP,byte[],int)"/>.
+		/// After this call the bitmap will contain no profile information.
+		/// This function should be called to ensure that a stored bitmap will not contain any profile information.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DestroyICCProfile")]
+		public static extern void DestroyICCProfile(FIBITMAP dib);
+
+		#endregion
+
+		#region Conversion functions
+
+		/// <summary>
+		/// Converts a bitmap to 4 bits.
+		/// If the bitmap was a high-color bitmap (16, 24 or 32-bit) or if it was a
+		/// monochrome or greyscale bitmap (1 or 8-bit), the end result will be a
+		/// greyscale bitmap, otherwise (1-bit palletised bitmaps) it will be a palletised bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo4Bits")]
+		public static extern FIBITMAP ConvertTo4Bits(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to 8 bits. If the bitmap was a high-color bitmap (16, 24 or 32-bit)
+		/// or if it was a monochrome or greyscale bitmap (1 or 4-bit), the end result will be a
+		/// greyscale bitmap, otherwise (1 or 4-bit palletised bitmaps) it will be a palletised bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo8Bits")]
+		public static extern FIBITMAP ConvertTo8Bits(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to a 8-bit greyscale image with a linear ramp.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToGreyscale")]
+		public static extern FIBITMAP ConvertToGreyscale(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to 16 bits, where each pixel has a color pattern of
+		/// 5 bits red, 5 bits green and 5 bits blue. One bit in each pixel is unused.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo16Bits555")]
+		public static extern FIBITMAP ConvertTo16Bits555(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to 16 bits, where each pixel has a color pattern of
+		/// 5 bits red, 6 bits green and 5 bits blue.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo16Bits565")]
+		public static extern FIBITMAP ConvertTo16Bits565(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to 24 bits. A clone of the input bitmap is returned for 24-bit bitmaps.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo24Bits")]
+		public static extern FIBITMAP ConvertTo24Bits(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a bitmap to 32 bits. A clone of the input bitmap is returned for 32-bit bitmaps.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertTo32Bits")]
+		public static extern FIBITMAP ConvertTo32Bits(FIBITMAP dib);
+
+		/// <summary>
+		/// Quantizes a high-color 24-bit bitmap to an 8-bit palette color bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ColorQuantize")]
+		public static extern FIBITMAP ColorQuantize(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize);
+
+		/// <summary>
+		/// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/> method that
+		/// provides additional options used to quantize a 24-bit image to any
+		/// number of colors (up to 256), as well as quantize a 24-bit image using a
+		/// partial or full provided palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
+		/// <param name="PaletteSize">Size of the desired output palette.</param>
+		/// <param name="ReserveSize">Size of the provided palette of ReservePalette.</param>
+		/// <param name="ReservePalette">The provided palette.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ColorQuantizeEx")]
+		public static extern FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, int ReserveSize, RGBQUAD[] ReservePalette);
+
+		/// <summary>
+		/// Converts a bitmap to 1-bit monochrome bitmap using a threshold T between [0..255].
+		/// The function first converts the bitmap to a 8-bit greyscale bitmap.
+		/// Then, any brightness level that is less than T is set to zero, otherwise to 1.
+		/// For 1-bit input bitmaps, the function clones the input bitmap and builds a monochrome palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="t">The threshold.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Threshold")]
+		public static extern FIBITMAP Threshold(FIBITMAP dib, byte t);
+
+		/// <summary>
+		/// Converts a bitmap to 1-bit monochrome bitmap using a dithering algorithm.
+		/// For 1-bit input bitmaps, the function clones the input bitmap and builds a monochrome palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="algorithm">The dithering algorithm to use.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Dither")]
+		public static extern FIBITMAP Dither(FIBITMAP dib, FREE_IMAGE_DITHER algorithm);
+
+		/// <summary>
+		/// Converts a raw bitmap to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="bits">Pointer to the memory block containing the raw bitmap.</param>
+		/// <param name="width">The width in pixels of the raw bitmap.</param>
+		/// <param name="height">The height in pixels of the raw bitmap.</param>
+		/// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
+		/// including padding bytes.</param>
+		/// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertFromRawBits")]
+		public static extern FIBITMAP ConvertFromRawBits(IntPtr bits, int width, int height, int pitch,
+			uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+		/// <summary>
+		/// Converts a raw bitmap to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="bits">Array of bytes containing the raw bitmap.</param>
+		/// <param name="width">The width in pixels of the raw bitmap.</param>
+		/// <param name="height">The height in pixels of the raw bitmap.</param>
+		/// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
+		/// including padding bytes.</param>
+		/// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertFromRawBits")]
+		public static extern FIBITMAP ConvertFromRawBits(byte[] bits, int width, int height, int pitch,
+			uint bpp, uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+		/// <summary>
+		/// Converts a FreeImage bitmap to a raw bitmap, that is a raw piece of memory.
+		/// </summary>
+		/// <param name="bits">Pointer to the memory block receiving the raw bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="pitch">The desired total width in bytes of a scanline in the raw bitmap,
+		/// including any padding bytes.</param>
+		/// <param name="bpp">The desired bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The desired bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The desired bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The desired bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap will be stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRawBits")]
+		public static extern void ConvertToRawBits(IntPtr bits, FIBITMAP dib, int pitch, uint bpp,
+			uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+		/// <summary>
+		/// Converts a FreeImage bitmap to a raw bitmap, that is a raw piece of memory.
+		/// </summary>
+		/// <param name="bits">Array of bytes receiving the raw bitmap.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="pitch">The desired total width in bytes of a scanline in the raw bitmap,
+		/// including any padding bytes.</param>
+		/// <param name="bpp">The desired bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The desired bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The desired bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The desired bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap will be stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRawBits")]
+		public static extern void ConvertToRawBits(byte[] bits, FIBITMAP dib, int pitch, uint bpp,
+			uint red_mask, uint green_mask, uint blue_mask, bool topdown);
+
+		/// <summary>
+		/// Converts a 24- or 32-bit RGB(A) standard image or a 48-bit RGB image to a FIT_RGBF type image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToRGBF")]
+		public static extern FIBITMAP ConvertToRGBF(FIBITMAP dib);
+
+		/// <summary>
+		/// Converts a non standard image whose color type is FIC_MINISBLACK
+		/// to a standard 8-bit greyscale image.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="scale_linear">When true the conversion is done by scaling linearly
+		/// each pixel value from [min, max] to an integer value between [0..255],
+		/// where min and max are the minimum and maximum pixel values in the image.
+		/// When false the conversion is done by rounding each pixel value to an integer between [0..255].
+		///
+		/// Rounding is done using the following formula:
+		///
+		/// dst_pixel = (BYTE) MIN(255, MAX(0, q)) where int q = int(src_pixel + 0.5);</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToStandardType")]
+		public static extern FIBITMAP ConvertToStandardType(FIBITMAP src, bool scale_linear);
+
+		/// <summary>
+		/// Converts an image of any type to type dst_type.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="dst_type">Destination type.</param>
+		/// <param name="scale_linear">True to scale linear, else false.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ConvertToType")]
+		public static extern FIBITMAP ConvertToType(FIBITMAP src, FREE_IMAGE_TYPE dst_type, bool scale_linear);
+
+		#endregion
+
+		#region Tone mapping operators
+
+		/// <summary>
+		/// Converts a High Dynamic Range image (48-bit RGB or 96-bit RGBF) to a 24-bit RGB image, suitable for display.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="tmo">The tone mapping operator to be used.</param>
+		/// <param name="first_param">Parmeter depending on the used algorithm</param>
+		/// <param name="second_param">Parmeter depending on the used algorithm</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ToneMapping")]
+		public static extern FIBITMAP ToneMapping(FIBITMAP dib, FREE_IMAGE_TMO tmo, double first_param, double second_param);
+
+		/// <summary>
+		/// Converts a High Dynamic Range image to a 24-bit RGB image using a global
+		/// operator based on logarithmic compression of luminance values, imitating the human response to light.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="gamma">A gamma correction that is applied after the tone mapping.
+		/// A value of 1 means no correction.</param>
+		/// <param name="exposure">Scale factor allowing to adjust the brightness of the output image.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoDrago03")]
+		public static extern FIBITMAP TmoDrago03(FIBITMAP src, double gamma, double exposure);
+
+		/// <summary>
+		/// Converts a High Dynamic Range image to a 24-bit RGB image using a global operator inspired
+		/// by photoreceptor physiology of the human visual system.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="intensity">Controls the overall image intensity in the range [-8, 8].</param>
+		/// <param name="contrast">Controls the overall image contrast in the range [0.3, 1.0[.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoReinhard05")]
+		public static extern FIBITMAP TmoReinhard05(FIBITMAP src, double intensity, double contrast);
+
+		/// <summary>
+		/// Apply the Gradient Domain High Dynamic Range Compression to a RGBF image and convert to 24-bit RGB.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="color_saturation">Color saturation (s parameter in the paper) in [0.4..0.6]</param>
+		/// <param name="attenuation">Atenuation factor (beta parameter in the paper) in [0.8..0.9]</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_TmoFattal02")]
+		public static extern FIBITMAP TmoFattal02(FIBITMAP src, double color_saturation, double attenuation);
+
+		#endregion
+
+		#region Compression functions
+
+		/// <summary>
+		/// Compresses a source buffer into a target buffer, using the ZLib library.
+		/// </summary>
+		/// <param name="target">Pointer to the target buffer.</param>
+		/// <param name="target_size">Size of the target buffer.
+		/// Must be at least 0.1% larger than source_size plus 12 bytes.</param>
+		/// <param name="source">Pointer to the source buffer.</param>
+		/// <param name="source_size">Size of the source buffer.</param>
+		/// <returns>The actual size of the compressed buffer, or 0 if an error occurred.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibCompress")]
+		public static extern uint ZLibCompress(byte[] target, uint target_size, byte[] source, uint source_size);
+
+		/// <summary>
+		/// Decompresses a source buffer into a target buffer, using the ZLib library.
+		/// </summary>
+		/// <param name="target">Pointer to the target buffer.</param>
+		/// <param name="target_size">Size of the target buffer.
+		/// Must have been saved outlide of zlib.</param>
+		/// <param name="source">Pointer to the source buffer.</param>
+		/// <param name="source_size">Size of the source buffer.</param>
+		/// <returns>The actual size of the uncompressed buffer, or 0 if an error occurred.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibUncompress")]
+		public static extern uint ZLibUncompress(byte[] target, uint target_size, byte[] source, uint source_size);
+
+		/// <summary>
+		/// Compresses a source buffer into a target buffer, using the ZLib library.
+		/// </summary>
+		/// <param name="target">Pointer to the target buffer.</param>
+		/// <param name="target_size">Size of the target buffer.
+		/// Must be at least 0.1% larger than source_size plus 24 bytes.</param>
+		/// <param name="source">Pointer to the source buffer.</param>
+		/// <param name="source_size">Size of the source buffer.</param>
+		/// <returns>The actual size of the compressed buffer, or 0 if an error occurred.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibGZip")]
+		public static extern uint ZLibGZip(byte[] target, uint target_size, byte[] source, uint source_size);
+
+		/// <summary>
+		/// Decompresses a source buffer into a target buffer, using the ZLib library.
+		/// </summary>
+		/// <param name="target">Pointer to the target buffer.</param>
+		/// <param name="target_size">Size of the target buffer.
+		/// Must have been saved outlide of zlib.</param>
+		/// <param name="source">Pointer to the source buffer.</param>
+		/// <param name="source_size">Size of the source buffer.</param>
+		/// <returns>The actual size of the uncompressed buffer, or 0 if an error occurred.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibGUnzip")]
+		public static extern uint ZLibGUnzip(byte[] target, uint target_size, byte[] source, uint source_size);
+
+		/// <summary>
+		/// Generates a CRC32 checksum.
+		/// </summary>
+		/// <param name="crc">The CRC32 checksum to begin with.</param>
+		/// <param name="source">Pointer to the source buffer.
+		/// If the value is 0, the function returns the required initial value for the crc.</param>
+		/// <param name="source_size">Size of the source buffer.</param>
+		/// <returns></returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ZLibCRC32")]
+		public static extern uint ZLibCRC32(uint crc, byte[] source, uint source_size);
+
+		#endregion
+
+		#region Tag creation and destruction
+
+		/// <summary>
+		/// Allocates a new <see cref="FITAG"/> object.
+		/// This object must be destroyed with a call to
+		/// <see cref="FreeImageAPI.FreeImage.DeleteTag(FITAG)"/> when no longer in use.
+		/// </summary>
+		/// <returns>The new <see cref="FITAG"/>.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CreateTag")]
+		public static extern FITAG CreateTag();
+
+		/// <summary>
+		/// Delete a previously allocated <see cref="FITAG"/> object.
+		/// </summary>
+		/// <param name="tag">The <see cref="FITAG"/> to destroy.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_DeleteTag")]
+		public static extern void DeleteTag(FITAG tag);
+
+		/// <summary>
+		/// Creates and returns a copy of a <see cref="FITAG"/> object.
+		/// </summary>
+		/// <param name="tag">The <see cref="FITAG"/> to clone.</param>
+		/// <returns>The new <see cref="FITAG"/>.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloneTag")]
+		public static extern FITAG CloneTag(FITAG tag);
+
+		#endregion
+
+		#region Tag accessors
+
+		/// <summary>
+		/// Returns the tag field name (unique inside a metadata model).
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The field name.</returns>
+		public static unsafe string GetTagKey(FITAG tag) { return PtrToStr(GetTagKey_(tag)); }
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetTagKey")]
+		private static unsafe extern byte* GetTagKey_(FITAG tag);
+
+		/// <summary>
+		/// Returns the tag description.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The description or NULL if unavailable.</returns>
+		public static unsafe string GetTagDescription(FITAG tag) { return PtrToStr(GetTagDescription_(tag)); }
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetTagDescription")]
+		private static unsafe extern byte* GetTagDescription_(FITAG tag);
+
+		/// <summary>
+		/// Returns the tag ID.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The ID or 0 if unavailable.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagID")]
+		public static extern ushort GetTagID(FITAG tag);
+
+		/// <summary>
+		/// Returns the tag data type.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The tag type.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagType")]
+		public static extern FREE_IMAGE_MDTYPE GetTagType(FITAG tag);
+
+		/// <summary>
+		/// Returns the number of components in the tag (in tag type units).
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The number of components.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagCount")]
+		public static extern uint GetTagCount(FITAG tag);
+
+		/// <summary>
+		/// Returns the length of the tag value in bytes.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>The length of the tag value.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagLength")]
+		public static extern uint GetTagLength(FITAG tag);
+
+		/// <summary>
+		/// Returns the tag value.
+		/// It is up to the programmer to interpret the returned pointer correctly,
+		/// according to the results of GetTagType and GetTagCount.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <returns>Pointer to the value.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetTagValue")]
+		public static extern IntPtr GetTagValue(FITAG tag);
+
+		/// <summary>
+		/// Sets the tag field name.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="key">The new name.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetTagKey")]
+		public static extern bool SetTagKey(FITAG tag, string key);
+
+		/// <summary>
+		/// Sets the tag description.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="description">The new description.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetTagDescription")]
+		public static extern bool SetTagDescription(FITAG tag, string description);
+
+		/// <summary>
+		/// Sets the tag ID.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="id">The new ID.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagID")]
+		public static extern bool SetTagID(FITAG tag, ushort id);
+
+		/// <summary>
+		/// Sets the tag data type.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="type">The new type.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagType")]
+		public static extern bool SetTagType(FITAG tag, FREE_IMAGE_MDTYPE type);
+
+		/// <summary>
+		/// Sets the number of data in the tag.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="count">New number of data.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagCount")]
+		public static extern bool SetTagCount(FITAG tag, uint count);
+
+		/// <summary>
+		/// Sets the length of the tag value in bytes.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="length">The new length.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagLength")]
+		public static extern bool SetTagLength(FITAG tag, uint length);
+
+		/// <summary>
+		/// Sets the tag value.
+		/// </summary>
+		/// <param name="tag">The tag field.</param>
+		/// <param name="value">Pointer to the new value.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetTagValue")]
+		public static extern bool SetTagValue(FITAG tag, byte[] value);
+
+		#endregion
+
+		#region Metadata iterator
+
+		/// <summary>
+		/// Provides information about the first instance of a tag that matches the metadata model.
+		/// </summary>
+		/// <param name="model">The model to match.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="tag">Tag that matches the metadata model.</param>
+		/// <returns>Unique search handle that can be used to call FindNextMetadata or FindCloseMetadata.
+		/// Null if the metadata model does not exist.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindFirstMetadata")]
+		public static extern FIMETADATA FindFirstMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, out FITAG tag);
+
+		/// <summary>
+		/// Find the next tag, if any, that matches the metadata model argument in a previous call
+		/// to FindFirstMetadata, and then alters the tag object contents accordingly.
+		/// </summary>
+		/// <param name="mdhandle">Unique search handle provided by FindFirstMetadata.</param>
+		/// <param name="tag">Tag that matches the metadata model.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindNextMetadata")]
+		public static extern bool FindNextMetadata(FIMETADATA mdhandle, out FITAG tag);
+
+		/// <summary>
+		/// Closes the specified metadata search handle and releases associated resources.
+		/// </summary>
+		/// <param name="mdhandle">The handle to close.</param>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FindCloseMetadata")]
+		private static extern void FindCloseMetadata_(FIMETADATA mdhandle);
+
+		#endregion
+
+		#region Metadata setter and getter
+
+		/// <summary>
+		/// Retrieve a metadata attached to a dib.
+		/// </summary>
+		/// <param name="model">The metadata model to look for.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="key">The metadata field name.</param>
+		/// <param name="tag">A FITAG structure returned by the function.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_GetMetadata")]
+		public static extern bool GetMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, string key, out FITAG tag);
+
+		/// <summary>
+		/// Attach a new FreeImage tag to a dib.
+		/// </summary>
+		/// <param name="model">The metadata model used to store the tag.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="key">The tag field name.</param>
+		/// <param name="tag">The FreeImage tag to be attached.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_SetMetadata")]
+		public static extern bool SetMetadata(FREE_IMAGE_MDMODEL model, FIBITMAP dib, string key, FITAG tag);
+
+		#endregion
+
+		#region Metadata helper functions
+
+		/// <summary>
+		/// Returns the number of tags contained in the model metadata model attached to the input dib.
+		/// </summary>
+		/// <param name="model">The metadata model.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Number of tags contained in the metadata model.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetMetadataCount")]
+		public static extern uint GetMetadataCount(FREE_IMAGE_MDMODEL model, FIBITMAP dib);
+
+		/// <summary>
+		/// Copies the metadata of FreeImage bitmap to another.
+		/// </summary>
+		/// <param name="dst">The FreeImage bitmap to copy the metadata to.</param>
+		/// <param name="src">The FreeImage bitmap to copy the metadata from.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_CloneMetadata")]
+		public static extern bool CloneMetadata(FIBITMAP dst, FIBITMAP src);
+
+		/// <summary>
+		/// Converts a FreeImage tag structure to a string that represents the interpreted tag value.
+		/// The function is not thread safe.
+		/// </summary>
+		/// <param name="model">The metadata model.</param>
+		/// <param name="tag">The interpreted tag value.</param>
+		/// <param name="Make">Reserved.</param>
+		/// <returns>The representing string.</returns>
+		public static unsafe string TagToString(FREE_IMAGE_MDMODEL model, FITAG tag, uint Make) { return PtrToStr(TagToString_(model, tag, Make)); }
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_TagToString")]
+		private static unsafe extern byte* TagToString_(FREE_IMAGE_MDMODEL model, FITAG tag, uint Make);
+
+		#endregion
+
+		#region Rotation and flipping
+
+		/// <summary>
+		/// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
+		/// 1-bit images rotation is limited to integer multiple of 90°.
+		/// <c>null</c> is returned for other values.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="angle">The angle of rotation.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_RotateClassic")]
+		[Obsolete("RotateClassic is deprecated (use Rotate instead).")]
+		public static extern FIBITMAP RotateClassic(FIBITMAP dib, double angle);
+
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Rotate")]
+		internal static extern FIBITMAP Rotate(FIBITMAP dib, double angle, IntPtr backgroundColor);
+
+		/// <summary>
+		/// This function performs a rotation and / or translation of an 8-bit greyscale,
+		/// 24- or 32-bit image, using a 3rd order (cubic) B-Spline.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="angle">The angle of rotation.</param>
+		/// <param name="x_shift">Horizontal image translation.</param>
+		/// <param name="y_shift">Vertical image translation.</param>
+		/// <param name="x_origin">Rotation center x-coordinate.</param>
+		/// <param name="y_origin">Rotation center y-coordinate.</param>
+		/// <param name="use_mask">When true the irrelevant part of the image is set to a black color,
+		/// otherwise, a mirroring technique is used to fill irrelevant pixels.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_RotateEx")]
+		public static extern FIBITMAP RotateEx(FIBITMAP dib, double angle,
+			double x_shift, double y_shift, double x_origin, double y_origin, bool use_mask);
+
+		/// <summary>
+		/// Flip the input dib horizontally along the vertical axis.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FlipHorizontal")]
+		public static extern bool FlipHorizontal(FIBITMAP dib);
+
+		/// <summary>
+		/// Flip the input dib vertically along the horizontal axis.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FlipVertical")]
+		public static extern bool FlipVertical(FIBITMAP dib);
+
+		/// <summary>
+		/// Performs a lossless rotation or flipping on a JPEG file.
+		/// </summary>
+		/// <param name="src_file">Source file.</param>
+		/// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
+		/// <param name="operation">The operation to apply.</param>
+		/// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool JPEGTransform(string src_file, string dst_file,
+			FREE_IMAGE_JPEG_OPERATION operation, bool perfect)
+		{
+			if (SupportsUnicode)
+			{
+				return JPEGTransformU(src_file, dst_file, operation, perfect);
+			}
+			else
+			{
+				return JPEGTransformA(src_file, dst_file, operation, perfect);
+			}
+		}
+
+		/// <summary>
+		/// Performs a lossless rotation or flipping on a JPEG file.
+		/// </summary>
+		/// <param name="src_file">Source file.</param>
+		/// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
+		/// <param name="operation">The operation to apply.</param>
+		/// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_JPEGTransform")]
+		private static extern bool JPEGTransformA(string src_file, string dst_file,
+			FREE_IMAGE_JPEG_OPERATION operation, bool perfect);
+
+		/// <summary>
+		/// Performs a lossless rotation or flipping on a JPEG file.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="src_file">Source file.</param>
+		/// <param name="dst_file">Destination file; can be the source file; will be overwritten.</param>
+		/// <param name="operation">The operation to apply.</param>
+		/// <param name="perfect">To avoid lossy transformation, you can set the perfect parameter to true.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_JPEGTransformU")]
+		private static extern bool JPEGTransformU(string src_file, string dst_file,
+			FREE_IMAGE_JPEG_OPERATION operation, bool perfect);
+
+		#endregion
+
+		#region Upsampling / downsampling
+
+		/// <summary>
+		/// Performs resampling (or scaling, zooming) of a greyscale or RGB(A) image
+		/// to the desired destination width and height.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="dst_width">Destination width.</param>
+		/// <param name="dst_height">Destination height.</param>
+		/// <param name="filter">The filter to apply.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Rescale")]
+		public static extern FIBITMAP Rescale(FIBITMAP dib, int dst_width, int dst_height, FREE_IMAGE_FILTER filter);
+
+		/// <summary>
+		/// Creates a thumbnail from a greyscale or RGB(A) image, keeping aspect ratio.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="max_pixel_size">Thumbnail square size.</param>
+		/// <param name="convert">When true HDR images are transperantly converted to standard images.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MakeThumbnail")]
+		public static extern FIBITMAP MakeThumbnail(FIBITMAP dib, int max_pixel_size, bool convert);
+
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_EnlargeCanvas")]
+		internal static extern FIBITMAP EnlargeCanvas(FIBITMAP dib,
+			int left, int top, int right, int bottom, IntPtr color, FREE_IMAGE_COLOR_OPTIONS options);
+
+		#endregion
+
+		#region Color manipulation
+
+		/// <summary>
+		/// Perfoms an histogram transformation on a 8-, 24- or 32-bit image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="lookUpTable">The lookup table.
+		/// It's size is assumed to be 256 in length.</param>
+		/// <param name="channel">The color channel to be transformed.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustCurve")]
+		public static extern bool AdjustCurve(FIBITMAP dib, byte[] lookUpTable, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		/// <summary>
+		/// Performs gamma correction on a 8-, 24- or 32-bit image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="gamma">The parameter represents the gamma value to use (gamma > 0).
+		/// A value of 1.0 leaves the image alone, less than one darkens it, and greater than one lightens it.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustGamma")]
+		public static extern bool AdjustGamma(FIBITMAP dib, double gamma);
+
+		/// <summary>
+		/// Adjusts the brightness of a 8-, 24- or 32-bit image by a certain amount.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="percentage">A value 0 means no change,
+		/// less than 0 will make the image darker and greater than 0 will make the image brighter.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustBrightness")]
+		public static extern bool AdjustBrightness(FIBITMAP dib, double percentage);
+
+		/// <summary>
+		/// Adjusts the contrast of a 8-, 24- or 32-bit image by a certain amount.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="percentage">A value 0 means no change,
+		/// less than 0 will decrease the contrast and greater than 0 will increase the contrast of the image.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustContrast")]
+		public static extern bool AdjustContrast(FIBITMAP dib, double percentage);
+
+		/// <summary>
+		/// Inverts each pixel data.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Invert")]
+		public static extern bool Invert(FIBITMAP dib);
+
+		/// <summary>
+		/// Computes the image histogram.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="histo">Array of integers with a size of 256.</param>
+		/// <param name="channel">Channel to compute from.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetHistogram")]
+		public static extern bool GetHistogram(FIBITMAP dib, int[] histo, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		#endregion
+
+		#region Channel processing
+
+		/// <summary>
+		/// Retrieves the red, green, blue or alpha channel of a 24- or 32-bit image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="channel">The color channel to extract.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetChannel")]
+		public static extern FIBITMAP GetChannel(FIBITMAP dib, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		/// <summary>
+		/// Insert a 8-bit dib into a 24- or 32-bit image.
+		/// Both images must have to same width and height.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="dib8">Handle to the bitmap to insert.</param>
+		/// <param name="channel">The color channel to replace.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetChannel")]
+		public static extern bool SetChannel(FIBITMAP dib, FIBITMAP dib8, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		/// <summary>
+		/// Retrieves the real part, imaginary part, magnitude or phase of a complex image.
+		/// </summary>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="channel">The color channel to extract.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetComplexChannel")]
+		public static extern FIBITMAP GetComplexChannel(FIBITMAP src, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		/// <summary>
+		/// Set the real or imaginary part of a complex image.
+		/// Both images must have to same width and height.
+		/// </summary>
+		/// <param name="dst">Handle to a FreeImage bitmap.</param>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="channel">The color channel to replace.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SetComplexChannel")]
+		public static extern bool SetComplexChannel(FIBITMAP dst, FIBITMAP src, FREE_IMAGE_COLOR_CHANNEL channel);
+
+		#endregion
+
+		#region Copy / Paste / Composite routines
+
+		/// <summary>
+		/// Copy a sub part of the current dib image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="left">Specifies the left position of the cropped rectangle.</param>
+		/// <param name="top">Specifies the top position of the cropped rectangle.</param>
+		/// <param name="right">Specifies the right position of the cropped rectangle.</param>
+		/// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Copy")]
+		public static extern FIBITMAP Copy(FIBITMAP dib, int left, int top, int right, int bottom);
+
+		/// <summary>
+		/// Alpha blend or combine a sub part image with the current dib image.
+		/// The bit depth of the dst bitmap must be greater than or equal to the bit depth of the src.
+		/// </summary>
+		/// <param name="dst">Handle to a FreeImage bitmap.</param>
+		/// <param name="src">Handle to a FreeImage bitmap.</param>
+		/// <param name="left">Specifies the left position of the sub image.</param>
+		/// <param name="top">Specifies the top position of the sub image.</param>
+		/// <param name="alpha">alpha blend factor.
+		/// The source and destination images are alpha blended if alpha=0..255.
+		/// If alpha > 255, then the source image is combined to the destination image.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Paste")]
+		public static extern bool Paste(FIBITMAP dst, FIBITMAP src, int left, int top, int alpha);
+
+		/// <summary>
+		/// This function composite a transparent foreground image against a single background color or
+		/// against a background image.
+		/// </summary>
+		/// <param name="fg">Handle to a FreeImage bitmap.</param>
+		/// <param name="useFileBkg">When true the background of fg is used if it contains one.</param>
+		/// <param name="appBkColor">The application background is used if useFileBkg is false.</param>
+		/// <param name="bg">Image used as background when useFileBkg is false or fg has no background
+		/// and appBkColor is null.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Composite")]
+		public static extern FIBITMAP Composite(FIBITMAP fg, bool useFileBkg, ref RGBQUAD appBkColor, FIBITMAP bg);
+
+		/// <summary>
+		/// This function composite a transparent foreground image against a single background color or
+		/// against a background image.
+		/// </summary>
+		/// <param name="fg">Handle to a FreeImage bitmap.</param>
+		/// <param name="useFileBkg">When true the background of fg is used if it contains one.</param>
+		/// <param name="appBkColor">The application background is used if useFileBkg is false
+		/// and 'appBkColor' is not null.</param>
+		/// <param name="bg">Image used as background when useFileBkg is false or fg has no background
+		/// and appBkColor is null.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_Composite")]
+		public static extern FIBITMAP Composite(FIBITMAP fg, bool useFileBkg, RGBQUAD[] appBkColor, FIBITMAP bg);
+
+		/// <summary>
+		/// Performs a lossless crop on a JPEG file.
+		/// </summary>
+		/// <param name="src_file">Source filename.</param>
+		/// <param name="dst_file">Destination filename.</param>
+		/// <param name="left">Specifies the left position of the cropped rectangle.</param>
+		/// <param name="top">Specifies the top position of the cropped rectangle.</param>
+		/// <param name="right">Specifies the right position of the cropped rectangle.</param>
+		/// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool JPEGCrop(string src_file, string dst_file, int left, int top, int right, int bottom)
+		{
+			if (SupportsUnicode)
+			{
+				return JPEGCropU(src_file, dst_file, left, top, right, bottom);
+			}
+			else
+			{
+				return JPEGCropA(src_file, dst_file, left, top, right, bottom);
+			}
+		}
+
+		/// <summary>
+		/// Performs a lossless crop on a JPEG file.
+		/// </summary>
+		/// <param name="src_file">Source filename.</param>
+		/// <param name="dst_file">Destination filename.</param>
+		/// <param name="left">Specifies the left position of the cropped rectangle.</param>
+		/// <param name="top">Specifies the top position of the cropped rectangle.</param>
+		/// <param name="right">Specifies the right position of the cropped rectangle.</param>
+		/// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Ansi, EntryPoint = "FreeImage_JPEGCrop")]
+		private static extern bool JPEGCropA(string src_file, string dst_file, int left, int top, int right, int bottom);
+
+		/// <summary>
+		/// Performs a lossless crop on a JPEG file.
+		/// Supports UNICODE filenames.
+		/// </summary>
+		/// <param name="src_file">Source filename.</param>
+		/// <param name="dst_file">Destination filename.</param>
+		/// <param name="left">Specifies the left position of the cropped rectangle.</param>
+		/// <param name="top">Specifies the top position of the cropped rectangle.</param>
+		/// <param name="right">Specifies the right position of the cropped rectangle.</param>
+		/// <param name="bottom">Specifies the bottom position of the cropped rectangle.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, CharSet = CharSet.Unicode, EntryPoint = "FreeImage_JPEGCropU")]
+		private static extern bool JPEGCropU(string src_file, string dst_file, int left, int top, int right, int bottom);
+
+		/// <summary>
+		/// Applies the alpha value of each pixel to its color components.
+		/// The aplha value stays unchanged.
+		/// Only works with 32-bits color depth.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_PreMultiplyWithAlpha")]
+		public static extern bool PreMultiplyWithAlpha(FIBITMAP dib);
+
+		#endregion
+
+		#region Miscellaneous algorithms
+
+		/// <summary>
+		/// Solves a Poisson equation, remap result pixels to [0..1] and returns the solution.
+		/// </summary>
+		/// <param name="Laplacian">Handle to a FreeImage bitmap.</param>
+		/// <param name="ncycle">Number of cycles in the multigrid algorithm (usually 2 or 3)</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_MultigridPoissonSolver")]
+		public static extern FIBITMAP MultigridPoissonSolver(FIBITMAP Laplacian, int ncycle);
+
+		#endregion
+
+		#region Colors
+
+		/// <summary>
+		/// Creates a lookup table to be used with <see cref="AdjustCurve"/> which may adjusts brightness and
+		/// contrast, correct gamma and invert the image with a single call to <see cref="AdjustCurve"/>.
+		/// </summary>
+		/// <param name="lookUpTable">Output lookup table to be used with <see cref="AdjustCurve"/>.
+		/// The size of 'lookUpTable' is assumed to be 256.</param>
+		/// <param name="brightness">Percentage brightness value where -100 &lt;= brightness &lt;= 100.
+		/// <para>A value of 0 means no change, less than 0 will make the image darker and greater
+		/// than 0 will make the image brighter.</para></param>
+		/// <param name="contrast">Percentage contrast value where -100 &lt;= contrast &lt;= 100.
+		/// <para>A value of 0 means no change, less than 0 will decrease the contrast
+		/// and greater than 0 will increase the contrast of the image.</para></param>
+		/// <param name="gamma">Gamma value to be used for gamma correction.
+		/// <para>A value of 1.0 leaves the image alone, less than one darkens it,
+		/// and greater than one lightens it.</para></param>
+		/// <param name="invert">If set to true, the image will be inverted.</param>
+		/// <returns>The number of adjustments applied to the resulting lookup table
+		/// compared to a blind lookup table.</returns>
+		/// <remarks>
+		/// This function creates a lookup table to be used with <see cref="AdjustCurve"/> which may adjust
+		/// brightness and contrast, correct gamma and invert the image with a single call to
+		/// <see cref="AdjustCurve"/>. If more than one of these image display properties need to be adjusted,
+		/// using a combined lookup table should be preferred over calling each adjustment function
+		/// separately. That's particularly true for huge images or if performance is an issue. Then,
+		/// the expensive process of iterating over all pixels of an image is performed only once and
+		/// not up to four times.
+		/// <para/>
+		/// Furthermore, the lookup table created does not depend on the order, in which each single
+		/// adjustment operation is performed. Due to rounding and byte casting issues, it actually
+		/// matters in which order individual adjustment operations are performed. Both of the following
+		/// snippets most likely produce different results:
+		/// <para/>
+		/// <code>
+		/// // snippet 1: contrast, brightness
+		/// AdjustContrast(dib, 15.0);
+		/// AdjustBrightness(dib, 50.0); 
+		/// </code>
+		/// <para/>
+		/// <code>
+		/// // snippet 2: brightness, contrast
+		/// AdjustBrightness(dib, 50.0);
+		/// AdjustContrast(dib, 15.0);
+		/// </code>
+		/// <para/>
+		/// Better and even faster would be snippet 3:
+		/// <para/>
+		/// <code>
+		/// // snippet 3:
+		/// byte[] lut = new byte[256];
+		/// GetAdjustColorsLookupTable(lut, 50.0, 15.0, 1.0, false);
+		/// AdjustCurve(dib, lut, FREE_IMAGE_COLOR_CHANNEL.FICC_RGB);
+		/// </code>
+		/// <para/>
+		/// This function is also used internally by <see cref="AdjustColors"/>, which does not return the
+		/// lookup table, but uses it to call <see cref="AdjustCurve"/> on the passed image.
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_GetAdjustColorsLookupTable")]
+		public static extern int GetAdjustColorsLookupTable(byte[] lookUpTable, double brightness, double contrast, double gamma, bool invert);
+
+		/// <summary>
+		/// Adjusts an image's brightness, contrast and gamma as well as it may
+		/// optionally invert the image within a single operation.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="brightness">Percentage brightness value where -100 &lt;= brightness &lt;= 100.
+		/// <para>A value of 0 means no change, less than 0 will make the image darker and greater
+		/// than 0 will make the image brighter.</para></param>
+		/// <param name="contrast">Percentage contrast value where -100 &lt;= contrast &lt;= 100.
+		/// <para>A value of 0 means no change, less than 0 will decrease the contrast
+		/// and greater than 0 will increase the contrast of the image.</para></param>
+		/// <param name="gamma">Gamma value to be used for gamma correction.
+		/// <para>A value of 1.0 leaves the image alone, less than one darkens it,
+		/// and greater than one lightens it.</para>
+		/// This parameter must not be zero or smaller than zero.
+		/// If so, it will be ignored and no gamma correction will be performed on the image.</param>
+		/// <param name="invert">If set to true, the image will be inverted.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <remarks>
+		/// This function adjusts an image's brightness, contrast and gamma as well as it
+		/// may optionally invert the image within a single operation. If more than one of
+		/// these image display properties need to be adjusted, using this function should
+		/// be preferred over calling each adjustment function separately. That's particularly
+		/// true for huge images or if performance is an issue.
+		/// <para/>
+		/// This function relies on <see cref="GetAdjustColorsLookupTable"/>,
+		/// which creates a single lookup table, that combines all adjustment operations requested.
+		/// <para/>
+		/// Furthermore, the lookup table created by <see cref="GetAdjustColorsLookupTable"/> does
+		/// not depend on the order, in which each single adjustment operation is performed.
+		/// Due to rounding and byte casting issues, it actually matters in which order individual
+		/// adjustment operations are performed. Both of the following snippets most likely produce
+		/// different results:
+		/// <para/>
+		/// <code>
+		/// // snippet 1: contrast, brightness
+		/// AdjustContrast(dib, 15.0);
+		/// AdjustBrightness(dib, 50.0);
+		/// </code>
+		/// <para/>
+		/// <code>
+		/// // snippet 2: brightness, contrast
+		/// AdjustBrightness(dib, 50.0);
+		/// AdjustContrast(dib, 15.0);
+		/// </code>
+		/// <para/>
+		/// Better and even faster would be snippet 3:
+		/// <para/>
+		/// <code>
+		/// // snippet 3:
+		/// AdjustColors(dib, 50.0, 15.0, 1.0, false);
+		/// </code>
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_AdjustColors")]
+		public static extern bool AdjustColors(FIBITMAP dib, double brightness, double contrast, double gamma, bool invert);
+
+		/// <summary>
+		/// Applies color mapping for one or several colors on a 1-, 4- or 8-bit
+		/// palletized or a 16-, 24- or 32-bit high color image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="srccolors">Array of colors to be used as the mapping source.</param>
+		/// <param name="dstcolors">Array of colors to be used as the mapping destination.</param>
+		/// <param name="count">The number of colors to be mapped. This is the size of both
+		/// srccolors and dstcolors.</param>
+		/// <param name="ignore_alpha">If true, 32-bit images and colors are treated as 24-bit.</param>
+		/// <param name="swap">If true, source and destination colors are swapped, that is,
+		/// each destination color is also mapped to the corresponding source color.</param>
+		/// <returns>The total number of pixels changed.</returns>
+		/// <remarks>
+		/// This function maps up to <paramref name="count"/> colors specified in
+		/// <paramref name="srccolors"/> to these specified in <paramref name="dstcolors"/>.
+		/// Thereby, color <i>srccolors[N]</i>, if found in the image, will be replaced by color
+		/// <i>dstcolors[N]</i>. If <paramref name="swap"/> is <b>true</b>, additionally all colors
+		/// specified in <paramref name="dstcolors"/> are also mapped to these specified
+		/// in <paramref name="srccolors"/>. For high color images, the actual image data will be
+		/// modified whereas, for palletized images only the palette will be changed.
+		/// <para/>
+		/// The function returns the number of pixels changed or zero, if no pixels were changed. 
+		/// <para/>
+		/// Both arrays <paramref name="srccolors"/> and <paramref name="dstcolors"/> are assumed
+		/// not to hold less than <paramref name="count"/> colors.
+		/// <para/>
+		/// For 16-bit images, all colors specified are transparently converted to their 
+		/// proper 16-bit representation (either in RGB555 or RGB565 format, which is determined
+		/// by the image's red- green- and blue-mask).
+		/// <para/>
+		/// <b>Note, that this behaviour is different from what <see cref="ApplyPaletteIndexMapping"/> does,
+		/// which modifies the actual image data on palletized images.</b>
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ApplyColorMapping")]
+		public static extern uint ApplyColorMapping(FIBITMAP dib, RGBQUAD[] srccolors, RGBQUAD[] dstcolors, uint count, bool ignore_alpha, bool swap);
+
+		/// <summary>
+		/// Swaps two specified colors on a 1-, 4- or 8-bit palletized
+		/// or a 16-, 24- or 32-bit high color image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="color_a">One of the two colors to be swapped.</param>
+		/// <param name="color_b">The other of the two colors to be swapped.</param>
+		/// <param name="ignore_alpha">If true, 32-bit images and colors are treated as 24-bit.</param>
+		/// <returns>The total number of pixels changed.</returns>
+		/// <remarks>
+		/// This function swaps the two specified colors <paramref name="color_a"/> and
+		/// <paramref name="color_b"/> on a palletized or high color image.
+		/// For high color images, the actual image data will be modified whereas, for palletized
+		/// images only the palette will be changed.
+		/// <para/>
+		/// <b>Note, that this behaviour is different from what <see cref="SwapPaletteIndices"/> does,
+		/// which modifies the actual image data on palletized images.</b>
+		/// <para/>
+		/// This is just a thin wrapper for <see cref="ApplyColorMapping"/> and resolves to:
+		/// <para/>
+		/// <code>
+		/// return ApplyColorMapping(dib, color_a, color_b, 1, ignore_alpha, true);
+		/// </code>
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SwapColors")]
+		public static extern uint SwapColors(FIBITMAP dib, ref RGBQUAD color_a, ref RGBQUAD color_b, bool ignore_alpha);
+
+		/// <summary>
+		/// Applies palette index mapping for one or several indices
+		/// on a 1-, 4- or 8-bit palletized image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="srcindices">Array of palette indices to be used as the mapping source.</param>
+		/// <param name="dstindices">Array of palette indices to be used as the mapping destination.</param>
+		/// <param name="count">The number of palette indices to be mapped. This is the size of both
+		/// srcindices and dstindices</param>
+		/// <param name="swap">If true, source and destination palette indices are swapped, that is,
+		/// each destination index is also mapped to the corresponding source index.</param>
+		/// <returns>The total number of pixels changed.</returns>
+		/// <remarks>
+		/// This function maps up to <paramref name="count"/> palette indices specified in
+		/// <paramref name="srcindices"/> to these specified in <paramref name="dstindices"/>.
+		/// Thereby, index <i>srcindices[N]</i>, if present in the image, will be replaced by index
+		/// <i>dstindices[N]</i>. If <paramref name="swap"/> is <b>true</b>, additionally all indices
+		/// specified in <paramref name="dstindices"/> are also mapped to these specified in 
+		/// <paramref name="srcindices"/>.
+		/// <para/>
+		/// The function returns the number of pixels changed or zero, if no pixels were changed.
+		/// Both arrays <paramref name="srcindices"/> and <paramref name="dstindices"/> are assumed not to
+		/// hold less than <paramref name="count"/> indices.
+		/// <para/>
+		/// <b>Note, that this behaviour is different from what <see cref="ApplyColorMapping"/> does, which
+		/// modifies the actual image data on palletized images.</b>
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_ApplyPaletteIndexMapping")]
+		public static extern uint ApplyPaletteIndexMapping(FIBITMAP dib, byte[] srcindices, byte[] dstindices, uint count, bool swap);
+
+		/// <summary>
+		/// Swaps two specified palette indices on a 1-, 4- or 8-bit palletized image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="index_a">One of the two palette indices to be swapped.</param>
+		/// <param name="index_b">The other of the two palette indices to be swapped.</param>
+		/// <returns>The total number of pixels changed.</returns>
+		/// <remarks>
+		/// This function swaps the two specified palette indices <i>index_a</i> and
+		/// <i>index_b</i> on a palletized image. Therefore, not the palette, but the
+		/// actual image data will be modified.
+		/// <para/>
+		/// <b>Note, that this behaviour is different from what <see cref="SwapColors"/> does on palletized images,
+		/// which only swaps the colors in the palette.</b>
+		/// <para/>
+		/// This is just a thin wrapper for <see cref="ApplyColorMapping"/> and resolves to:
+		/// <para/>
+		/// <code>
+		/// return ApplyPaletteIndexMapping(dib, index_a, index_b, 1, true);
+		/// </code>
+		/// </remarks>
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_SwapPaletteIndices")]
+		public static extern uint SwapPaletteIndices(FIBITMAP dib, ref byte index_a, ref byte index_b);
+
+		[DllImport(ExternDll.FreeImage, EntryPoint = "FreeImage_FillBackground")]
+		internal static extern bool FillBackground(FIBITMAP dib, IntPtr color, FREE_IMAGE_COLOR_OPTIONS options);
+
+		#endregion
+	}
 }

--- a/src/FreeImage.Standard/FreeImageWrapper.cs
+++ b/src/FreeImage.Standard/FreeImageWrapper.cs
@@ -48,526 +48,526 @@ using Win32 = FreeImageAPI.NativeMethods.Win32;
 
 namespace FreeImageAPI
 {
-    /// <summary>
-    /// Static class importing functions from the FreeImage library
-    /// and providing additional functions.
-    /// </summary>
-    public static partial class FreeImage
-    {
-        #region Constants
+	/// <summary>
+	/// Static class importing functions from the FreeImage library
+	/// and providing additional functions.
+	/// </summary>
+	public static partial class FreeImage
+	{
+		#region Constants
 
-        /// <summary>
-        /// Array containing all 'FREE_IMAGE_MDMODEL's.
-        /// </summary>
-        public static readonly FREE_IMAGE_MDMODEL[] FREE_IMAGE_MDMODELS =
-            (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
+		/// <summary>
+		/// Array containing all 'FREE_IMAGE_MDMODEL's.
+		/// </summary>
+		public static readonly FREE_IMAGE_MDMODEL[] FREE_IMAGE_MDMODELS =
+			(FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
 
-        /// <summary>
-        /// Stores handles used to read from streams.
-        /// </summary>
-        private static Dictionary<FIMULTIBITMAP, fi_handle> streamHandles =
-            new Dictionary<FIMULTIBITMAP, fi_handle>();
+		/// <summary>
+		/// Stores handles used to read from streams.
+		/// </summary>
+		private static Dictionary<FIMULTIBITMAP, fi_handle> streamHandles =
+			new Dictionary<FIMULTIBITMAP, fi_handle>();
 
-        ///// <summary>
-        ///// Version of the wrapper library.
-        ///// </summary>
-        //private static Version WrapperVersion;
-        //private static object WrapperVersionLock = new object();
+		///// <summary>
+		///// Version of the wrapper library.
+		///// </summary>
+		//private static Version WrapperVersion;
+		//private static object WrapperVersionLock = new object();
 
-        private const int DIB_RGB_COLORS = 0;
-        private const int DIB_PAL_COLORS = 1;
-        private const int CBM_INIT = 0x4;
+		private const int DIB_RGB_COLORS = 0;
+		private const int DIB_PAL_COLORS = 1;
+		private const int CBM_INIT = 0x4;
 
-        /// <summary>
-        /// An uncompressed format.
-        /// </summary>
-        public const int BI_RGB = 0;
+		/// <summary>
+		/// An uncompressed format.
+		/// </summary>
+		public const int BI_RGB = 0;
 
-        /// <summary>
-        /// A run-length encoded (RLE) format for bitmaps with 8 bpp. The compression format is a 2-byte
-        /// format consisting of a count byte followed by a byte containing a color index.
-        /// </summary>
-        public const int BI_RLE8 = 1;
+		/// <summary>
+		/// A run-length encoded (RLE) format for bitmaps with 8 bpp. The compression format is a 2-byte
+		/// format consisting of a count byte followed by a byte containing a color index.
+		/// </summary>
+		public const int BI_RLE8 = 1;
 
-        /// <summary>
-        /// An RLE format for bitmaps with 4 bpp. The compression format is a 2-byte format consisting
-        /// of a count byte followed by two word-length color indexes.
-        /// </summary>
-        public const int BI_RLE4 = 2;
+		/// <summary>
+		/// An RLE format for bitmaps with 4 bpp. The compression format is a 2-byte format consisting
+		/// of a count byte followed by two word-length color indexes.
+		/// </summary>
+		public const int BI_RLE4 = 2;
 
-        /// <summary>
-        /// Specifies that the bitmap is not compressed and that the color table consists of three
-        /// <b>DWORD</b> color masks that specify the red, green, and blue components, respectively,
-        /// of each pixel. This is valid when used with 16- and 32-bpp bitmaps.
-        /// </summary>
-        public const int BI_BITFIELDS = 3;
+		/// <summary>
+		/// Specifies that the bitmap is not compressed and that the color table consists of three
+		/// <b>DWORD</b> color masks that specify the red, green, and blue components, respectively,
+		/// of each pixel. This is valid when used with 16- and 32-bpp bitmaps.
+		/// </summary>
+		public const int BI_BITFIELDS = 3;
 
-        /// <summary>
-        /// <b>Windows 98/Me, Windows 2000/XP:</b> Indicates that the image is a JPEG image.
-        /// </summary>
-        public const int BI_JPEG = 4;
+		/// <summary>
+		/// <b>Windows 98/Me, Windows 2000/XP:</b> Indicates that the image is a JPEG image.
+		/// </summary>
+		public const int BI_JPEG = 4;
 
-        /// <summary>
-        /// <b>Windows 98/Me, Windows 2000/XP:</b> Indicates that the image is a PNG image.
-        /// </summary>
-        public const int BI_PNG = 5;
+		/// <summary>
+		/// <b>Windows 98/Me, Windows 2000/XP:</b> Indicates that the image is a PNG image.
+		/// </summary>
+		public const int BI_PNG = 5;
 
-        #endregion
+		#endregion
 
-        #region General functions
+		#region General functions
 
-        private static readonly Version ExpectedNativeFreeImageVersion = new Version("3.17.0");
+		private static readonly Version ExpectedNativeFreeImageVersion = new Version("3.17.0");
 
-        ///// <summary>
-        ///// Returns the internal version of this FreeImage .NET wrapper.
-        ///// </summary>
-        ///// <returns>The internal version of this FreeImage .NET wrapper.</returns>
-        //public static Version GetWrapperVersion()
-        //{
-        //	if (WrapperVersion == null)
-        //	{
-        //		lock (WrapperVersionLock)
-        //		{
-        //			if (WrapperVersion == null)
-        //			{
-        //				Assembly assembly = GetFreeImageAssembly();
-        //				AssemblyInformationalVersionAttribute attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-        //
-        //				if (attribute == null)
-        //				{
-        //					throw new InvalidOperationException("Failed to get assembly version attribute");
-        //				}
-        //
-        //				if (string.IsNullOrWhiteSpace(attribute.InformationalVersion))
-        //				{
-        //					throw new InvalidOperationException("No assembly version present");
-        //				}
-        //
-        //				string version = attribute.InformationalVersion;
-        //
-        //				string[] versionParts = version.Split(new[] { '-' }, StringSplitOptions.RemoveEmptyEntries);
-        //
-        //				if (versionParts.Length < 1)
-        //				{
-        //					throw new InvalidOperationException("Invalid assembly version");
-        //				}
-        //
-        //				if (false == Version.TryParse(versionParts[0], out WrapperVersion))
-        //				{
-        //					throw new InvalidOperationException("Unable to parse assembly version");
-        //				}
-        //			}
-        //		}
-        //	}
-        //
-        //	return WrapperVersion;
-        //}
+		///// <summary>
+		///// Returns the internal version of this FreeImage .NET wrapper.
+		///// </summary>
+		///// <returns>The internal version of this FreeImage .NET wrapper.</returns>
+		//public static Version GetWrapperVersion()
+		//{
+		//	if (WrapperVersion == null)
+		//	{
+		//		lock (WrapperVersionLock)
+		//		{
+		//			if (WrapperVersion == null)
+		//			{
+		//				Assembly assembly = GetFreeImageAssembly();
+		//				AssemblyInformationalVersionAttribute attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+		//
+		//				if (attribute == null)
+		//				{
+		//					throw new InvalidOperationException("Failed to get assembly version attribute");
+		//				}
+		//
+		//				if (string.IsNullOrWhiteSpace(attribute.InformationalVersion))
+		//				{
+		//					throw new InvalidOperationException("No assembly version present");
+		//				}
+		//
+		//				string version = attribute.InformationalVersion;
+		//
+		//				string[] versionParts = version.Split(new[] { '-' }, StringSplitOptions.RemoveEmptyEntries);
+		//
+		//				if (versionParts.Length < 1)
+		//				{
+		//					throw new InvalidOperationException("Invalid assembly version");
+		//				}
+		//
+		//				if (false == Version.TryParse(versionParts[0], out WrapperVersion))
+		//				{
+		//					throw new InvalidOperationException("Unable to parse assembly version");
+		//				}
+		//			}
+		//		}
+		//	}
+		//
+		//	return WrapperVersion;
+		//}
 
-        internal static Assembly GetFreeImageAssembly()
-        {
-            return GetAssembly(typeof(FreeImage));
-        }
+		internal static Assembly GetFreeImageAssembly()
+		{
+			return GetAssembly(typeof(FreeImage));
+		}
 
-        internal static Assembly GetAssembly(Type type)
-        {
+		internal static Assembly GetAssembly(Type type)
+		{
 			return Assembly.GetAssembly(type);
-        }
+		}
 
-        /// <summary>
-        /// Returns the version of the native FreeImage library.
-        /// </summary>
-        /// <returns>The version of the native FreeImage library.</returns>
-        public static Version GetNativeVersion()
-        {
-            return new Version(GetVersion());
-        }
+		/// <summary>
+		/// Returns the version of the native FreeImage library.
+		/// </summary>
+		/// <returns>The version of the native FreeImage library.</returns>
+		public static Version GetNativeVersion()
+		{
+			return new Version(GetVersion());
+		}
 
-        /// <summary>
-        /// Validates that the FreeImage library is available on the system - throws an exception if not
-        /// </summary>
-        /// <remarks>
-        /// The FreeImage.NET library is a wrapper for the native C++ library
-        /// (FreeImage.dll ... dont mix ist up with this library FreeImageNet.dll).
-        /// The native library <b>must</b> be either in the same folder as the program's
-        /// executable or in a folder contained in the envirent variable <i>PATH</i>
-        /// (for example %WINDIR%\System32).<para/>
-        /// Further more must both libraries, including the program itself,
-        /// be the same architecture (x86 or x64) and be a compatible version.
-        /// </remarks>
-        public static void ValidateAvailability()
-        {
-            try
-            {
-                Version nativeVersion = new Version(GetVersion());
-                //Version wrapperVersion = GetWrapperVersion();
+		/// <summary>
+		/// Validates that the FreeImage library is available on the system - throws an exception if not
+		/// </summary>
+		/// <remarks>
+		/// The FreeImage.NET library is a wrapper for the native C++ library
+		/// (FreeImage.dll ... dont mix ist up with this library FreeImageNet.dll).
+		/// The native library <b>must</b> be either in the same folder as the program's
+		/// executable or in a folder contained in the envirent variable <i>PATH</i>
+		/// (for example %WINDIR%\System32).<para/>
+		/// Further more must both libraries, including the program itself,
+		/// be the same architecture (x86 or x64) and be a compatible version.
+		/// </remarks>
+		public static void ValidateAvailability()
+		{
+			try
+			{
+				Version nativeVersion = new Version(GetVersion());
+				//Version wrapperVersion = GetWrapperVersion();
 
-                //if (false ==	((nativeVersion.Major > wrapperVersion.Major) ||
-                //				((nativeVersion.Major == wrapperVersion.Major) && (nativeVersion.Minor > wrapperVersion.Minor)) ||
-                //				((nativeVersion.Major == wrapperVersion.Major) && (nativeVersion.Minor == wrapperVersion.Minor) && (nativeVersion.Build >= wrapperVersion.Build))))
-                if (nativeVersion != ExpectedNativeFreeImageVersion)
-                {
-                    throw new FreeImageException("FreeImage library version mismatch");
-                }
-            }
-            catch (DllNotFoundException e)
-            {
-                throw new FreeImageException("FreeImage library not found", e);
-            }
+				//if (false ==	((nativeVersion.Major > wrapperVersion.Major) ||
+				//				((nativeVersion.Major == wrapperVersion.Major) && (nativeVersion.Minor > wrapperVersion.Minor)) ||
+				//				((nativeVersion.Major == wrapperVersion.Major) && (nativeVersion.Minor == wrapperVersion.Minor) && (nativeVersion.Build >= wrapperVersion.Build))))
+				if (nativeVersion != ExpectedNativeFreeImageVersion)
+				{
+					throw new FreeImageException("FreeImage library version mismatch");
+				}
+			}
+			catch (DllNotFoundException e)
+			{
+				throw new FreeImageException("FreeImage library not found", e);
+			}
 			catch (EntryPointNotFoundException e)
 			{
 				throw new FreeImageException("FreeImage entry point not found", e);
 			}
-            catch (BadImageFormatException e)
-            {
-                throw new FreeImageException("Incorrect FreeImage library format", e);
-            }
-            catch (Exception e)
-            {
-                throw new FreeImageException("Unexpected error", e);
-            }
-        }
+			catch (BadImageFormatException e)
+			{
+				throw new FreeImageException("Incorrect FreeImage library format", e);
+			}
+			catch (Exception e)
+			{
+				throw new FreeImageException("Unexpected error", e);
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region Bitmap management functions
+		#region Bitmap management functions
 
-        /// <summary>
-        /// Creates a new bitmap in memory.
-        /// </summary>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new Bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP Allocate(int width, int height, int bpp)
-        {
-            return Allocate(width, height, bpp, 0, 0, 0);
-        }
+		/// <summary>
+		/// Creates a new bitmap in memory.
+		/// </summary>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new Bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP Allocate(int width, int height, int bpp)
+		{
+			return Allocate(width, height, bpp, 0, 0, 0);
+		}
 
-        /// <summary>
-        /// Creates a new bitmap in memory.
-        /// </summary>
-        /// <param name="type">Type of the image.</param>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new Bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp)
-        {
-            return AllocateT(type, width, height, bpp, 0, 0, 0);
-        }
+		/// <summary>
+		/// Creates a new bitmap in memory.
+		/// </summary>
+		/// <param name="type">Type of the image.</param>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new Bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP AllocateT(FREE_IMAGE_TYPE type, int width, int height, int bpp)
+		{
+			return AllocateT(type, width, height, bpp, 0, 0, 0);
+		}
 
-        /// <summary>
-        /// Allocates a new image of the specified width, height and bit depth and optionally
-        /// fills it with the specified color. See remarks for further details.
-        /// </summary>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmaps.</param>
-        /// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
-        /// <param name="options">Options to enable or disable function-features.</param>
-        /// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function is an extension to <see cref="Allocate"/>, which additionally supports
-        /// specifying a palette to be set for the newly create image, as well as specifying a
-        /// background color, the newly created image should initially be filled with.
-        /// <para/>
-        /// Basically, this function internally relies on function <see cref="Allocate"/>, followed by a
-        /// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters
-        /// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
-        /// documented for function <see cref="FillBackground&lt;T&gt;"/>.
-        /// So, please refer to the documentation of <see cref="FillBackground&lt;T&gt;"/> to
-        /// learn more about parameters <paramref name="color"/> and <paramref name="options"/>.
-        /// <para/>
-        /// The palette specified through parameter <paramref name="palette"/> is only copied to the
-        /// newly created image, if the desired bit depth is smaller than or equal to 8 bits per pixel.
-        /// In other words, the <paramref name="palette"/> parameter is only taken into account for
-        /// palletized images. So, for an 8-bit image, the length is 256, for an 4-bit image it is 16
-        /// and it is 2 for a 1-bit image. In other words, this function does not support partial palettes.
-        /// <para/>
-        /// However, specifying a palette is not necesarily needed, even for palletized images. This
-        /// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
-        /// If the specified background color is a greyscale value (red = green = blue) or if option
-        /// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
-        /// is created. For a 1-bit image, only if the specified background color is either black or white,
-        /// a monochrome palette, consisting of black and white only is created. In any case, the darker
-        /// colors are stored at the smaller palette indices.
-        /// <para/>
-        /// If the specified background color is not a greyscale value, or is neither black nor white
-        /// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
-        /// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
-        /// is implicit, so the specified <paramref name="color"/> is applied to the palette entry,
-        /// specified by the background color's <see cref="RGBQUAD.rgbReserved"/> field.
-        /// The image is then filled with this palette index.
-        /// <para/>
-        /// This function returns a newly created image as function <see cref="Allocate"/> does, if both
-        /// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
-        /// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
-        /// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
-        /// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
-        /// However, in the latter case, this function returns an image, whose
-        /// pixels are all initialized with zeros so, the image will be filled with the color of the
-        /// first palette entry.
-        /// </remarks>
-        public static FIBITMAP AllocateEx(int width, int height, int bpp,
-            RGBQUAD? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette)
-        {
-            return AllocateEx(width, height, bpp, color, options, palette, 0, 0, 0);
-        }
+		/// <summary>
+		/// Allocates a new image of the specified width, height and bit depth and optionally
+		/// fills it with the specified color. See remarks for further details.
+		/// </summary>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmaps.</param>
+		/// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
+		/// <param name="options">Options to enable or disable function-features.</param>
+		/// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function is an extension to <see cref="Allocate"/>, which additionally supports
+		/// specifying a palette to be set for the newly create image, as well as specifying a
+		/// background color, the newly created image should initially be filled with.
+		/// <para/>
+		/// Basically, this function internally relies on function <see cref="Allocate"/>, followed by a
+		/// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters
+		/// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
+		/// documented for function <see cref="FillBackground&lt;T&gt;"/>.
+		/// So, please refer to the documentation of <see cref="FillBackground&lt;T&gt;"/> to
+		/// learn more about parameters <paramref name="color"/> and <paramref name="options"/>.
+		/// <para/>
+		/// The palette specified through parameter <paramref name="palette"/> is only copied to the
+		/// newly created image, if the desired bit depth is smaller than or equal to 8 bits per pixel.
+		/// In other words, the <paramref name="palette"/> parameter is only taken into account for
+		/// palletized images. So, for an 8-bit image, the length is 256, for an 4-bit image it is 16
+		/// and it is 2 for a 1-bit image. In other words, this function does not support partial palettes.
+		/// <para/>
+		/// However, specifying a palette is not necesarily needed, even for palletized images. This
+		/// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
+		/// If the specified background color is a greyscale value (red = green = blue) or if option
+		/// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
+		/// is created. For a 1-bit image, only if the specified background color is either black or white,
+		/// a monochrome palette, consisting of black and white only is created. In any case, the darker
+		/// colors are stored at the smaller palette indices.
+		/// <para/>
+		/// If the specified background color is not a greyscale value, or is neither black nor white
+		/// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
+		/// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
+		/// is implicit, so the specified <paramref name="color"/> is applied to the palette entry,
+		/// specified by the background color's <see cref="RGBQUAD.rgbReserved"/> field.
+		/// The image is then filled with this palette index.
+		/// <para/>
+		/// This function returns a newly created image as function <see cref="Allocate"/> does, if both
+		/// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
+		/// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
+		/// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
+		/// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
+		/// However, in the latter case, this function returns an image, whose
+		/// pixels are all initialized with zeros so, the image will be filled with the color of the
+		/// first palette entry.
+		/// </remarks>
+		public static FIBITMAP AllocateEx(int width, int height, int bpp,
+			RGBQUAD? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette)
+		{
+			return AllocateEx(width, height, bpp, color, options, palette, 0, 0, 0);
+		}
 
-        /// <summary>
-        /// Allocates a new image of the specified width, height and bit depth and optionally
-        /// fills it with the specified color. See remarks for further details.
-        /// </summary>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmaps.</param>
-        /// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
-        /// <param name="options">Options to enable or disable function-features.</param>
-        /// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
-        /// <param name="red_mask">Red part of the color layout.
-        /// eg: 0xFF0000</param>
-        /// <param name="green_mask">Green part of the color layout.
-        /// eg: 0x00FF00</param>
-        /// <param name="blue_mask">Blue part of the color layout.
-        /// eg: 0x0000FF</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function is an extension to <see cref="Allocate"/>, which additionally supports
-        /// specifying a palette to be set for the newly create image, as well as specifying a
-        /// background color, the newly created image should initially be filled with.
-        /// <para/>
-        /// Basically, this function internally relies on function <see cref="Allocate"/>, followed by a
-        /// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters
-        /// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
-        /// documented for function <see cref="FillBackground&lt;T&gt;"/>.
-        /// So, please refer to the documentation of <see cref="FillBackground&lt;T&gt;"/> to
-        /// learn more about parameters <paramref name="color"/> and <paramref name="options"/>.
-        /// <para/>
-        /// The palette specified through parameter <paramref name="palette"/> is only copied to the
-        /// newly created image, if the desired bit depth is smaller than or equal to 8 bits per pixel.
-        /// In other words, the <paramref name="palette"/> parameter is only taken into account for
-        /// palletized images. So, for an 8-bit image, the length is 256, for an 4-bit image it is 16
-        /// and it is 2 for a 1-bit image. In other words, this function does not support partial palettes.
-        /// <para/>
-        /// However, specifying a palette is not necesarily needed, even for palletized images. This
-        /// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
-        /// If the specified background color is a greyscale value (red = green = blue) or if option
-        /// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
-        /// is created. For a 1-bit image, only if the specified background color is either black or white,
-        /// a monochrome palette, consisting of black and white only is created. In any case, the darker
-        /// colors are stored at the smaller palette indices.
-        /// <para/>
-        /// If the specified background color is not a greyscale value, or is neither black nor white
-        /// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
-        /// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
-        /// is implicit, so the specified <paramref name="color"/> is applied to the palette entry,
-        /// specified by the background color's <see cref="RGBQUAD.rgbReserved"/> field.
-        /// The image is then filled with this palette index.
-        /// <para/>
-        /// This function returns a newly created image as function <see cref="Allocate"/> does, if both
-        /// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
-        /// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
-        /// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
-        /// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
-        /// However, in the latter case, this function returns an image, whose
-        /// pixels are all initialized with zeros so, the image will be filled with the color of the
-        /// first palette entry.
-        /// </remarks>
-        public static FIBITMAP AllocateEx(int width, int height, int bpp,
-            RGBQUAD? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
-            uint red_mask, uint green_mask, uint blue_mask)
-        {
-            if ((palette != null) && (bpp <= 8) && (palette.Length < (1 << bpp)))
-                return FIBITMAP.Zero;
+		/// <summary>
+		/// Allocates a new image of the specified width, height and bit depth and optionally
+		/// fills it with the specified color. See remarks for further details.
+		/// </summary>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmaps.</param>
+		/// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
+		/// <param name="options">Options to enable or disable function-features.</param>
+		/// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
+		/// <param name="red_mask">Red part of the color layout.
+		/// eg: 0xFF0000</param>
+		/// <param name="green_mask">Green part of the color layout.
+		/// eg: 0x00FF00</param>
+		/// <param name="blue_mask">Blue part of the color layout.
+		/// eg: 0x0000FF</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function is an extension to <see cref="Allocate"/>, which additionally supports
+		/// specifying a palette to be set for the newly create image, as well as specifying a
+		/// background color, the newly created image should initially be filled with.
+		/// <para/>
+		/// Basically, this function internally relies on function <see cref="Allocate"/>, followed by a
+		/// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters
+		/// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
+		/// documented for function <see cref="FillBackground&lt;T&gt;"/>.
+		/// So, please refer to the documentation of <see cref="FillBackground&lt;T&gt;"/> to
+		/// learn more about parameters <paramref name="color"/> and <paramref name="options"/>.
+		/// <para/>
+		/// The palette specified through parameter <paramref name="palette"/> is only copied to the
+		/// newly created image, if the desired bit depth is smaller than or equal to 8 bits per pixel.
+		/// In other words, the <paramref name="palette"/> parameter is only taken into account for
+		/// palletized images. So, for an 8-bit image, the length is 256, for an 4-bit image it is 16
+		/// and it is 2 for a 1-bit image. In other words, this function does not support partial palettes.
+		/// <para/>
+		/// However, specifying a palette is not necesarily needed, even for palletized images. This
+		/// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
+		/// If the specified background color is a greyscale value (red = green = blue) or if option
+		/// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
+		/// is created. For a 1-bit image, only if the specified background color is either black or white,
+		/// a monochrome palette, consisting of black and white only is created. In any case, the darker
+		/// colors are stored at the smaller palette indices.
+		/// <para/>
+		/// If the specified background color is not a greyscale value, or is neither black nor white
+		/// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
+		/// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
+		/// is implicit, so the specified <paramref name="color"/> is applied to the palette entry,
+		/// specified by the background color's <see cref="RGBQUAD.rgbReserved"/> field.
+		/// The image is then filled with this palette index.
+		/// <para/>
+		/// This function returns a newly created image as function <see cref="Allocate"/> does, if both
+		/// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
+		/// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
+		/// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
+		/// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
+		/// However, in the latter case, this function returns an image, whose
+		/// pixels are all initialized with zeros so, the image will be filled with the color of the
+		/// first palette entry.
+		/// </remarks>
+		public static FIBITMAP AllocateEx(int width, int height, int bpp,
+			RGBQUAD? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
+			uint red_mask, uint green_mask, uint blue_mask)
+		{
+			if ((palette != null) && (bpp <= 8) && (palette.Length < (1 << bpp)))
+				return FIBITMAP.Zero;
 
-            if (color.HasValue)
-            {
-                GCHandle handle = new GCHandle();
-                try
-                {
-                    RGBQUAD[] buffer = new RGBQUAD[] { color.Value };
-                    handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-                    return AllocateEx(width, height, bpp, handle.AddrOfPinnedObject(),
-                        options, palette, red_mask, green_mask, blue_mask);
-                }
-                finally
-                {
-                    if (handle.IsAllocated)
-                        handle.Free();
-                }
-            }
-            else
-            {
-                return AllocateEx(width, height, bpp, IntPtr.Zero,
-                    options, palette, red_mask, green_mask, blue_mask);
-            }
-        }
+			if (color.HasValue)
+			{
+				GCHandle handle = new GCHandle();
+				try
+				{
+					RGBQUAD[] buffer = new RGBQUAD[] { color.Value };
+					handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+					return AllocateEx(width, height, bpp, handle.AddrOfPinnedObject(),
+						options, palette, red_mask, green_mask, blue_mask);
+				}
+				finally
+				{
+					if (handle.IsAllocated)
+						handle.Free();
+				}
+			}
+			else
+			{
+				return AllocateEx(width, height, bpp, IntPtr.Zero,
+					options, palette, red_mask, green_mask, blue_mask);
+			}
+		}
 
-        /// <summary>
-        /// Allocates a new image of the specified type, width, height and bit depth and optionally
-        /// fills it with the specified color. See remarks for further details.
-        /// </summary>
-        /// <typeparam name="T">The type of the specified color.</typeparam>
-        /// <param name="type">Type of the image.</param>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
-        /// <param name="options">Options to enable or disable function-features.</param>
-        /// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function is an extension to <see cref="AllocateT"/>, which additionally supports
-        /// specifying a palette to be set for the newly create image, as well as specifying a
-        /// background color, the newly created image should initially be filled with.
-        /// <para/>
-        /// Basically, this function internally relies on function <see cref="AllocateT"/>, followed by a
-        /// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters 
-        /// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
-        /// documented for function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the
-        /// documentation of <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters color and options.
-        /// <para/>
-        /// The palette specified through parameter palette is only copied to the newly created
-        /// image, if its image type is <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> and the desired bit
-        /// depth is smaller than or equal to 8 bits per pixel. In other words, the <paramref name="palette"/>
-        /// palette is only taken into account for palletized images. However, if the preceding conditions
-        /// match and if <paramref name="palette"/> is not <c>null</c>, the palette is assumed to be at
-        /// least as large as the size of a fully populated palette for the desired bit depth.
-        /// So, for an 8-bit image, this length is 256, for an 4-bit image it is 16 and it is
-        /// 2 for a 1-bit image. In other words, this function does not support partial palettes.
-        /// <para/>
-        /// However, specifying a palette is not necesarily needed, even for palletized images. This
-        /// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
-        /// If the specified background color is a greyscale value (red = green = blue) or if option
-        /// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
-        /// is created. For a 1-bit image, only if the specified background color is either black or white,
-        /// a monochrome palette, consisting of black and white only is created. In any case, the darker
-        /// colors are stored at the smaller palette indices.
-        /// <para/>
-        /// If the specified background color is not a greyscale value, or is neither black nor white
-        /// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
-        /// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
-        /// is implicit, so the specified color is applied to the palette entry, specified by the
-        /// background color's <see cref="RGBQUAD.rgbReserved"/> field. The image is then filled with
-        /// this palette index.
-        /// <para/>
-        /// This function returns a newly created image as function <see cref="AllocateT"/> does, if both
-        /// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
-        /// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
-        /// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
-        /// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
-        /// However, in the latter case, this function returns an image, whose
-        /// pixels are all initialized with zeros so, the image will be filled with the color of the
-        /// first palette entry.
-        /// </remarks>
-        public static FIBITMAP AllocateExT<T>(FREE_IMAGE_TYPE type, int width, int height, int bpp,
-            T? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette) where T : struct
-        {
-            return AllocateExT(type, width, height, bpp, color, options, palette, 0, 0, 0);
-        }
+		/// <summary>
+		/// Allocates a new image of the specified type, width, height and bit depth and optionally
+		/// fills it with the specified color. See remarks for further details.
+		/// </summary>
+		/// <typeparam name="T">The type of the specified color.</typeparam>
+		/// <param name="type">Type of the image.</param>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
+		/// <param name="options">Options to enable or disable function-features.</param>
+		/// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function is an extension to <see cref="AllocateT"/>, which additionally supports
+		/// specifying a palette to be set for the newly create image, as well as specifying a
+		/// background color, the newly created image should initially be filled with.
+		/// <para/>
+		/// Basically, this function internally relies on function <see cref="AllocateT"/>, followed by a
+		/// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters 
+		/// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
+		/// documented for function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the
+		/// documentation of <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters color and options.
+		/// <para/>
+		/// The palette specified through parameter palette is only copied to the newly created
+		/// image, if its image type is <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> and the desired bit
+		/// depth is smaller than or equal to 8 bits per pixel. In other words, the <paramref name="palette"/>
+		/// palette is only taken into account for palletized images. However, if the preceding conditions
+		/// match and if <paramref name="palette"/> is not <c>null</c>, the palette is assumed to be at
+		/// least as large as the size of a fully populated palette for the desired bit depth.
+		/// So, for an 8-bit image, this length is 256, for an 4-bit image it is 16 and it is
+		/// 2 for a 1-bit image. In other words, this function does not support partial palettes.
+		/// <para/>
+		/// However, specifying a palette is not necesarily needed, even for palletized images. This
+		/// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
+		/// If the specified background color is a greyscale value (red = green = blue) or if option
+		/// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
+		/// is created. For a 1-bit image, only if the specified background color is either black or white,
+		/// a monochrome palette, consisting of black and white only is created. In any case, the darker
+		/// colors are stored at the smaller palette indices.
+		/// <para/>
+		/// If the specified background color is not a greyscale value, or is neither black nor white
+		/// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
+		/// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
+		/// is implicit, so the specified color is applied to the palette entry, specified by the
+		/// background color's <see cref="RGBQUAD.rgbReserved"/> field. The image is then filled with
+		/// this palette index.
+		/// <para/>
+		/// This function returns a newly created image as function <see cref="AllocateT"/> does, if both
+		/// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
+		/// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
+		/// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
+		/// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
+		/// However, in the latter case, this function returns an image, whose
+		/// pixels are all initialized with zeros so, the image will be filled with the color of the
+		/// first palette entry.
+		/// </remarks>
+		public static FIBITMAP AllocateExT<T>(FREE_IMAGE_TYPE type, int width, int height, int bpp,
+			T? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette) where T : struct
+		{
+			return AllocateExT(type, width, height, bpp, color, options, palette, 0, 0, 0);
+		}
 
-        /// <summary>
-        /// Allocates a new image of the specified type, width, height and bit depth and optionally
-        /// fills it with the specified color. See remarks for further details.
-        /// </summary>
-        /// <typeparam name="T">The type of the specified color.</typeparam>
-        /// <param name="type">Type of the image.</param>
-        /// <param name="width">Width of the new bitmap.</param>
-        /// <param name="height">Height of the new bitmap.</param>
-        /// <param name="bpp">Bit depth of the new bitmap.
-        /// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
-        /// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
-        /// <param name="options">Options to enable or disable function-features.</param>
-        /// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
-        /// <param name="red_mask">Red part of the color layout.
-        /// eg: 0xFF0000</param>
-        /// <param name="green_mask">Green part of the color layout.
-        /// eg: 0x00FF00</param>
-        /// <param name="blue_mask">Blue part of the color layout.
-        /// eg: 0x0000FF</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function is an extension to <see cref="AllocateT"/>, which additionally supports
-        /// specifying a palette to be set for the newly create image, as well as specifying a
-        /// background color, the newly created image should initially be filled with.
-        /// <para/>
-        /// Basically, this function internally relies on function <see cref="AllocateT"/>, followed by a
-        /// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters 
-        /// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
-        /// documented for function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the
-        /// documentation of <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters color and options.
-        /// <para/>
-        /// The palette specified through parameter palette is only copied to the newly created
-        /// image, if its image type is <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> and the desired bit
-        /// depth is smaller than or equal to 8 bits per pixel. In other words, the <paramref name="palette"/>
-        /// palette is only taken into account for palletized images. However, if the preceding conditions
-        /// match and if <paramref name="palette"/> is not <c>null</c>, the palette is assumed to be at
-        /// least as large as the size of a fully populated palette for the desired bit depth.
-        /// So, for an 8-bit image, this length is 256, for an 4-bit image it is 16 and it is
-        /// 2 for a 1-bit image. In other words, this function does not support partial palettes.
-        /// <para/>
-        /// However, specifying a palette is not necesarily needed, even for palletized images. This
-        /// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
-        /// If the specified background color is a greyscale value (red = green = blue) or if option
-        /// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
-        /// is created. For a 1-bit image, only if the specified background color is either black or white,
-        /// a monochrome palette, consisting of black and white only is created. In any case, the darker
-        /// colors are stored at the smaller palette indices.
-        /// <para/>
-        /// If the specified background color is not a greyscale value, or is neither black nor white
-        /// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
-        /// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
-        /// is implicit, so the specified color is applied to the palette entry, specified by the
-        /// background color's <see cref="RGBQUAD.rgbReserved"/> field. The image is then filled with
-        /// this palette index.
-        /// <para/>
-        /// This function returns a newly created image as function <see cref="AllocateT"/> does, if both
-        /// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
-        /// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
-        /// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
-        /// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
-        /// However, in the latter case, this function returns an image, whose
-        /// pixels are all initialized with zeros so, the image will be filled with the color of the
-        /// first palette entry.
-        /// </remarks>
-        public static FIBITMAP AllocateExT<T>(FREE_IMAGE_TYPE type, int width, int height, int bpp,
-            T? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
-            uint red_mask, uint green_mask, uint blue_mask) where T : struct
-        {
-            if ((palette != null) && (bpp <= 8) && (palette.Length < (1 << bpp)))
-                return FIBITMAP.Zero;
+		/// <summary>
+		/// Allocates a new image of the specified type, width, height and bit depth and optionally
+		/// fills it with the specified color. See remarks for further details.
+		/// </summary>
+		/// <typeparam name="T">The type of the specified color.</typeparam>
+		/// <param name="type">Type of the image.</param>
+		/// <param name="width">Width of the new bitmap.</param>
+		/// <param name="height">Height of the new bitmap.</param>
+		/// <param name="bpp">Bit depth of the new bitmap.
+		/// Supported pixel depth: 1-, 4-, 8-, 16-, 24-, 32-bit per pixel for standard bitmap</param>
+		/// <param name="color">The color to fill the bitmap with or <c>null</c>.</param>
+		/// <param name="options">Options to enable or disable function-features.</param>
+		/// <param name="palette">The palette of the bitmap or <c>null</c>.</param>
+		/// <param name="red_mask">Red part of the color layout.
+		/// eg: 0xFF0000</param>
+		/// <param name="green_mask">Green part of the color layout.
+		/// eg: 0x00FF00</param>
+		/// <param name="blue_mask">Blue part of the color layout.
+		/// eg: 0x0000FF</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function is an extension to <see cref="AllocateT"/>, which additionally supports
+		/// specifying a palette to be set for the newly create image, as well as specifying a
+		/// background color, the newly created image should initially be filled with.
+		/// <para/>
+		/// Basically, this function internally relies on function <see cref="AllocateT"/>, followed by a
+		/// call to <see cref="FillBackground&lt;T&gt;"/>. This is why both parameters 
+		/// <paramref name="color"/> and <paramref name="options"/> behave the same as it is
+		/// documented for function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the
+		/// documentation of <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters color and options.
+		/// <para/>
+		/// The palette specified through parameter palette is only copied to the newly created
+		/// image, if its image type is <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> and the desired bit
+		/// depth is smaller than or equal to 8 bits per pixel. In other words, the <paramref name="palette"/>
+		/// palette is only taken into account for palletized images. However, if the preceding conditions
+		/// match and if <paramref name="palette"/> is not <c>null</c>, the palette is assumed to be at
+		/// least as large as the size of a fully populated palette for the desired bit depth.
+		/// So, for an 8-bit image, this length is 256, for an 4-bit image it is 16 and it is
+		/// 2 for a 1-bit image. In other words, this function does not support partial palettes.
+		/// <para/>
+		/// However, specifying a palette is not necesarily needed, even for palletized images. This
+		/// function is capable of implicitly creating a palette, if <paramref name="palette"/> is <c>null</c>.
+		/// If the specified background color is a greyscale value (red = green = blue) or if option
+		/// <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/> is specified, a greyscale palette
+		/// is created. For a 1-bit image, only if the specified background color is either black or white,
+		/// a monochrome palette, consisting of black and white only is created. In any case, the darker
+		/// colors are stored at the smaller palette indices.
+		/// <para/>
+		/// If the specified background color is not a greyscale value, or is neither black nor white
+		/// for a 1-bit image, solely this specified color is injected into the otherwise black-initialized
+		/// palette. For this operation, option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
+		/// is implicit, so the specified color is applied to the palette entry, specified by the
+		/// background color's <see cref="RGBQUAD.rgbReserved"/> field. The image is then filled with
+		/// this palette index.
+		/// <para/>
+		/// This function returns a newly created image as function <see cref="AllocateT"/> does, if both
+		/// parameters <paramref name="color"/> and <paramref name="palette"/> are <c>null</c>.
+		/// If only <paramref name="color"/> is <c>null</c>, the palette pointed to by
+		/// parameter <paramref name="palette"/> is initially set for the new image, if a palletized
+		/// image of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> is created.
+		/// However, in the latter case, this function returns an image, whose
+		/// pixels are all initialized with zeros so, the image will be filled with the color of the
+		/// first palette entry.
+		/// </remarks>
+		public static FIBITMAP AllocateExT<T>(FREE_IMAGE_TYPE type, int width, int height, int bpp,
+			T? color, FREE_IMAGE_COLOR_OPTIONS options, RGBQUAD[] palette,
+			uint red_mask, uint green_mask, uint blue_mask) where T : struct
+		{
+			if ((palette != null) && (bpp <= 8) && (palette.Length < (1 << bpp)))
+				return FIBITMAP.Zero;
 
-            if (color.HasValue)
-            {
-                if (!CheckColorType(type, color.Value))
-                    return FIBITMAP.Zero;
+			if (color.HasValue)
+			{
+				if (!CheckColorType(type, color.Value))
+					return FIBITMAP.Zero;
 
-                GCHandle handle = new GCHandle();
-                try
-                {
-                    T[] buffer = new T[] { color.Value };
-                    handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-                    return AllocateExT(type, width, height, bpp, handle.AddrOfPinnedObject(),
-                        options, palette, red_mask, green_mask, blue_mask);
-                }
-                finally
-                {
-                    if (handle.IsAllocated)
-                        handle.Free();
-                }
-            }
-            else
-            {
-                return AllocateExT(type, width, height, bpp, IntPtr.Zero,
-                    options, palette, red_mask, green_mask, blue_mask);
-            }
-        }
+				GCHandle handle = new GCHandle();
+				try
+				{
+					T[] buffer = new T[] { color.Value };
+					handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+					return AllocateExT(type, width, height, bpp, handle.AddrOfPinnedObject(),
+						options, palette, red_mask, green_mask, blue_mask);
+				}
+				finally
+				{
+					if (handle.IsAllocated)
+						handle.Free();
+				}
+			}
+			else
+			{
+				return AllocateExT(type, width, height, bpp, IntPtr.Zero,
+					options, palette, red_mask, green_mask, blue_mask);
+			}
+		}
 
 		/// <summary>
 		/// Converts a FreeImage bitmap to a .NET <see cref="System.Drawing.Bitmap"/>.
@@ -629,11 +629,11 @@ namespace FreeImageAPI
 			// Unlock the bitmap
 			result.UnlockBits(data);
 			// Apply the bitmap resolution
-            if((GetResolutionX(dib) > 0) && (GetResolutionY(dib) > 0)) 
-            {
-                // SetResolution will throw an exception when zero values are given on input 
-                result.SetResolution(GetResolutionX(dib), GetResolutionY(dib));
-            }
+			if ((GetResolutionX(dib) > 0) && (GetResolutionY(dib) > 0))
+			{
+				// SetResolution will throw an exception when zero values are given on input 
+				result.SetResolution(GetResolutionX(dib), GetResolutionY(dib));
+			}
 			// Check whether the bitmap has a palette
 			if (GetPalette(dib) != IntPtr.Zero)
 			{
@@ -816,112 +816,112 @@ namespace FreeImageAPI
 			return result;
 		}
 
-        /// <summary>
-        /// Converts a raw bitmap to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="bits">Array of bytes containing the raw bitmap.</param>
-        /// <param name="type">The type of the raw bitmap.</param>
-        /// <param name="width">The width in pixels of the raw bitmap.</param>
-        /// <param name="height">The height in pixels of the raw bitmap.</param>
-        /// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
-        /// including padding bytes.</param>
-        /// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static unsafe FIBITMAP ConvertFromRawBits(
-            byte[] bits,
-            FREE_IMAGE_TYPE type,
-            int width,
-            int height,
-            int pitch,
-            uint bpp,
-            uint red_mask,
-            uint green_mask,
-            uint blue_mask,
-            bool topdown)
-        {
-            fixed (byte* ptr = bits)
-            {
-                return ConvertFromRawBits(
-                    (IntPtr)ptr,
-                    type,
-                    width,
-                    height,
-                    pitch,
-                    bpp,
-                    red_mask,
-                    green_mask,
-                    blue_mask,
-                    topdown);
-            }
-        }
+		/// <summary>
+		/// Converts a raw bitmap to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="bits">Array of bytes containing the raw bitmap.</param>
+		/// <param name="type">The type of the raw bitmap.</param>
+		/// <param name="width">The width in pixels of the raw bitmap.</param>
+		/// <param name="height">The height in pixels of the raw bitmap.</param>
+		/// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
+		/// including padding bytes.</param>
+		/// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static unsafe FIBITMAP ConvertFromRawBits(
+			byte[] bits,
+			FREE_IMAGE_TYPE type,
+			int width,
+			int height,
+			int pitch,
+			uint bpp,
+			uint red_mask,
+			uint green_mask,
+			uint blue_mask,
+			bool topdown)
+		{
+			fixed (byte* ptr = bits)
+			{
+				return ConvertFromRawBits(
+					(IntPtr)ptr,
+					type,
+					width,
+					height,
+					pitch,
+					bpp,
+					red_mask,
+					green_mask,
+					blue_mask,
+					topdown);
+			}
+		}
 
-        /// <summary>
-        /// Converts a raw bitmap to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="bits">Pointer to the memory block containing the raw bitmap.</param>
-        /// <param name="type">The type of the raw bitmap.</param>
-        /// <param name="width">The width in pixels of the raw bitmap.</param>
-        /// <param name="height">The height in pixels of the raw bitmap.</param>
-        /// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
-        /// including padding bytes.</param>
-        /// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
-        /// <param name="red_mask">The bit mask describing the bits used to store a single 
-        /// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="green_mask">The bit mask describing the bits used to store a single
-        /// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="blue_mask">The bit mask describing the bits used to store a single
-        /// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
-        /// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
-        /// and in bottom-up order (bottom-left pixel first) otherwise.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static unsafe FIBITMAP ConvertFromRawBits(
-            IntPtr bits,
-            FREE_IMAGE_TYPE type,
-            int width,
-            int height,
-            int pitch,
-            uint bpp,
-            uint red_mask,
-            uint green_mask,
-            uint blue_mask,
-            bool topdown)
-        {
-            byte* addr = (byte*)bits;
-            if ((addr == null) || (width <= 0) || (height <= 0))
-            {
-                return FIBITMAP.Zero;
-            }
+		/// <summary>
+		/// Converts a raw bitmap to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="bits">Pointer to the memory block containing the raw bitmap.</param>
+		/// <param name="type">The type of the raw bitmap.</param>
+		/// <param name="width">The width in pixels of the raw bitmap.</param>
+		/// <param name="height">The height in pixels of the raw bitmap.</param>
+		/// <param name="pitch">Defines the total width of a scanline in the raw bitmap,
+		/// including padding bytes.</param>
+		/// <param name="bpp">The bit depth (bits per pixel) of the raw bitmap.</param>
+		/// <param name="red_mask">The bit mask describing the bits used to store a single 
+		/// pixel's red component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="green_mask">The bit mask describing the bits used to store a single
+		/// pixel's green component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="blue_mask">The bit mask describing the bits used to store a single
+		/// pixel's blue component in the raw bitmap. This is only applied to 16-bpp raw bitmaps.</param>
+		/// <param name="topdown">If true, the raw bitmap is stored in top-down order (top-left pixel first)
+		/// and in bottom-up order (bottom-left pixel first) otherwise.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static unsafe FIBITMAP ConvertFromRawBits(
+			IntPtr bits,
+			FREE_IMAGE_TYPE type,
+			int width,
+			int height,
+			int pitch,
+			uint bpp,
+			uint red_mask,
+			uint green_mask,
+			uint blue_mask,
+			bool topdown)
+		{
+			byte* addr = (byte*)bits;
+			if ((addr == null) || (width <= 0) || (height <= 0))
+			{
+				return FIBITMAP.Zero;
+			}
 
-            FIBITMAP dib = AllocateT(type, width, height, (int)bpp, red_mask, green_mask, blue_mask);
-            if (dib != FIBITMAP.Zero)
-            {
-                if (topdown)
-                {
-                    for (int i = height - 1; i >= 0; --i)
-                    {
-                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
-                        addr += pitch;
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < height; ++i)
-                    {
-                        CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
-                        addr += pitch;
-                    }
-                }
-            }
-            return dib;
-        }
+			FIBITMAP dib = AllocateT(type, width, height, (int)bpp, red_mask, green_mask, blue_mask);
+			if (dib != FIBITMAP.Zero)
+			{
+				if (topdown)
+				{
+					for (int i = height - 1; i >= 0; --i)
+					{
+						CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+						addr += pitch;
+					}
+				}
+				else
+				{
+					for (int i = 0; i < height; ++i)
+					{
+						CopyMemory((byte*)GetScanLine(dib, i), addr, (int)GetLine(dib));
+						addr += pitch;
+					}
+				}
+			}
+			return dib;
+		}
 
 		/// <summary>
 		/// Saves a .NET <see cref="System.Drawing.Bitmap"/> to a file.
@@ -987,90 +987,90 @@ namespace FreeImageAPI
 			return result;
 		}
 
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// The file will be loaded with default loading flags.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists.</exception>
-        public static FIBITMAP LoadEx(string filename)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return LoadEx(filename, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-        }
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// The file will be loaded with default loading flags.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists.</exception>
+		public static FIBITMAP LoadEx(string filename)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return LoadEx(filename, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+		}
 
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists.</exception>
-        public static FIBITMAP LoadEx(string filename, FREE_IMAGE_LOAD_FLAGS flags)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return LoadEx(filename, flags, ref format);
-        }
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists.</exception>
+		public static FIBITMAP LoadEx(string filename, FREE_IMAGE_LOAD_FLAGS flags)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return LoadEx(filename, flags, ref format);
+		}
 
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
-        /// real format is being analysed. If no plugin can read the file, format remains
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
-        /// The file will be loaded with default loading flags.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="format">Format of the image. If the format is unknown use
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadEx it will be returned in format.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists.</exception>
-        public static FIBITMAP LoadEx(string filename, ref FREE_IMAGE_FORMAT format)
-        {
-            return LoadEx(filename, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-        }
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
+		/// real format is being analysed. If no plugin can read the file, format remains
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
+		/// The file will be loaded with default loading flags.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="format">Format of the image. If the format is unknown use
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadEx it will be returned in format.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists.</exception>
+		public static FIBITMAP LoadEx(string filename, ref FREE_IMAGE_FORMAT format)
+		{
+			return LoadEx(filename, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+		}
 
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
-        /// real format is being analysed. If no plugin can read the file, format remains
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="format">Format of the image. If the format is unknown use
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadEx it will be returned in format.
-        /// </param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists.</exception>
-        public static FIBITMAP LoadEx(string filename, FREE_IMAGE_LOAD_FLAGS flags, ref FREE_IMAGE_FORMAT format)
-        {
-            // check if file exists
-            if (!File.Exists(filename))
-            {
-                throw new FileNotFoundException(filename + " could not be found.");
-            }
-            FIBITMAP dib = new FIBITMAP();
-            if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-            {
-                // query all plugins to see if one can read the file
-                format = GetFileType(filename, 0);
-            }
-            // check if the plugin is capable of loading files
-            if (FIFSupportsReading(format))
-            {
-                dib = Load(format, filename, flags);
-            }
-            return dib;
-        }
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
+		/// real format is being analysed. If no plugin can read the file, format remains
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="format">Format of the image. If the format is unknown use
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadEx it will be returned in format.
+		/// </param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists.</exception>
+		public static FIBITMAP LoadEx(string filename, FREE_IMAGE_LOAD_FLAGS flags, ref FREE_IMAGE_FORMAT format)
+		{
+			// check if file exists
+			if (!File.Exists(filename))
+			{
+				throw new FileNotFoundException(filename + " could not be found.");
+			}
+			FIBITMAP dib = new FIBITMAP();
+			if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+			{
+				// query all plugins to see if one can read the file
+				format = GetFileType(filename, 0);
+			}
+			// check if the plugin is capable of loading files
+			if (FIFSupportsReading(format))
+			{
+				dib = Load(format, filename, flags);
+			}
+			return dib;
+		}
 
 		/// <summary>
 		/// Loads a .NET <see cref="System.Drawing.Bitmap"/> from a file.
@@ -1092,1500 +1092,1500 @@ namespace FreeImageAPI
 			return result;
 		}
 
-        /// <summary>
-        /// Deletes a previously loaded FreeImage bitmap from memory and resets the handle to 0.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        public static void UnloadEx(ref FIBITMAP dib)
-        {
-            if (!dib.IsNull)
-            {
-                Unload(dib);
-                dib.SetNull();
-            }
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// The format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(FIBITMAP dib, string filename)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                FREE_IMAGE_FORMAT.FIF_UNKNOWN,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
-        /// the format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="format">Format of the image. If the format should be taken from the
-        /// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_FORMAT format)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                format,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// The format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.
-        /// If the function failed and returned false, the bitmap was not unloaded.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            ref FIBITMAP dib,
-            string filename,
-            bool unloadSource)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                FREE_IMAGE_FORMAT.FIF_UNKNOWN,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// The format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// Save flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                FREE_IMAGE_FORMAT.FIF_UNKNOWN,
-                flags,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// The format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// Save flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.
-        /// If the function failed and returned false, the bitmap was not unloaded.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            ref FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_SAVE_FLAGS flags,
-            bool unloadSource)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                FREE_IMAGE_FORMAT.FIF_UNKNOWN,
-                flags,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
-        /// the format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="format">Format of the image. If the format should be taken from the
-        /// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.
-        /// If the function failed and returned false, the bitmap was not unloaded.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            ref FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_FORMAT format,
-            bool unloadSource)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                format,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
-        /// the format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// Save flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="format">Format of the image. If the format should be taken from the
-        /// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            return SaveEx(
-                ref dib,
-                filename,
-                format,
-                flags,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a file.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
-        /// the format is taken off the filename.
-        /// If no suitable format was found false will be returned.
-        /// Save flags can be provided by the flags parameter.
-        /// The bitmaps color depth can be set by 'colorDepth'.
-        /// If set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> a suitable color depth
-        /// will be taken if available.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="filename">The complete name of the file to save to.
-        /// The extension will be corrected if it is no valid extension for the
-        /// selected format or if no extension was specified.</param>
-        /// <param name="format">Format of the image. If the format should be taken from the
-        /// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="colorDepth">The new color depth of the bitmap.
-        /// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if Save should take the
-        /// best suitable color depth.
-        /// If a color depth is selected that the provided format cannot write an
-        /// error-message will be thrown.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.
-        /// If the function failed and returned false, the bitmap was not unloaded.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentException">
-        /// A direct color conversion failed.</exception>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
-        public static bool SaveEx(
-            ref FIBITMAP dib,
-            string filename,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags,
-            FREE_IMAGE_COLOR_DEPTH colorDepth,
-            bool unloadSource)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            if (filename == null)
-            {
-                throw new ArgumentNullException("filename");
-            }
-            bool result = false;
-            // Gets format from filename if the format is unknown
-            if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-            {
-                format = GetFIFFromFilename(filename);
-            }
-            if (format != FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-            {
-                // Checks writing support
-                if (FIFSupportsWriting(format) && FIFSupportsExportType(format, GetImageType(dib)))
-                {
-                    // Check valid filename and correct it if needed
-                    if (!IsFilenameValidForFIF(format, filename))
-                    {
-                        string extension = GetPrimaryExtensionFromFIF(format);
-                        filename = Path.ChangeExtension(filename, extension);
-                    }
-
-                    FIBITMAP dibToSave = PrepareBitmapColorDepth(dib, format, colorDepth);
-                    try
-                    {
-                        result = Save(format, dibToSave, filename, flags);
-                    }
-                    finally
-                    {
-                        // Always unload a temporary created bitmap.
-                        if (dibToSave != dib)
-                        {
-                            UnloadEx(ref dibToSave);
-                        }
-                        // On success unload the bitmap
-                        if (result && unloadSource)
-                        {
-                            UnloadEx(ref dib);
-                        }
-                    }
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// The stream must be set to the correct position before calling LoadFromStream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> is not capable of reading.</exception>
-        public static FIBITMAP LoadFromStream(Stream stream)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return LoadFromStream(stream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// The stream must be set to the correct position before calling LoadFromStream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> is not capable of reading.</exception>
-        public static FIBITMAP LoadFromStream(Stream stream, FREE_IMAGE_LOAD_FLAGS flags)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return LoadFromStream(stream, flags, ref format);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the
-        /// bitmaps real format is being analysed.
-        /// The stream must be set to the correct position before calling LoadFromStream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="format">Format of the image. If the format is unknown use
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadFromStream it will be returned in format.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> is not capable of reading.</exception>
-        public static FIBITMAP LoadFromStream(Stream stream, ref FREE_IMAGE_FORMAT format)
-        {
-            return LoadFromStream(stream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
-        /// the bitmaps real format is being analysed.
-        /// The stream must be set to the correct position before calling LoadFromStream.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="format">Format of the image. If the format is unknown use
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadFromStream it will be returned in format.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> is not capable of reading.</exception>
-        public static FIBITMAP LoadFromStream(
-            Stream stream,
-            FREE_IMAGE_LOAD_FLAGS flags,
-            ref FREE_IMAGE_FORMAT format)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException("stream is not capable of reading.");
-            }
-            // Wrap the source stream if it is unable to seek (which is required by FreeImage)
-            stream = (stream.CanSeek) ? stream : new StreamWrapper(stream, true);
-
-            stream.Position = 0L;
-            if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-            {
-                // Get the format of the bitmap
-                format = GetFileTypeFromStream(stream);
-                // Restore the streams position
-                stream.Position = 0L;
-            }
-            if (!FIFSupportsReading(format))
-            {
-                return FIBITMAP.Zero;
-            }
-            // Create a 'FreeImageIO' structure for calling 'LoadFromHandle'
-            // using the internal structure 'FreeImageStreamIO'.
-            FreeImageIO io = FreeImageStreamIO.io;
-            using (fi_handle handle = new fi_handle(stream))
-            {
-                return LoadFromHandle(format, ref io, handle, flags);
-            }
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format)
-        {
-            return SaveToStream(
-                ref dib,
-                stream,
-                format,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            ref FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            bool unloadSource)
-        {
-            return SaveToStream(
-                ref dib,
-                stream,
-                format,
-                FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            return SaveToStream(
-                ref dib,
-                stream,
-                format,
-                flags,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            ref FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags,
-            bool unloadSource)
-        {
-            return SaveToStream(
-                ref dib, stream,
-                format,
-                flags,
-                FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="colorDepth">The new color depth of the bitmap.
-        /// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if SaveToStream should
-        /// take the best suitable color depth.
-        /// If a color depth is selected that the provided format cannot write an
-        /// error-message will be thrown.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags,
-            FREE_IMAGE_COLOR_DEPTH colorDepth)
-        {
-            return SaveToStream(
-                ref dib,
-                stream,
-                format,
-                flags,
-                colorDepth,
-                false);
-        }
-
-        /// <summary>
-        /// Saves a previously loaded FreeImage bitmap to a stream.
-        /// The stream must be set to the correct position before calling SaveToStream.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="stream">The stream to write to.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="colorDepth">The new color depth of the bitmap.
-        /// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if SaveToStream should
-        /// take the best suitable color depth.
-        /// If a color depth is selected that the provided format cannot write an
-        /// error-message will be thrown.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> cannot write.</exception>
-        public static bool SaveToStream(
-            ref FIBITMAP dib,
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_SAVE_FLAGS flags,
-            FREE_IMAGE_COLOR_DEPTH colorDepth,
-            bool unloadSource)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            if (stream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
-            if (!stream.CanWrite)
-            {
-                throw new ArgumentException("stream is not capable of writing.");
-            }
-            if ((!FIFSupportsWriting(format)) || (!FIFSupportsExportType(format, GetImageType(dib))))
-            {
-                return false;
-            }
-
-            FIBITMAP dibToSave = PrepareBitmapColorDepth(dib, format, colorDepth);
-            bool result = false;
-
-            try
-            {
-                // Create a 'FreeImageIO' structure for calling 'SaveToHandle'
-                FreeImageIO io = FreeImageStreamIO.io;
-
-                using (fi_handle handle = new fi_handle(stream))
-                {
-                    result = SaveToHandle(format, dibToSave, ref io, handle, flags);
-                }
-            }
-            finally
-            {
-                // Always unload a temporary created bitmap.
-                if (dibToSave != dib)
-                {
-                    UnloadEx(ref dibToSave);
-                }
-                // On success unload the bitmap
-                if (result && unloadSource)
-                {
-                    UnloadEx(ref dib);
-                }
-            }
-
-            return result;
-        }
-
-        #endregion
-
-        #region Plugin functions
-
-        /// <summary>
-        /// Checks if an extension is valid for a certain format.
-        /// </summary>
-        /// <param name="fif">The desired format.</param>
-        /// <param name="extension">The desired extension.</param>
-        /// <returns>True if the extension is valid for the given format, false otherwise.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="extension"/> is null.</exception>
-        public static bool IsExtensionValidForFIF(FREE_IMAGE_FORMAT fif, string extension)
-        {
-            return IsExtensionValidForFIF(fif, extension, StringComparison.CurrentCultureIgnoreCase);
-        }
-
-        /// <summary>
-        /// Checks if an extension is valid for a certain format.
-        /// </summary>
-        /// <param name="fif">The desired format.</param>
-        /// <param name="extension">The desired extension.</param>
-        /// <param name="comparisonType">The string comparison type.</param>
-        /// <returns>True if the extension is valid for the given format, false otherwise.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="extension"/> is null.</exception>
-        public static bool IsExtensionValidForFIF(FREE_IMAGE_FORMAT fif, string extension, StringComparison comparisonType)
-        {
-            if (extension == null)
-            {
-                throw new ArgumentNullException("extension");
-            }
-            bool result = false;
-            // Split up the string and compare each with the given extension
-            string tempList = GetFIFExtensionList(fif);
-            if (tempList != null)
-            {
-                string[] extensionList = tempList.Split(',');
-                foreach (string ext in extensionList)
-                {
-                    if (extension.Equals(ext, comparisonType))
-                    {
-                        result = true;
-                        break;
-                    }
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Checks if a filename is valid for a certain format.
-        /// </summary>
-        /// <param name="fif">The desired format.</param>
-        /// <param name="filename">The desired filename.</param>
-        /// <returns>True if the filename is valid for the given format, false otherwise.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="filename"/> is null.</exception>
-        public static bool IsFilenameValidForFIF(FREE_IMAGE_FORMAT fif, string filename)
-        {
-            return IsFilenameValidForFIF(fif, filename, StringComparison.CurrentCultureIgnoreCase);
-        }
-
-        /// <summary>
-        /// Checks if a filename is valid for a certain format.
-        /// </summary>
-        /// <param name="fif">The desired format.</param>
-        /// <param name="filename">The desired filename.</param>
-        /// <param name="comparisonType">The string comparison type.</param>
-        /// <returns>True if the filename is valid for the given format, false otherwise.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="filename"/> is null.</exception>
-        public static bool IsFilenameValidForFIF(FREE_IMAGE_FORMAT fif, string filename, StringComparison comparisonType)
-        {
-            if (filename == null)
-            {
-                throw new ArgumentNullException("filename");
-            }
-            bool result = false;
-            // Extract the filenames extension if it exists
-            string extension = Path.GetExtension(filename);
-            if (extension.Length != 0)
-            {
-                extension = extension.Remove(0, 1);
-                result = IsExtensionValidForFIF(fif, extension, comparisonType);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// This function returns the primary (main or most commonly used?) extension of a certain
-        /// image format (fif). This is done by returning the first of all possible extensions
-        /// returned by GetFIFExtensionList().
-        /// That assumes, that the plugin returns the extensions in ordered form.</summary>
-        /// <param name="fif">The image format to obtain the primary extension for.</param>
-        /// <returns>The primary extension of the specified image format.</returns>
-        public static string GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT fif)
-        {
-            string result = null;
-            string extensions = GetFIFExtensionList(fif);
-            if (extensions != null)
-            {
-                int position = extensions.IndexOf(',');
-                if (position < 0)
-                {
-                    result = extensions;
-                }
-                else
-                {
-                    result = extensions.Substring(0, position);
-                }
-            }
-            return result;
-        }
-
-        #endregion
-
-        #region Multipage functions
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(string filename)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return OpenMultiBitmapEx(
-                filename,
-                ref format,
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                false,
-                false,
-                false);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(string filename, bool keep_cache_in_memory)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return OpenMultiBitmapEx(
-                filename,
-                ref format,
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                false,
-                false,
-                keep_cache_in_memory);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="read_only">When true the bitmap will be loaded read only.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(
-            string filename,
-            bool read_only,
-            bool keep_cache_in_memory)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return OpenMultiBitmapEx(
-                filename,
-                ref format,
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                false,
-                read_only,
-                keep_cache_in_memory);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="create_new">When true a new bitmap is created.</param>
-        /// <param name="read_only">When true the bitmap will be loaded read only.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(
-            string filename,
-            bool create_new,
-            bool read_only,
-            bool keep_cache_in_memory)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return OpenMultiBitmapEx(
-                filename,
-                ref format,
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                create_new,
-                read_only,
-                keep_cache_in_memory);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files real
-        /// format is being analysed. If no plugin can read the file, format remains
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="format">Format of the image. If the format is unknown use
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadEx it will be returned in format.</param>
-        /// <param name="create_new">When true a new bitmap is created.</param>
-        /// <param name="read_only">When true the bitmap will be loaded read only.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(
-            string filename,
-            ref FREE_IMAGE_FORMAT format,
-            bool create_new,
-            bool read_only,
-            bool keep_cache_in_memory)
-        {
-            return OpenMultiBitmapEx(
-                filename,
-                ref format,
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                create_new,
-                read_only,
-                keep_cache_in_memory);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
-        /// real format is being analysed. If no plugin can read the file, format remains
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="filename">The complete name of the file to load.</param>
-        /// <param name="format">Format of the image. If the format is unknown use 
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
-        /// In case a suitable format was found by LoadEx it will be returned in format.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="create_new">When true a new bitmap is created.</param>
-        /// <param name="read_only">When true the bitmap will be loaded read only.</param>
-        /// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filename"/> does not exists while opening.</exception>
-        public static FIMULTIBITMAP OpenMultiBitmapEx(
-            string filename,
-            ref FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_LOAD_FLAGS flags,
-            bool create_new,
-            bool read_only,
-            bool keep_cache_in_memory)
-        {
-            if (!File.Exists(filename) && !create_new)
-            {
-                throw new FileNotFoundException(filename + " could not be found.");
-            }
-            if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-            {
-                // Check if a plugin can read the data
-                format = GetFileType(filename, 0);
-            }
-            FIMULTIBITMAP dib = new FIMULTIBITMAP();
-            if (FIFSupportsReading(format))
-            {
-                dib = OpenMultiBitmap(format, filename, create_new, read_only, keep_cache_in_memory, flags);
-            }
-            return dib;
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// </summary>
-        /// <param name="stream">The stream to load the bitmap from.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        public static FIMULTIBITMAP OpenMultiBitmapFromStream(Stream stream)
-        {
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            return OpenMultiBitmapFromStream(stream, ref format, FREE_IMAGE_LOAD_FLAGS.DEFAULT);
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap.
-        /// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
-        /// real format is being analysed. If no plugin can read the file, format remains
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
-        /// Load flags can be provided by the flags parameter.
-        /// </summary>
-        /// <param name="stream">The stream to load the bitmap from.</param>
-        /// <param name="format">Format of the image. If the format is unknown use 
-        /// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/></param>.
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        public static FIMULTIBITMAP OpenMultiBitmapFromStream(Stream stream, ref FREE_IMAGE_FORMAT format, FREE_IMAGE_LOAD_FLAGS flags)
-        {
-            if (stream == null)
-                return FIMULTIBITMAP.Zero;
-
-            if (!stream.CanSeek)
-                stream = new StreamWrapper(stream, true);
-
-            FIMULTIBITMAP mdib = FIMULTIBITMAP.Zero;
-            FreeImageIO io = FreeImageStreamIO.io;
-            fi_handle handle = new fi_handle(stream);
-
-            try
-            {
-                if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
-                {
-                    format = GetFileTypeFromHandle(ref io, handle, checked((int)stream.Length));
-                }
-
-                mdib = OpenMultiBitmapFromHandle(format, ref io, handle, flags);
-
-                if (mdib.IsNull)
-                {
-                    handle.Dispose();
-                }
-                else
-                {
-                    lock (streamHandles)
-                    {
-                        streamHandles.Add(mdib, handle);
-                    }
-                }
-
-                return mdib;
-            }
-            catch
-            {
-                if (!mdib.IsNull)
-                    CloseMultiBitmap(mdib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
-
-                if (handle != null)
-                    handle.Dispose();
-
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only, applies any changes made to it.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool CloseMultiBitmap(FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            if (CloseMultiBitmap_(bitmap, flags))
-            {
-                fi_handle handle;
-                lock (streamHandles)
-                {
-                    if (streamHandles.TryGetValue(bitmap, out handle))
-                    {
-                        streamHandles.Remove(bitmap);
-                        handle.Dispose();
-                    }
-                }
-                return true;
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only,
-        /// applies any changes made to it.
-        /// On success the handle will be reset to null.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool CloseMultiBitmapEx(ref FIMULTIBITMAP bitmap)
-        {
-            return CloseMultiBitmapEx(ref bitmap, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
-        }
-
-        /// <summary>
-        /// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only,
-        /// applies any changes made to it.
-        /// On success the handle will be reset to null.
-        /// </summary>
-        /// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool CloseMultiBitmapEx(ref FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags)
-        {
-            bool result = false;
-            if (!bitmap.IsNull)
-            {
-                if (CloseMultiBitmap(bitmap, flags))
-                {
-                    bitmap.SetNull();
-                    result = true;
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Retrieves the number of pages that are locked in a multi-paged bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <returns>Number of locked pages.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static int GetLockedPageCount(FIMULTIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            int result = 0;
-            GetLockedPageNumbers(dib, null, ref result);
-            return result;
-        }
-
-        /// <summary>
-        /// Retrieves a list locked pages of a multi-paged bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage multi-paged bitmap.</param>
-        /// <returns>List containing the indexes of the locked pages.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static int[] GetLockedPages(FIMULTIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            // Get the number of pages and create an array to save the information
-            int count = 0;
-            int[] result = null;
-            // Get count
-            if (GetLockedPageNumbers(dib, result, ref count))
-            {
-                result = new int[count];
-                // Fill array
-                if (!GetLockedPageNumbers(dib, result, ref count))
-                {
-                    result = null;
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Loads a FreeImage multi-paged bitmap from a stream and returns the
-        /// FreeImage memory stream used as temporary buffer.
-        /// The bitmap can not be modified by calling
-        /// <see cref="FreeImage.AppendPage(FIMULTIBITMAP,FIBITMAP)"/>,
-        /// <see cref="FreeImage.InsertPage(FIMULTIBITMAP,Int32,FIBITMAP)"/>,
-        /// <see cref="FreeImage.MovePage(FIMULTIBITMAP,Int32,Int32)"/> or
-        /// <see cref="FreeImage.DeletePage(FIMULTIBITMAP,Int32)"/>.
-        /// </summary>
-        /// <param name="stream">The stream to read from.</param>
-        /// <param name="format">Format of the image.</param>
-        /// <param name="flags">Flags to enable or disable plugin-features.</param>
-        /// <param name="memory">The temporary memory buffer used to load the bitmap.</param>
-        /// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> can not read.</exception>
-        public static FIMULTIBITMAP LoadMultiBitmapFromStream(
-            Stream stream,
-            FREE_IMAGE_FORMAT format,
-            FREE_IMAGE_LOAD_FLAGS flags,
-            out FIMEMORY memory)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException("stream");
-            }
-            const int blockSize = 1024;
-            int bytesRead;
-            byte[] buffer = new byte[blockSize];
-
-            stream = stream.CanSeek ? stream : new StreamWrapper(stream, true);
-            memory = OpenMemory(IntPtr.Zero, 0);
-
-            do
-            {
-                bytesRead = stream.Read(buffer, 0, blockSize);
-                WriteMemory(buffer, (uint)blockSize, (uint)1, memory);
-            }
-            while (bytesRead == blockSize);
-
-            return LoadMultiBitmapFromMemory(format, memory, flags);
-        }
-
-        #endregion
-
-        #region Filetype functions
-
-        /// <summary>
-        /// Orders FreeImage to analyze the bitmap signature.
-        /// In case the stream is not seekable, the stream will have been used
-        /// and must be recreated for loading.
-        /// </summary>
-        /// <param name="stream">Name of the stream to analyze.</param>
-        /// <returns>Type of the bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="stream"/> is null.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="stream"/> can not read.</exception>
-        public static FREE_IMAGE_FORMAT GetFileTypeFromStream(Stream stream)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException("stream");
-            }
-            if (!stream.CanRead)
-            {
-                throw new ArgumentException("stream is not capable of reading.");
-            }
-            // Wrap the stream if it cannot seek
-            stream = (stream.CanSeek) ? stream : new StreamWrapper(stream, true);
-            // Create a 'FreeImageIO' structure for the stream
-            FreeImageIO io = FreeImageStreamIO.io;
-            using (fi_handle handle = new fi_handle(stream))
-            {
-                return GetFileTypeFromHandle(ref io, handle, 0);
-            }
-        }
-
-        #endregion
-
-        #region Bitmap information functions
-
-        /// <summary>
-        /// Retrieves a DIB's resolution in X-direction measured in 'dots per inch' (DPI) and not in
-        /// 'dots per meter'.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The resolution in 'dots per inch'.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static uint GetResolutionX(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            return (uint)(0.5d + 0.0254d * GetDotsPerMeterX(dib));
-        }
-
-        /// <summary>
-        /// Retrieves a DIB's resolution in Y-direction measured in 'dots per inch' (DPI) and not in
-        /// 'dots per meter'.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The resolution in 'dots per inch'.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static uint GetResolutionY(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            return (uint)(0.5d + 0.0254d * GetDotsPerMeterY(dib));
-        }
-
-        /// <summary>
-        /// Sets a DIB's resolution in X-direction measured in 'dots per inch' (DPI) and not in
-        /// 'dots per meter'.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="res">The new resolution in 'dots per inch'.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static void SetResolutionX(FIBITMAP dib, uint res)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            SetDotsPerMeterX(dib, (uint)((double)res / 0.0254d + 0.5d));
-        }
-
-        /// <summary>
-        /// Sets a DIB's resolution in Y-direction measured in 'dots per inch' (DPI) and not in
-        /// 'dots per meter'.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="res">The new resolution in 'dots per inch'.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static void SetResolutionY(FIBITMAP dib, uint res)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            SetDotsPerMeterY(dib, (uint)((double)res / 0.0254d + 0.5d));
-        }
-
-        /// <summary>
-        /// Returns whether the image is a greyscale image or not.
-        /// The function scans all colors in the bitmaps palette for entries where
-        /// red, green and blue are not all the same (not a grey color).
-        /// Supports 1-, 4- and 8-bit bitmaps.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>True if the image is a greyscale image, else false.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static unsafe bool IsGreyscaleImage(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            bool result = true;
-            uint bpp = GetBPP(dib);
-            switch (bpp)
-            {
-                case 1:
-                case 4:
-                case 8:
-                    RGBQUAD* palette = (RGBQUAD*)GetPalette(dib);
-                    uint paletteLength = GetColorsUsed(dib);
-                    for (int i = 0; i < paletteLength; i++)
-                    {
-                        if (palette[i].rgbRed != palette[i].rgbGreen ||
-                            palette[i].rgbRed != palette[i].rgbBlue)
-                        {
-                            result = false;
-                            break;
-                        }
-                    }
-                    break;
-                default:
-                    result = false;
-                    break;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Returns a structure that represents the palette of a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>A structure representing the bitmaps palette.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static Palette GetPaletteEx(FIBITMAP dib)
-        {
-            return new Palette(dib);
-        }
-
-        /// <summary>
-        /// Returns the <see cref="BITMAPINFOHEADER"/> structure of a FreeImage bitmap.
-        /// The structure is a copy, so changes will have no effect on
-        /// the bitmap itself.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns><see cref="BITMAPINFOHEADER"/> structure of the bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static unsafe BITMAPINFOHEADER GetInfoHeaderEx(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            return *(BITMAPINFOHEADER*)GetInfoHeader(dib);
-        }
-
-        /// <summary>
-        /// Returns the <see cref="BITMAPINFO"/> structure of a FreeImage bitmap.
-        /// The structure is a copy, so changes will have no effect on
-        /// the bitmap itself.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns><see cref="BITMAPINFO"/> structure of the bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static BITMAPINFO GetInfoEx(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            BITMAPINFO result = new BITMAPINFO();
-            result.bmiHeader = GetInfoHeaderEx(dib);
-            IntPtr ptr = GetPalette(dib);
-            if (ptr == IntPtr.Zero)
-            {
-                result.bmiColors = new RGBQUAD[0];
-            }
-            else
-            {
-                result.bmiColors = new MemoryArray<RGBQUAD>(ptr, (int)result.bmiHeader.biClrUsed).Data;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Returns the pixelformat of the bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns><see cref="System.Drawing.Imaging.PixelFormat"/> of the bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static PixelFormat GetPixelFormat(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-
-            PixelFormat result = PixelFormat.Undefined;
-
-            if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
-            {
-                switch (GetBPP(dib))
-                {
-                    case 1:
-                        result = PixelFormat.Format1bppIndexed;
-                        break;
-                    case 4:
-                        result = PixelFormat.Format4bppIndexed;
-                        break;
-                    case 8:
-                        result = PixelFormat.Format8bppIndexed;
-                        break;
-                    case 16:
-                        if ((GetBlueMask(dib) == FI16_565_BLUE_MASK) &&
-                            (GetGreenMask(dib) == FI16_565_GREEN_MASK) &&
-                            (GetRedMask(dib) == FI16_565_RED_MASK))
-                        {
-                            result = PixelFormat.Format16bppRgb565;
-                        }
-                        if ((GetBlueMask(dib) == FI16_555_BLUE_MASK) &&
-                            (GetGreenMask(dib) == FI16_555_GREEN_MASK) &&
-                            (GetRedMask(dib) == FI16_555_RED_MASK))
-                        {
-                            result = PixelFormat.Format16bppRgb555;
-                        }
-                        break;
-                    case 24:
-                        result = PixelFormat.Format24bppRgb;
-                        break;
-                    case 32:
-                        result = PixelFormat.Format32bppArgb;
-                        break;
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Retrieves all parameters needed to create a new FreeImage bitmap from
-        /// the format of a .NET <see cref="System.Drawing.Image"/>.
-        /// </summary>
-        /// <param name="format">The <see cref="System.Drawing.Imaging.PixelFormat"/>
-        /// of the .NET <see cref="System.Drawing.Image"/>.</param>
-        /// <param name="type">Returns the type used for the new bitmap.</param>
-        /// <param name="bpp">Returns the color depth for the new bitmap.</param>
-        /// <param name="red_mask">Returns the red_mask for the new bitmap.</param>
-        /// <param name="green_mask">Returns the green_mask for the new bitmap.</param>
-        /// <param name="blue_mask">Returns the blue_mask for the new bitmap.</param>
-        /// <returns>True in case a matching conversion exists; else false.
-        /// </returns>
-        public static bool GetFormatParameters(
-            PixelFormat format,
-            out FREE_IMAGE_TYPE type,
-            out uint bpp,
-            out uint red_mask,
-            out uint green_mask,
-            out uint blue_mask)
-        {
-            bool result = false;
-            type = FREE_IMAGE_TYPE.FIT_UNKNOWN;
-            bpp = 0;
-            red_mask = 0;
-            green_mask = 0;
-            blue_mask = 0;
-            switch (format)
-            {
-                case PixelFormat.Format1bppIndexed:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 1;
-                    result = true;
-                    break;
-                case PixelFormat.Format4bppIndexed:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 4;
-                    result = true;
-                    break;
-                case PixelFormat.Format8bppIndexed:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 8;
-                    result = true;
-                    break;
-                case PixelFormat.Format16bppRgb565:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 16;
-                    red_mask = FI16_565_RED_MASK;
-                    green_mask = FI16_565_GREEN_MASK;
-                    blue_mask = FI16_565_BLUE_MASK;
-                    result = true;
-                    break;
-                case PixelFormat.Format16bppRgb555:
-                case PixelFormat.Format16bppArgb1555:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 16;
-                    red_mask = FI16_555_RED_MASK;
-                    green_mask = FI16_555_GREEN_MASK;
-                    blue_mask = FI16_555_BLUE_MASK;
-                    result = true;
-                    break;
-                case PixelFormat.Format24bppRgb:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 24;
-                    red_mask = FI_RGBA_RED_MASK;
-                    green_mask = FI_RGBA_GREEN_MASK;
-                    blue_mask = FI_RGBA_BLUE_MASK;
-                    result = true;
-                    break;
-                case PixelFormat.Format32bppRgb:
-                case PixelFormat.Format32bppArgb:
-                case PixelFormat.Format32bppPArgb:
-                    type = FREE_IMAGE_TYPE.FIT_BITMAP;
-                    bpp = 32;
-                    red_mask = FI_RGBA_RED_MASK;
-                    green_mask = FI_RGBA_GREEN_MASK;
-                    blue_mask = FI_RGBA_BLUE_MASK;
-                    result = true;
-                    break;
-                case PixelFormat.Format16bppGrayScale:
-                    type = FREE_IMAGE_TYPE.FIT_UINT16;
-                    bpp = 16;
-                    result = true;
-                    break;
-                case PixelFormat.Format48bppRgb:
-                    type = FREE_IMAGE_TYPE.FIT_RGB16;
-                    bpp = 48;
-                    result = true;
-                    break;
-                case PixelFormat.Format64bppArgb:
-                case PixelFormat.Format64bppPArgb:
-                    type = FREE_IMAGE_TYPE.FIT_RGBA16;
-                    bpp = 64;
-                    result = true;
-                    break;
-            }
-            return result;
-        }
+		/// <summary>
+		/// Deletes a previously loaded FreeImage bitmap from memory and resets the handle to 0.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		public static void UnloadEx(ref FIBITMAP dib)
+		{
+			if (!dib.IsNull)
+			{
+				Unload(dib);
+				dib.SetNull();
+			}
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// The format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(FIBITMAP dib, string filename)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				FREE_IMAGE_FORMAT.FIF_UNKNOWN,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
+		/// the format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="format">Format of the image. If the format should be taken from the
+		/// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_FORMAT format)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				format,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// The format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.
+		/// If the function failed and returned false, the bitmap was not unloaded.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			ref FIBITMAP dib,
+			string filename,
+			bool unloadSource)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				FREE_IMAGE_FORMAT.FIF_UNKNOWN,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// The format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// Save flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				FREE_IMAGE_FORMAT.FIF_UNKNOWN,
+				flags,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// The format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// Save flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.
+		/// If the function failed and returned false, the bitmap was not unloaded.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			ref FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_SAVE_FLAGS flags,
+			bool unloadSource)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				FREE_IMAGE_FORMAT.FIF_UNKNOWN,
+				flags,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
+		/// the format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="format">Format of the image. If the format should be taken from the
+		/// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.
+		/// If the function failed and returned false, the bitmap was not unloaded.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			ref FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_FORMAT format,
+			bool unloadSource)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				format,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
+		/// the format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// Save flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="format">Format of the image. If the format should be taken from the
+		/// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			return SaveEx(
+				ref dib,
+				filename,
+				format,
+				flags,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a file.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
+		/// the format is taken off the filename.
+		/// If no suitable format was found false will be returned.
+		/// Save flags can be provided by the flags parameter.
+		/// The bitmaps color depth can be set by 'colorDepth'.
+		/// If set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> a suitable color depth
+		/// will be taken if available.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="filename">The complete name of the file to save to.
+		/// The extension will be corrected if it is no valid extension for the
+		/// selected format or if no extension was specified.</param>
+		/// <param name="format">Format of the image. If the format should be taken from the
+		/// filename use <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="colorDepth">The new color depth of the bitmap.
+		/// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if Save should take the
+		/// best suitable color depth.
+		/// If a color depth is selected that the provided format cannot write an
+		/// error-message will be thrown.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.
+		/// If the function failed and returned false, the bitmap was not unloaded.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentException">
+		/// A direct color conversion failed.</exception>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="filename"/> is null.</exception>
+		public static bool SaveEx(
+			ref FIBITMAP dib,
+			string filename,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags,
+			FREE_IMAGE_COLOR_DEPTH colorDepth,
+			bool unloadSource)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			if (filename == null)
+			{
+				throw new ArgumentNullException("filename");
+			}
+			bool result = false;
+			// Gets format from filename if the format is unknown
+			if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+			{
+				format = GetFIFFromFilename(filename);
+			}
+			if (format != FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+			{
+				// Checks writing support
+				if (FIFSupportsWriting(format) && FIFSupportsExportType(format, GetImageType(dib)))
+				{
+					// Check valid filename and correct it if needed
+					if (!IsFilenameValidForFIF(format, filename))
+					{
+						string extension = GetPrimaryExtensionFromFIF(format);
+						filename = Path.ChangeExtension(filename, extension);
+					}
+
+					FIBITMAP dibToSave = PrepareBitmapColorDepth(dib, format, colorDepth);
+					try
+					{
+						result = Save(format, dibToSave, filename, flags);
+					}
+					finally
+					{
+						// Always unload a temporary created bitmap.
+						if (dibToSave != dib)
+						{
+							UnloadEx(ref dibToSave);
+						}
+						// On success unload the bitmap
+						if (result && unloadSource)
+						{
+							UnloadEx(ref dib);
+						}
+					}
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// The stream must be set to the correct position before calling LoadFromStream.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> is not capable of reading.</exception>
+		public static FIBITMAP LoadFromStream(Stream stream)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return LoadFromStream(stream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// The stream must be set to the correct position before calling LoadFromStream.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> is not capable of reading.</exception>
+		public static FIBITMAP LoadFromStream(Stream stream, FREE_IMAGE_LOAD_FLAGS flags)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return LoadFromStream(stream, flags, ref format);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the
+		/// bitmaps real format is being analysed.
+		/// The stream must be set to the correct position before calling LoadFromStream.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="format">Format of the image. If the format is unknown use
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadFromStream it will be returned in format.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> is not capable of reading.</exception>
+		public static FIBITMAP LoadFromStream(Stream stream, ref FREE_IMAGE_FORMAT format)
+		{
+			return LoadFromStream(stream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>
+		/// the bitmaps real format is being analysed.
+		/// The stream must be set to the correct position before calling LoadFromStream.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="format">Format of the image. If the format is unknown use
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadFromStream it will be returned in format.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> is not capable of reading.</exception>
+		public static FIBITMAP LoadFromStream(
+			Stream stream,
+			FREE_IMAGE_LOAD_FLAGS flags,
+			ref FREE_IMAGE_FORMAT format)
+		{
+			if (stream == null)
+			{
+				throw new ArgumentNullException("stream");
+			}
+			if (!stream.CanRead)
+			{
+				throw new ArgumentException("stream is not capable of reading.");
+			}
+			// Wrap the source stream if it is unable to seek (which is required by FreeImage)
+			stream = (stream.CanSeek) ? stream : new StreamWrapper(stream, true);
+
+			stream.Position = 0L;
+			if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+			{
+				// Get the format of the bitmap
+				format = GetFileTypeFromStream(stream);
+				// Restore the streams position
+				stream.Position = 0L;
+			}
+			if (!FIFSupportsReading(format))
+			{
+				return FIBITMAP.Zero;
+			}
+			// Create a 'FreeImageIO' structure for calling 'LoadFromHandle'
+			// using the internal structure 'FreeImageStreamIO'.
+			FreeImageIO io = FreeImageStreamIO.io;
+			using (fi_handle handle = new fi_handle(stream))
+			{
+				return LoadFromHandle(format, ref io, handle, flags);
+			}
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format)
+		{
+			return SaveToStream(
+				ref dib,
+				stream,
+				format,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			ref FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			bool unloadSource)
+		{
+			return SaveToStream(
+				ref dib,
+				stream,
+				format,
+				FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			return SaveToStream(
+				ref dib,
+				stream,
+				format,
+				flags,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			ref FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags,
+			bool unloadSource)
+		{
+			return SaveToStream(
+				ref dib, stream,
+				format,
+				flags,
+				FREE_IMAGE_COLOR_DEPTH.FICD_AUTO,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="colorDepth">The new color depth of the bitmap.
+		/// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if SaveToStream should
+		/// take the best suitable color depth.
+		/// If a color depth is selected that the provided format cannot write an
+		/// error-message will be thrown.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags,
+			FREE_IMAGE_COLOR_DEPTH colorDepth)
+		{
+			return SaveToStream(
+				ref dib,
+				stream,
+				format,
+				flags,
+				colorDepth,
+				false);
+		}
+
+		/// <summary>
+		/// Saves a previously loaded FreeImage bitmap to a stream.
+		/// The stream must be set to the correct position before calling SaveToStream.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="stream">The stream to write to.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="colorDepth">The new color depth of the bitmap.
+		/// Set to <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_AUTO"/> if SaveToStream should
+		/// take the best suitable color depth.
+		/// If a color depth is selected that the provided format cannot write an
+		/// error-message will be thrown.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> cannot write.</exception>
+		public static bool SaveToStream(
+			ref FIBITMAP dib,
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_SAVE_FLAGS flags,
+			FREE_IMAGE_COLOR_DEPTH colorDepth,
+			bool unloadSource)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			if (stream == null)
+			{
+				throw new ArgumentNullException("stream");
+			}
+			if (!stream.CanWrite)
+			{
+				throw new ArgumentException("stream is not capable of writing.");
+			}
+			if ((!FIFSupportsWriting(format)) || (!FIFSupportsExportType(format, GetImageType(dib))))
+			{
+				return false;
+			}
+
+			FIBITMAP dibToSave = PrepareBitmapColorDepth(dib, format, colorDepth);
+			bool result = false;
+
+			try
+			{
+				// Create a 'FreeImageIO' structure for calling 'SaveToHandle'
+				FreeImageIO io = FreeImageStreamIO.io;
+
+				using (fi_handle handle = new fi_handle(stream))
+				{
+					result = SaveToHandle(format, dibToSave, ref io, handle, flags);
+				}
+			}
+			finally
+			{
+				// Always unload a temporary created bitmap.
+				if (dibToSave != dib)
+				{
+					UnloadEx(ref dibToSave);
+				}
+				// On success unload the bitmap
+				if (result && unloadSource)
+				{
+					UnloadEx(ref dib);
+				}
+			}
+
+			return result;
+		}
+
+		#endregion
+
+		#region Plugin functions
+
+		/// <summary>
+		/// Checks if an extension is valid for a certain format.
+		/// </summary>
+		/// <param name="fif">The desired format.</param>
+		/// <param name="extension">The desired extension.</param>
+		/// <returns>True if the extension is valid for the given format, false otherwise.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="extension"/> is null.</exception>
+		public static bool IsExtensionValidForFIF(FREE_IMAGE_FORMAT fif, string extension)
+		{
+			return IsExtensionValidForFIF(fif, extension, StringComparison.CurrentCultureIgnoreCase);
+		}
+
+		/// <summary>
+		/// Checks if an extension is valid for a certain format.
+		/// </summary>
+		/// <param name="fif">The desired format.</param>
+		/// <param name="extension">The desired extension.</param>
+		/// <param name="comparisonType">The string comparison type.</param>
+		/// <returns>True if the extension is valid for the given format, false otherwise.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="extension"/> is null.</exception>
+		public static bool IsExtensionValidForFIF(FREE_IMAGE_FORMAT fif, string extension, StringComparison comparisonType)
+		{
+			if (extension == null)
+			{
+				throw new ArgumentNullException("extension");
+			}
+			bool result = false;
+			// Split up the string and compare each with the given extension
+			string tempList = GetFIFExtensionList(fif);
+			if (tempList != null)
+			{
+				string[] extensionList = tempList.Split(',');
+				foreach (string ext in extensionList)
+				{
+					if (extension.Equals(ext, comparisonType))
+					{
+						result = true;
+						break;
+					}
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Checks if a filename is valid for a certain format.
+		/// </summary>
+		/// <param name="fif">The desired format.</param>
+		/// <param name="filename">The desired filename.</param>
+		/// <returns>True if the filename is valid for the given format, false otherwise.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="filename"/> is null.</exception>
+		public static bool IsFilenameValidForFIF(FREE_IMAGE_FORMAT fif, string filename)
+		{
+			return IsFilenameValidForFIF(fif, filename, StringComparison.CurrentCultureIgnoreCase);
+		}
+
+		/// <summary>
+		/// Checks if a filename is valid for a certain format.
+		/// </summary>
+		/// <param name="fif">The desired format.</param>
+		/// <param name="filename">The desired filename.</param>
+		/// <param name="comparisonType">The string comparison type.</param>
+		/// <returns>True if the filename is valid for the given format, false otherwise.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="filename"/> is null.</exception>
+		public static bool IsFilenameValidForFIF(FREE_IMAGE_FORMAT fif, string filename, StringComparison comparisonType)
+		{
+			if (filename == null)
+			{
+				throw new ArgumentNullException("filename");
+			}
+			bool result = false;
+			// Extract the filenames extension if it exists
+			string extension = Path.GetExtension(filename);
+			if (extension.Length != 0)
+			{
+				extension = extension.Remove(0, 1);
+				result = IsExtensionValidForFIF(fif, extension, comparisonType);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// This function returns the primary (main or most commonly used?) extension of a certain
+		/// image format (fif). This is done by returning the first of all possible extensions
+		/// returned by GetFIFExtensionList().
+		/// That assumes, that the plugin returns the extensions in ordered form.</summary>
+		/// <param name="fif">The image format to obtain the primary extension for.</param>
+		/// <returns>The primary extension of the specified image format.</returns>
+		public static string GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT fif)
+		{
+			string result = null;
+			string extensions = GetFIFExtensionList(fif);
+			if (extensions != null)
+			{
+				int position = extensions.IndexOf(',');
+				if (position < 0)
+				{
+					result = extensions;
+				}
+				else
+				{
+					result = extensions.Substring(0, position);
+				}
+			}
+			return result;
+		}
+
+		#endregion
+
+		#region Multipage functions
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(string filename)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return OpenMultiBitmapEx(
+				filename,
+				ref format,
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				false,
+				false,
+				false);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(string filename, bool keep_cache_in_memory)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return OpenMultiBitmapEx(
+				filename,
+				ref format,
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				false,
+				false,
+				keep_cache_in_memory);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="read_only">When true the bitmap will be loaded read only.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(
+			string filename,
+			bool read_only,
+			bool keep_cache_in_memory)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return OpenMultiBitmapEx(
+				filename,
+				ref format,
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				false,
+				read_only,
+				keep_cache_in_memory);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="create_new">When true a new bitmap is created.</param>
+		/// <param name="read_only">When true the bitmap will be loaded read only.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(
+			string filename,
+			bool create_new,
+			bool read_only,
+			bool keep_cache_in_memory)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return OpenMultiBitmapEx(
+				filename,
+				ref format,
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				create_new,
+				read_only,
+				keep_cache_in_memory);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files real
+		/// format is being analysed. If no plugin can read the file, format remains
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="format">Format of the image. If the format is unknown use
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadEx it will be returned in format.</param>
+		/// <param name="create_new">When true a new bitmap is created.</param>
+		/// <param name="read_only">When true the bitmap will be loaded read only.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(
+			string filename,
+			ref FREE_IMAGE_FORMAT format,
+			bool create_new,
+			bool read_only,
+			bool keep_cache_in_memory)
+		{
+			return OpenMultiBitmapEx(
+				filename,
+				ref format,
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				create_new,
+				read_only,
+				keep_cache_in_memory);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
+		/// real format is being analysed. If no plugin can read the file, format remains
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="filename">The complete name of the file to load.</param>
+		/// <param name="format">Format of the image. If the format is unknown use 
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/>.
+		/// In case a suitable format was found by LoadEx it will be returned in format.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="create_new">When true a new bitmap is created.</param>
+		/// <param name="read_only">When true the bitmap will be loaded read only.</param>
+		/// <param name="keep_cache_in_memory">When true performance is increased at the cost of memory.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="FileNotFoundException">
+		/// <paramref name="filename"/> does not exists while opening.</exception>
+		public static FIMULTIBITMAP OpenMultiBitmapEx(
+			string filename,
+			ref FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_LOAD_FLAGS flags,
+			bool create_new,
+			bool read_only,
+			bool keep_cache_in_memory)
+		{
+			if (!File.Exists(filename) && !create_new)
+			{
+				throw new FileNotFoundException(filename + " could not be found.");
+			}
+			if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+			{
+				// Check if a plugin can read the data
+				format = GetFileType(filename, 0);
+			}
+			FIMULTIBITMAP dib = new FIMULTIBITMAP();
+			if (FIFSupportsReading(format))
+			{
+				dib = OpenMultiBitmap(format, filename, create_new, read_only, keep_cache_in_memory, flags);
+			}
+			return dib;
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// </summary>
+		/// <param name="stream">The stream to load the bitmap from.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		public static FIMULTIBITMAP OpenMultiBitmapFromStream(Stream stream)
+		{
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			return OpenMultiBitmapFromStream(stream, ref format, FREE_IMAGE_LOAD_FLAGS.DEFAULT);
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap.
+		/// In case the loading format is <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> the files
+		/// real format is being analysed. If no plugin can read the file, format remains
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/> and 0 is returned.
+		/// Load flags can be provided by the flags parameter.
+		/// </summary>
+		/// <param name="stream">The stream to load the bitmap from.</param>
+		/// <param name="format">Format of the image. If the format is unknown use 
+		/// <see cref="FREE_IMAGE_FORMAT.FIF_UNKNOWN"/></param>.
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		public static FIMULTIBITMAP OpenMultiBitmapFromStream(Stream stream, ref FREE_IMAGE_FORMAT format, FREE_IMAGE_LOAD_FLAGS flags)
+		{
+			if (stream == null)
+				return FIMULTIBITMAP.Zero;
+
+			if (!stream.CanSeek)
+				stream = new StreamWrapper(stream, true);
+
+			FIMULTIBITMAP mdib = FIMULTIBITMAP.Zero;
+			FreeImageIO io = FreeImageStreamIO.io;
+			fi_handle handle = new fi_handle(stream);
+
+			try
+			{
+				if (format == FREE_IMAGE_FORMAT.FIF_UNKNOWN)
+				{
+					format = GetFileTypeFromHandle(ref io, handle, checked((int)stream.Length));
+				}
+
+				mdib = OpenMultiBitmapFromHandle(format, ref io, handle, flags);
+
+				if (mdib.IsNull)
+				{
+					handle.Dispose();
+				}
+				else
+				{
+					lock (streamHandles)
+					{
+						streamHandles.Add(mdib, handle);
+					}
+				}
+
+				return mdib;
+			}
+			catch
+			{
+				if (!mdib.IsNull)
+					CloseMultiBitmap(mdib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
+
+				if (handle != null)
+					handle.Dispose();
+
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only, applies any changes made to it.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool CloseMultiBitmap(FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			if (CloseMultiBitmap_(bitmap, flags))
+			{
+				fi_handle handle;
+				lock (streamHandles)
+				{
+					if (streamHandles.TryGetValue(bitmap, out handle))
+					{
+						streamHandles.Remove(bitmap);
+						handle.Dispose();
+					}
+				}
+				return true;
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only,
+		/// applies any changes made to it.
+		/// On success the handle will be reset to null.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool CloseMultiBitmapEx(ref FIMULTIBITMAP bitmap)
+		{
+			return CloseMultiBitmapEx(ref bitmap, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
+		}
+
+		/// <summary>
+		/// Closes a previously opened multi-page bitmap and, when the bitmap was not opened read-only,
+		/// applies any changes made to it.
+		/// On success the handle will be reset to null.
+		/// </summary>
+		/// <param name="bitmap">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool CloseMultiBitmapEx(ref FIMULTIBITMAP bitmap, FREE_IMAGE_SAVE_FLAGS flags)
+		{
+			bool result = false;
+			if (!bitmap.IsNull)
+			{
+				if (CloseMultiBitmap(bitmap, flags))
+				{
+					bitmap.SetNull();
+					result = true;
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Retrieves the number of pages that are locked in a multi-paged bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <returns>Number of locked pages.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static int GetLockedPageCount(FIMULTIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			int result = 0;
+			GetLockedPageNumbers(dib, null, ref result);
+			return result;
+		}
+
+		/// <summary>
+		/// Retrieves a list locked pages of a multi-paged bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage multi-paged bitmap.</param>
+		/// <returns>List containing the indexes of the locked pages.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static int[] GetLockedPages(FIMULTIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			// Get the number of pages and create an array to save the information
+			int count = 0;
+			int[] result = null;
+			// Get count
+			if (GetLockedPageNumbers(dib, result, ref count))
+			{
+				result = new int[count];
+				// Fill array
+				if (!GetLockedPageNumbers(dib, result, ref count))
+				{
+					result = null;
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Loads a FreeImage multi-paged bitmap from a stream and returns the
+		/// FreeImage memory stream used as temporary buffer.
+		/// The bitmap can not be modified by calling
+		/// <see cref="FreeImage.AppendPage(FIMULTIBITMAP,FIBITMAP)"/>,
+		/// <see cref="FreeImage.InsertPage(FIMULTIBITMAP,Int32,FIBITMAP)"/>,
+		/// <see cref="FreeImage.MovePage(FIMULTIBITMAP,Int32,Int32)"/> or
+		/// <see cref="FreeImage.DeletePage(FIMULTIBITMAP,Int32)"/>.
+		/// </summary>
+		/// <param name="stream">The stream to read from.</param>
+		/// <param name="format">Format of the image.</param>
+		/// <param name="flags">Flags to enable or disable plugin-features.</param>
+		/// <param name="memory">The temporary memory buffer used to load the bitmap.</param>
+		/// <returns>Handle to a FreeImage multi-paged bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> can not read.</exception>
+		public static FIMULTIBITMAP LoadMultiBitmapFromStream(
+			Stream stream,
+			FREE_IMAGE_FORMAT format,
+			FREE_IMAGE_LOAD_FLAGS flags,
+			out FIMEMORY memory)
+		{
+			if (stream == null)
+			{
+				throw new ArgumentNullException("stream");
+			}
+			if (!stream.CanRead)
+			{
+				throw new ArgumentException("stream");
+			}
+			const int blockSize = 1024;
+			int bytesRead;
+			byte[] buffer = new byte[blockSize];
+
+			stream = stream.CanSeek ? stream : new StreamWrapper(stream, true);
+			memory = OpenMemory(IntPtr.Zero, 0);
+
+			do
+			{
+				bytesRead = stream.Read(buffer, 0, blockSize);
+				WriteMemory(buffer, (uint)blockSize, (uint)1, memory);
+			}
+			while (bytesRead == blockSize);
+
+			return LoadMultiBitmapFromMemory(format, memory, flags);
+		}
+
+		#endregion
+
+		#region Filetype functions
+
+		/// <summary>
+		/// Orders FreeImage to analyze the bitmap signature.
+		/// In case the stream is not seekable, the stream will have been used
+		/// and must be recreated for loading.
+		/// </summary>
+		/// <param name="stream">Name of the stream to analyze.</param>
+		/// <returns>Type of the bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentException">
+		/// <paramref name="stream"/> can not read.</exception>
+		public static FREE_IMAGE_FORMAT GetFileTypeFromStream(Stream stream)
+		{
+			if (stream == null)
+			{
+				throw new ArgumentNullException("stream");
+			}
+			if (!stream.CanRead)
+			{
+				throw new ArgumentException("stream is not capable of reading.");
+			}
+			// Wrap the stream if it cannot seek
+			stream = (stream.CanSeek) ? stream : new StreamWrapper(stream, true);
+			// Create a 'FreeImageIO' structure for the stream
+			FreeImageIO io = FreeImageStreamIO.io;
+			using (fi_handle handle = new fi_handle(stream))
+			{
+				return GetFileTypeFromHandle(ref io, handle, 0);
+			}
+		}
+
+		#endregion
+
+		#region Bitmap information functions
+
+		/// <summary>
+		/// Retrieves a DIB's resolution in X-direction measured in 'dots per inch' (DPI) and not in
+		/// 'dots per meter'.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The resolution in 'dots per inch'.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static uint GetResolutionX(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			return (uint)(0.5d + 0.0254d * GetDotsPerMeterX(dib));
+		}
+
+		/// <summary>
+		/// Retrieves a DIB's resolution in Y-direction measured in 'dots per inch' (DPI) and not in
+		/// 'dots per meter'.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The resolution in 'dots per inch'.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static uint GetResolutionY(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			return (uint)(0.5d + 0.0254d * GetDotsPerMeterY(dib));
+		}
+
+		/// <summary>
+		/// Sets a DIB's resolution in X-direction measured in 'dots per inch' (DPI) and not in
+		/// 'dots per meter'.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="res">The new resolution in 'dots per inch'.</param>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static void SetResolutionX(FIBITMAP dib, uint res)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			SetDotsPerMeterX(dib, (uint)((double)res / 0.0254d + 0.5d));
+		}
+
+		/// <summary>
+		/// Sets a DIB's resolution in Y-direction measured in 'dots per inch' (DPI) and not in
+		/// 'dots per meter'.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="res">The new resolution in 'dots per inch'.</param>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static void SetResolutionY(FIBITMAP dib, uint res)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			SetDotsPerMeterY(dib, (uint)((double)res / 0.0254d + 0.5d));
+		}
+
+		/// <summary>
+		/// Returns whether the image is a greyscale image or not.
+		/// The function scans all colors in the bitmaps palette for entries where
+		/// red, green and blue are not all the same (not a grey color).
+		/// Supports 1-, 4- and 8-bit bitmaps.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>True if the image is a greyscale image, else false.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static unsafe bool IsGreyscaleImage(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			bool result = true;
+			uint bpp = GetBPP(dib);
+			switch (bpp)
+			{
+				case 1:
+				case 4:
+				case 8:
+					RGBQUAD* palette = (RGBQUAD*)GetPalette(dib);
+					uint paletteLength = GetColorsUsed(dib);
+					for (int i = 0; i < paletteLength; i++)
+					{
+						if (palette[i].rgbRed != palette[i].rgbGreen ||
+							palette[i].rgbRed != palette[i].rgbBlue)
+						{
+							result = false;
+							break;
+						}
+					}
+					break;
+				default:
+					result = false;
+					break;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Returns a structure that represents the palette of a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>A structure representing the bitmaps palette.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static Palette GetPaletteEx(FIBITMAP dib)
+		{
+			return new Palette(dib);
+		}
+
+		/// <summary>
+		/// Returns the <see cref="BITMAPINFOHEADER"/> structure of a FreeImage bitmap.
+		/// The structure is a copy, so changes will have no effect on
+		/// the bitmap itself.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns><see cref="BITMAPINFOHEADER"/> structure of the bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static unsafe BITMAPINFOHEADER GetInfoHeaderEx(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			return *(BITMAPINFOHEADER*)GetInfoHeader(dib);
+		}
+
+		/// <summary>
+		/// Returns the <see cref="BITMAPINFO"/> structure of a FreeImage bitmap.
+		/// The structure is a copy, so changes will have no effect on
+		/// the bitmap itself.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns><see cref="BITMAPINFO"/> structure of the bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static BITMAPINFO GetInfoEx(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			BITMAPINFO result = new BITMAPINFO();
+			result.bmiHeader = GetInfoHeaderEx(dib);
+			IntPtr ptr = GetPalette(dib);
+			if (ptr == IntPtr.Zero)
+			{
+				result.bmiColors = new RGBQUAD[0];
+			}
+			else
+			{
+				result.bmiColors = new MemoryArray<RGBQUAD>(ptr, (int)result.bmiHeader.biClrUsed).Data;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Returns the pixelformat of the bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns><see cref="System.Drawing.Imaging.PixelFormat"/> of the bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static PixelFormat GetPixelFormat(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+
+			PixelFormat result = PixelFormat.Undefined;
+
+			if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
+			{
+				switch (GetBPP(dib))
+				{
+					case 1:
+						result = PixelFormat.Format1bppIndexed;
+						break;
+					case 4:
+						result = PixelFormat.Format4bppIndexed;
+						break;
+					case 8:
+						result = PixelFormat.Format8bppIndexed;
+						break;
+					case 16:
+						if ((GetBlueMask(dib) == FI16_565_BLUE_MASK) &&
+							(GetGreenMask(dib) == FI16_565_GREEN_MASK) &&
+							(GetRedMask(dib) == FI16_565_RED_MASK))
+						{
+							result = PixelFormat.Format16bppRgb565;
+						}
+						if ((GetBlueMask(dib) == FI16_555_BLUE_MASK) &&
+							(GetGreenMask(dib) == FI16_555_GREEN_MASK) &&
+							(GetRedMask(dib) == FI16_555_RED_MASK))
+						{
+							result = PixelFormat.Format16bppRgb555;
+						}
+						break;
+					case 24:
+						result = PixelFormat.Format24bppRgb;
+						break;
+					case 32:
+						result = PixelFormat.Format32bppArgb;
+						break;
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Retrieves all parameters needed to create a new FreeImage bitmap from
+		/// the format of a .NET <see cref="System.Drawing.Image"/>.
+		/// </summary>
+		/// <param name="format">The <see cref="System.Drawing.Imaging.PixelFormat"/>
+		/// of the .NET <see cref="System.Drawing.Image"/>.</param>
+		/// <param name="type">Returns the type used for the new bitmap.</param>
+		/// <param name="bpp">Returns the color depth for the new bitmap.</param>
+		/// <param name="red_mask">Returns the red_mask for the new bitmap.</param>
+		/// <param name="green_mask">Returns the green_mask for the new bitmap.</param>
+		/// <param name="blue_mask">Returns the blue_mask for the new bitmap.</param>
+		/// <returns>True in case a matching conversion exists; else false.
+		/// </returns>
+		public static bool GetFormatParameters(
+			PixelFormat format,
+			out FREE_IMAGE_TYPE type,
+			out uint bpp,
+			out uint red_mask,
+			out uint green_mask,
+			out uint blue_mask)
+		{
+			bool result = false;
+			type = FREE_IMAGE_TYPE.FIT_UNKNOWN;
+			bpp = 0;
+			red_mask = 0;
+			green_mask = 0;
+			blue_mask = 0;
+			switch (format)
+			{
+				case PixelFormat.Format1bppIndexed:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 1;
+					result = true;
+					break;
+				case PixelFormat.Format4bppIndexed:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 4;
+					result = true;
+					break;
+				case PixelFormat.Format8bppIndexed:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 8;
+					result = true;
+					break;
+				case PixelFormat.Format16bppRgb565:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 16;
+					red_mask = FI16_565_RED_MASK;
+					green_mask = FI16_565_GREEN_MASK;
+					blue_mask = FI16_565_BLUE_MASK;
+					result = true;
+					break;
+				case PixelFormat.Format16bppRgb555:
+				case PixelFormat.Format16bppArgb1555:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 16;
+					red_mask = FI16_555_RED_MASK;
+					green_mask = FI16_555_GREEN_MASK;
+					blue_mask = FI16_555_BLUE_MASK;
+					result = true;
+					break;
+				case PixelFormat.Format24bppRgb:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 24;
+					red_mask = FI_RGBA_RED_MASK;
+					green_mask = FI_RGBA_GREEN_MASK;
+					blue_mask = FI_RGBA_BLUE_MASK;
+					result = true;
+					break;
+				case PixelFormat.Format32bppRgb:
+				case PixelFormat.Format32bppArgb:
+				case PixelFormat.Format32bppPArgb:
+					type = FREE_IMAGE_TYPE.FIT_BITMAP;
+					bpp = 32;
+					red_mask = FI_RGBA_RED_MASK;
+					green_mask = FI_RGBA_GREEN_MASK;
+					blue_mask = FI_RGBA_BLUE_MASK;
+					result = true;
+					break;
+				case PixelFormat.Format16bppGrayScale:
+					type = FREE_IMAGE_TYPE.FIT_UINT16;
+					bpp = 16;
+					result = true;
+					break;
+				case PixelFormat.Format48bppRgb:
+					type = FREE_IMAGE_TYPE.FIT_RGB16;
+					bpp = 48;
+					result = true;
+					break;
+				case PixelFormat.Format64bppArgb:
+				case PixelFormat.Format64bppPArgb:
+					type = FREE_IMAGE_TYPE.FIT_RGBA16;
+					bpp = 64;
+					result = true;
+					break;
+			}
+			return result;
+		}
 
 		/// <summary>
 		/// Returns the <see cref="FREE_IMAGE_FORMAT"/> for the specified
@@ -2615,2413 +2615,2414 @@ namespace FreeImageAPI
 			return FREE_IMAGE_FORMAT.FIF_UNKNOWN;
 		}
 
-        /// <summary>
-        /// Retrieves all parameters needed to create a new FreeImage bitmap from
-        /// raw bits <see cref="System.Drawing.Image"/>.
-        /// </summary>
-        /// <param name="type">The <see cref="FREE_IMAGE_TYPE"/>
-        /// of the data in memory.</param>
-        /// <param name="bpp">The color depth for the data.</param>
-        /// <param name="red_mask">Returns the red_mask for the data.</param>
-        /// <param name="green_mask">Returns the green_mask for the data.</param>
-        /// <param name="blue_mask">Returns the blue_mask for the data.</param>
-        /// <returns>True in case a matching conversion exists; else false.
-        /// </returns>
-        public static bool GetTypeParameters(
-            FREE_IMAGE_TYPE type,
-            int bpp,
-            out uint red_mask,
-            out uint green_mask,
-            out uint blue_mask)
-        {
-            bool result = false;
-            red_mask = 0;
-            green_mask = 0;
-            blue_mask = 0;
-            switch (type)
-            {
-                case FREE_IMAGE_TYPE.FIT_BITMAP:
-                    switch (bpp)
-                    {
-                        case 1:
-                        case 4:
-                        case 8:
-                            result = true;
-                            break;
-                        case 16:
-                            result = true;
-                            red_mask = FI16_555_RED_MASK;
-                            green_mask = FI16_555_GREEN_MASK;
-                            blue_mask = FI16_555_BLUE_MASK;
-                            break;
-                        case 24:
-                        case 32:
-                            result = true;
-                            red_mask = FI_RGBA_RED_MASK;
-                            green_mask = FI_RGBA_GREEN_MASK;
-                            blue_mask = FI_RGBA_BLUE_MASK;
-                            break;
-                    }
-                    break;
-                case FREE_IMAGE_TYPE.FIT_UNKNOWN:
-                    break;
-                default:
-                    result = true;
-                    break;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Compares two FreeImage bitmaps.
-        /// </summary>
-        /// <param name="dib1">The first bitmap to compare.</param>
-        /// <param name="dib2">The second bitmap to compare.</param>
-        /// <param name="flags">Determines which components of the bitmaps will be compared.</param>
-        /// <returns>True in case both bitmaps match the compare conditions, false otherwise.</returns>
-        public static bool Compare(FIBITMAP dib1, FIBITMAP dib2, FREE_IMAGE_COMPARE_FLAGS flags)
-        {
-            // Check whether one bitmap is null
-            if (dib1.IsNull ^ dib2.IsNull)
-            {
-                return false;
-            }
-            // Check whether both pointers are the same
-            if (dib1 == dib2)
-            {
-                return true;
-            }
-            if (((flags & FREE_IMAGE_COMPARE_FLAGS.HEADER) > 0) && (!CompareHeader(dib1, dib2)))
-            {
-                return false;
-            }
-            if (((flags & FREE_IMAGE_COMPARE_FLAGS.PALETTE) > 0) && (!ComparePalette(dib1, dib2)))
-            {
-                return false;
-            }
-            if (((flags & FREE_IMAGE_COMPARE_FLAGS.DATA) > 0) && (!CompareData(dib1, dib2)))
-            {
-                return false;
-            }
-            if (((flags & FREE_IMAGE_COMPARE_FLAGS.METADATA) > 0) && (!CompareMetadata(dib1, dib2)))
-            {
-                return false;
-            }
-            return true;
-        }
-
-        private static unsafe bool CompareHeader(FIBITMAP dib1, FIBITMAP dib2)
-        {
-            IntPtr i1 = GetInfoHeader(dib1);
-            IntPtr i2 = GetInfoHeader(dib2);
-            return CompareMemory((void*)i1, (void*)i2, sizeof(BITMAPINFOHEADER));
-        }
-
-        private static unsafe bool ComparePalette(FIBITMAP dib1, FIBITMAP dib2)
-        {
-            IntPtr pal1 = GetPalette(dib1), pal2 = GetPalette(dib2);
-            bool hasPalette1 = pal1 != IntPtr.Zero;
-            bool hasPalette2 = pal2 != IntPtr.Zero;
-            if (hasPalette1 ^ hasPalette2)
-            {
-                return false;
-            }
-            if (!hasPalette1)
-            {
-                return true;
-            }
-            uint colors = GetColorsUsed(dib1);
-            if (colors != GetColorsUsed(dib2))
-            {
-                return false;
-            }
-            return CompareMemory((void*)pal1, (void*)pal2, sizeof(RGBQUAD) * colors);
-        }
-
-        private static unsafe bool CompareData(FIBITMAP dib1, FIBITMAP dib2)
-        {
-            uint width = GetWidth(dib1);
-            if (width != GetWidth(dib2))
-            {
-                return false;
-            }
-            uint height = GetHeight(dib1);
-            if (height != GetHeight(dib2))
-            {
-                return false;
-            }
-            uint bpp = GetBPP(dib1);
-            if (bpp != GetBPP(dib2))
-            {
-                return false;
-            }
-            if (GetColorType(dib1) != GetColorType(dib2))
-            {
-                return false;
-            }
-            FREE_IMAGE_TYPE type = GetImageType(dib1);
-            if (type != GetImageType(dib2))
-            {
-                return false;
-            }
-            if (GetRedMask(dib1) != GetRedMask(dib2))
-            {
-                return false;
-            }
-            if (GetGreenMask(dib1) != GetGreenMask(dib2))
-            {
-                return false;
-            }
-            if (GetBlueMask(dib1) != GetBlueMask(dib2))
-            {
-                return false;
-            }
-
-            byte* ptr1, ptr2;
-            int fullBytes;
-            int shift;
-            uint line = GetLine(dib1);
-
-            if (type == FREE_IMAGE_TYPE.FIT_BITMAP)
-            {
-                switch (bpp)
-                {
-                    case 32:
-                        for (int i = 0; i < height; i++)
-                        {
-                            ptr1 = (byte*)GetScanLine(dib1, i);
-                            ptr2 = (byte*)GetScanLine(dib2, i);
-                            if (!CompareMemory(ptr1, ptr2, line))
-                            {
-                                return false;
-                            }
-                        }
-                        break;
-                    case 24:
-                        for (int i = 0; i < height; i++)
-                        {
-                            ptr1 = (byte*)GetScanLine(dib1, i);
-                            ptr2 = (byte*)GetScanLine(dib2, i);
-                            if (!CompareMemory(ptr1, ptr2, line))
-                            {
-                                return false;
-                            }
-                        }
-                        break;
-                    case 16:
-                        short* sPtr1, sPtr2;
-                        short mask = (short)(GetRedMask(dib1) | GetGreenMask(dib1) | GetBlueMask(dib1));
-                        if (mask == -1)
-                        {
-                            for (int i = 0; i < height; i++)
-                            {
-                                sPtr1 = (short*)GetScanLine(dib1, i);
-                                sPtr2 = (short*)GetScanLine(dib2, i);
-                                if (!CompareMemory(sPtr1, sPtr1, line))
-                                {
-                                    return false;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            for (int i = 0; i < height; i++)
-                            {
-                                sPtr1 = (short*)GetScanLine(dib1, i);
-                                sPtr2 = (short*)GetScanLine(dib2, i);
-                                for (int x = 0; x < width; x++)
-                                {
-                                    if ((sPtr1[x] & mask) != (sPtr2[x] & mask))
-                                    {
-                                        return false;
-                                    }
-                                }
-                            }
-                        }
-                        break;
-                    case 8:
-                        for (int i = 0; i < height; i++)
-                        {
-                            ptr1 = (byte*)GetScanLine(dib1, i);
-                            ptr2 = (byte*)GetScanLine(dib2, i);
-                            if (!CompareMemory(ptr1, ptr2, line))
-                            {
-                                return false;
-                            }
-                        }
-                        break;
-                    case 4:
-                        fullBytes = (int)width / 2;
-                        shift = (width % 2) == 0 ? 8 : 4;
-                        for (int i = 0; i < height; i++)
-                        {
-                            ptr1 = (byte*)GetScanLine(dib1, i);
-                            ptr2 = (byte*)GetScanLine(dib2, i);
-                            if (fullBytes != 0)
-                            {
-                                if (!CompareMemory(ptr1, ptr2, fullBytes))
-                                {
-                                    return false;
-                                }
-                                ptr1 += fullBytes;
-                                ptr2 += fullBytes;
-                            }
-                            if (shift != 8)
-                            {
-                                if ((ptr1[0] >> shift) != (ptr2[0] >> shift))
-                                {
-                                    return false;
-                                }
-                            }
-                        }
-                        break;
-                    case 1:
-                        fullBytes = (int)width / 8;
-                        shift = 8 - ((int)width % 8);
-                        for (int i = 0; i < height; i++)
-                        {
-                            ptr1 = (byte*)GetScanLine(dib1, i);
-                            ptr2 = (byte*)GetScanLine(dib2, i);
-                            if (fullBytes != 0)
-                            {
-                                if (!CompareMemory(ptr1, ptr2, fullBytes))
-                                {
-                                    return false;
-                                }
-                                ptr1 += fullBytes;
-                                ptr2 += fullBytes;
-                            }
-                            if (shift != 8)
-                            {
-                                if ((ptr1[0] >> shift) != (ptr2[0] >> shift))
-                                {
-                                    return false;
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        throw new NotSupportedException("Only 1, 4, 8, 16, 24 and 32 bpp bitmaps are supported.");
-                }
-            }
-            else
-            {
-                for (int i = 0; i < height; i++)
-                {
-                    ptr1 = (byte*)GetScanLine(dib1, i);
-                    ptr2 = (byte*)GetScanLine(dib2, i);
-                    if (!CompareMemory(ptr1, ptr2, line))
-                    {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        }
-
-        private static bool CompareMetadata(FIBITMAP dib1, FIBITMAP dib2)
-        {
-            MetadataTag tag1, tag2;
-
-            foreach (FREE_IMAGE_MDMODEL metadataModel in FREE_IMAGE_MDMODELS)
-            {
-                if (GetMetadataCount(metadataModel, dib1) !=
-                    GetMetadataCount(metadataModel, dib2))
-                {
-                    return false;
-                }
-                if (GetMetadataCount(metadataModel, dib1) == 0)
-                {
-                    continue;
-                }
-
-                FIMETADATA mdHandle = FindFirstMetadata(metadataModel, dib1, out tag1);
-                if (mdHandle.IsNull)
-                {
-                    continue;
-                }
-                do
-                {
-                    if ((!GetMetadata(metadataModel, dib2, tag1.Key, out tag2)) || (tag1 != tag2))
-                    {
-                        FindCloseMetadata(mdHandle);
-                        return false;
-                    }
-                }
-                while (FindNextMetadata(mdHandle, out tag1));
-                FindCloseMetadata(mdHandle);
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Returns the FreeImage bitmap's transparency table.
-        /// The array is empty in case the bitmap has no transparency table.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>The FreeImage bitmap's transparency table.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static unsafe byte[] GetTransparencyTableEx(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            uint count = GetTransparencyCount(dib);
-            byte[] result = new byte[count];
-            byte* ptr = (byte*)GetTransparencyTable(dib);
-            fixed (byte* dst = result)
-            {
-                CopyMemory(dst, ptr, count);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Set the FreeImage bitmap's transparency table. Only affects palletised bitmaps.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="table">The FreeImage bitmap's new transparency table.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> or <paramref name="table"/> is null.</exception>
-        public static void SetTransparencyTable(FIBITMAP dib, byte[] table)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            if (table == null)
-            {
-                throw new ArgumentNullException("table");
-            }
-            SetTransparencyTable(dib, table, table.Length);
-        }
-
-        /// <summary>
-        /// This function returns the number of unique colors actually used by the
-        /// specified 1-, 4-, 8-, 16-, 24- or 32-bit image. This might be different from
-        /// what function FreeImage_GetColorsUsed() returns, which actually returns the
-        /// palette size for palletised images. Works for
-        /// <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> type images only.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Returns the number of unique colors used by the image specified or
-        /// zero, if the image type cannot be handled.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static unsafe int GetUniqueColors(FIBITMAP dib)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-
-            int result = 0;
-
-            if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
-            {
-                BitArray bitArray;
-                int uniquePalEnts;
-                int hashcode;
-                byte[] lut;
-                int width = (int)GetWidth(dib);
-                int height = (int)GetHeight(dib);
-
-                switch (GetBPP(dib))
-                {
-                    case 1:
-
-                        result = 1;
-                        lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
-                        if (uniquePalEnts == 1)
-                        {
-                            break;
-                        }
-
-                        if ((*(byte*)GetScanLine(dib, 0) & 0x80) == 0)
-                        {
-                            for (int y = 0; y < height; y++)
-                            {
-                                byte* scanline = (byte*)GetScanLine(dib, y);
-                                int mask = 0x80;
-                                for (int x = 0; x < width; x++)
-                                {
-                                    if ((scanline[x / 8] & mask) > 0)
-                                    {
-                                        return 2;
-                                    }
-                                    mask = (mask == 0x1) ? 0x80 : (mask >> 1);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            for (int y = 0; y < height; y++)
-                            {
-                                byte* scanline = (byte*)GetScanLine(dib, y);
-                                int mask = 0x80;
-                                for (int x = 0; x < width; x++)
-                                {
-                                    if ((scanline[x / 8] & mask) == 0)
-                                    {
-                                        return 2;
-                                    }
-                                    mask = (mask == 0x1) ? 0x80 : (mask >> 1);
-                                }
-                            }
-                        }
-                        break;
-
-                    case 4:
-
-                        bitArray = new BitArray(0x10);
-                        lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
-                        if (uniquePalEnts == 1)
-                        {
-                            result = 1;
-                            break;
-                        }
-
-                        for (int y = 0; (y < height) && (result < uniquePalEnts); y++)
-                        {
-                            byte* scanline = (byte*)GetScanLine(dib, y);
-                            bool top = true;
-                            for (int x = 0; (x < width) && (result < uniquePalEnts); x++)
-                            {
-                                if (top)
-                                {
-                                    hashcode = lut[scanline[x / 2] >> 4];
-                                }
-                                else
-                                {
-                                    hashcode = lut[scanline[x / 2] & 0xF];
-                                }
-                                top = !top;
-                                if (!bitArray[hashcode])
-                                {
-                                    bitArray[hashcode] = true;
-                                    result++;
-                                }
-                            }
-                        }
-                        break;
-
-                    case 8:
-
-                        bitArray = new BitArray(0x100);
-                        lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
-                        if (uniquePalEnts == 1)
-                        {
-                            result = 1;
-                            break;
-                        }
-
-                        for (int y = 0; (y < height) && (result < uniquePalEnts); y++)
-                        {
-                            byte* scanline = (byte*)GetScanLine(dib, y);
-                            for (int x = 0; (x < width) && (result < uniquePalEnts); x++)
-                            {
-                                hashcode = lut[scanline[x]];
-                                if (!bitArray[hashcode])
-                                {
-                                    bitArray[hashcode] = true;
-                                    result++;
-                                }
-                            }
-                        }
-                        break;
-
-                    case 16:
-
-                        bitArray = new BitArray(0x10000);
-
-                        for (int y = 0; y < height; y++)
-                        {
-                            short* scanline = (short*)GetScanLine(dib, y);
-                            for (int x = 0; x < width; x++, scanline++)
-                            {
-                                hashcode = *scanline;
-                                if (!bitArray[hashcode])
-                                {
-                                    bitArray[hashcode] = true;
-                                    result++;
-                                }
-                            }
-                        }
-                        break;
-
-                    case 24:
-
-                        bitArray = new BitArray(0x1000000);
-
-                        for (int y = 0; y < height; y++)
-                        {
-                            byte* scanline = (byte*)GetScanLine(dib, y);
-                            for (int x = 0; x < width; x++, scanline += 3)
-                            {
-                                hashcode = *((int*)scanline) & 0x00FFFFFF;
-                                if (!bitArray[hashcode])
-                                {
-                                    bitArray[hashcode] = true;
-                                    result++;
-                                }
-                            }
-                        }
-                        break;
-
-                    case 32:
-
-                        bitArray = new BitArray(0x1000000);
-
-                        for (int y = 0; y < height; y++)
-                        {
-                            int* scanline = (int*)GetScanLine(dib, y);
-                            for (int x = 0; x < width; x++, scanline++)
-                            {
-                                hashcode = *scanline & 0x00FFFFFF;
-                                if (!bitArray[hashcode])
-                                {
-                                    bitArray[hashcode] = true;
-                                    result++;
-                                }
-                            }
-                        }
-                        break;
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Verifies whether the FreeImage bitmap is 16bit 555.
-        /// </summary>
-        /// <param name="dib">The FreeImage bitmap to verify.</param>
-        /// <returns><b>true</b> if the bitmap is RGB16-555; otherwise <b>false</b>.</returns>
-        public static bool IsRGB555(FIBITMAP dib)
-        {
-            return ((GetRedMask(dib) == FI16_555_RED_MASK) &&
-                (GetGreenMask(dib) == FI16_555_GREEN_MASK) &&
-                (GetBlueMask(dib) == FI16_555_BLUE_MASK));
-        }
-
-        /// <summary>
-        /// Verifies whether the FreeImage bitmap is 16bit 565.
-        /// </summary>
-        /// <param name="dib">The FreeImage bitmap to verify.</param>
-        /// <returns><b>true</b> if the bitmap is RGB16-565; otherwise <b>false</b>.</returns>
-        public static bool IsRGB565(FIBITMAP dib)
-        {
-            return ((GetRedMask(dib) == FI16_565_RED_MASK) &&
-                (GetGreenMask(dib) == FI16_565_GREEN_MASK) &&
-                (GetBlueMask(dib) == FI16_565_BLUE_MASK));
-        }
-
-        #endregion
-
-        #region ICC profile functions
-
-        /// <summary>
-        /// Creates a new ICC-Profile for a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="data">The data of the new ICC-Profile.</param>
-        /// <returns>The new ICC-Profile of the bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIICCPROFILE CreateICCProfileEx(FIBITMAP dib, byte[] data)
-        {
-            return new FIICCPROFILE(dib, data);
-        }
-
-        /// <summary>
-        /// Creates a new ICC-Profile for a FreeImage bitmap.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="data">The data of the new ICC-Profile.</param>
-        /// <param name="size">The number of bytes of <paramref name="data"/> to use.</param>
-        /// <returns>The new ICC-Profile of the FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIICCPROFILE CreateICCProfileEx(FIBITMAP dib, byte[] data, int size)
-        {
-            return new FIICCPROFILE(dib, data, size);
-        }
-
-        #endregion
-
-        #region Conversion functions
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                FREE_IMAGE_DITHER.FID_FS,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                false);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            bool unloadSource)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                FREE_IMAGE_DITHER.FID_FS,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="threshold">Threshold value when converting with
-        /// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            byte threshold)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                threshold,
-                FREE_IMAGE_DITHER.FID_FS,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                false);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="ditherMethod">Dither algorithm when converting 
-        /// with <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            FREE_IMAGE_DITHER ditherMethod)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                ditherMethod,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                false);
-        }
-
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            FREE_IMAGE_QUANTIZE quantizationMethod)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                FREE_IMAGE_DITHER.FID_FS,
-                quantizationMethod,
-                false);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="threshold">Threshold value when converting with
-        /// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            byte threshold,
-            bool unloadSource)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                threshold,
-                FREE_IMAGE_DITHER.FID_FS,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="ditherMethod">Dither algorithm when converting with
-        /// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            FREE_IMAGE_DITHER ditherMethod,
-            bool unloadSource)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                ditherMethod,
-                FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
-                unloadSource);
-        }
-
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            FREE_IMAGE_QUANTIZE quantizationMethod,
-            bool unloadSource)
-        {
-            return ConvertColorDepth(
-                dib,
-                conversion,
-                128,
-                FREE_IMAGE_DITHER.FID_FS,
-                quantizationMethod,
-                unloadSource);
-        }
-
-        /// <summary>
-        /// Converts a FreeImage bitmap from one color depth to another.
-        /// If the conversion fails the original FreeImage bitmap is returned.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="conversion">The desired output format.</param>
-        /// <param name="threshold">Threshold value when converting with
-        /// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
-        /// <param name="ditherMethod">Dither algorithm when converting with
-        /// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
-        /// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
-        /// <param name="unloadSource">When true the structure will be unloaded on success.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        internal static FIBITMAP ConvertColorDepth(
-            FIBITMAP dib,
-            FREE_IMAGE_COLOR_DEPTH conversion,
-            byte threshold,
-            FREE_IMAGE_DITHER ditherMethod,
-            FREE_IMAGE_QUANTIZE quantizationMethod,
-            bool unloadSource)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-
-            FIBITMAP result = new FIBITMAP();
-            FIBITMAP dibTemp = new FIBITMAP();
-            uint bpp = GetBPP(dib);
-            bool reorderPalette = ((conversion & FREE_IMAGE_COLOR_DEPTH.FICD_REORDER_PALETTE) > 0);
-            bool forceGreyscale = ((conversion & FREE_IMAGE_COLOR_DEPTH.FICD_FORCE_GREYSCALE) > 0);
-
-            if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
-            {
-                switch (conversion & (FREE_IMAGE_COLOR_DEPTH)0xFF)
-                {
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD:
-
-                        if (bpp != 1)
-                        {
-                            if (forceGreyscale)
-                            {
-                                result = Threshold(dib, threshold);
-                            }
-                            else
-                            {
-                                dibTemp = ConvertTo24Bits(dib);
-                                result = ColorQuantizeEx(dibTemp, quantizationMethod, 2, null, 1);
-                                Unload(dibTemp);
-                            }
-                        }
-                        else
-                        {
-                            bool isGreyscale = IsGreyscaleImage(dib);
-                            if ((forceGreyscale && (!isGreyscale)) ||
-                                (reorderPalette && isGreyscale))
-                            {
-                                result = Threshold(dib, threshold);
-                            }
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER:
-
-                        if (bpp != 1)
-                        {
-                            if (forceGreyscale)
-                            {
-                                result = Dither(dib, ditherMethod);
-                            }
-                            else
-                            {
-                                dibTemp = ConvertTo24Bits(dib);
-                                result = ColorQuantizeEx(dibTemp, quantizationMethod, 2, null, 1);
-                                Unload(dibTemp);
-                            }
-                        }
-                        else
-                        {
-                            bool isGreyscale = IsGreyscaleImage(dib);
-                            if ((forceGreyscale && (!isGreyscale)) ||
-                                (reorderPalette && isGreyscale))
-                            {
-                                result = Dither(dib, ditherMethod);
-                            }
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_04_BPP:
-
-                        if (bpp != 4)
-                        {
-                            // Special case when 1bpp and FIC_PALETTE
-                            if (forceGreyscale ||
-                                ((bpp == 1) && (GetColorType(dib) == FREE_IMAGE_COLOR_TYPE.FIC_PALETTE)))
-                            {
-                                dibTemp = ConvertToGreyscale(dib);
-                                result = ConvertTo4Bits(dibTemp);
-                                Unload(dibTemp);
-                            }
-                            else
-                            {
-                                dibTemp = ConvertTo24Bits(dib);
-                                result = ColorQuantizeEx(dibTemp, quantizationMethod, 16, null, 4);
-                                Unload(dibTemp);
-                            }
-                        }
-                        else
-                        {
-                            bool isGreyscale = IsGreyscaleImage(dib);
-                            if ((forceGreyscale && (!isGreyscale)) ||
-                                (reorderPalette && isGreyscale))
-                            {
-                                dibTemp = ConvertToGreyscale(dib);
-                                result = ConvertTo4Bits(dibTemp);
-                                Unload(dibTemp);
-                            }
-                        }
-
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_08_BPP:
-
-                        if (bpp != 8)
-                        {
-                            if (forceGreyscale)
-                            {
-                                result = ConvertToGreyscale(dib);
-                            }
-                            else
-                            {
-                                dibTemp = ConvertTo24Bits(dib);
-                                result = ColorQuantize(dibTemp, quantizationMethod);
-                                Unload(dibTemp);
-                            }
-                        }
-                        else
-                        {
-                            bool isGreyscale = IsGreyscaleImage(dib);
-                            if ((forceGreyscale && (!isGreyscale)) || (reorderPalette && isGreyscale))
-                            {
-                                result = ConvertToGreyscale(dib);
-                            }
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_16_BPP_555:
-
-                        if (forceGreyscale)
-                        {
-                            dibTemp = ConvertToGreyscale(dib);
-                            result = ConvertTo16Bits555(dibTemp);
-                            Unload(dibTemp);
-                        }
-                        else if (bpp != 16 || GetRedMask(dib) != FI16_555_RED_MASK || GetGreenMask(dib) != FI16_555_GREEN_MASK || GetBlueMask(dib) != FI16_555_BLUE_MASK)
-                        {
-                            result = ConvertTo16Bits555(dib);
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_16_BPP:
-
-                        if (forceGreyscale)
-                        {
-                            dibTemp = ConvertToGreyscale(dib);
-                            result = ConvertTo16Bits565(dibTemp);
-                            Unload(dibTemp);
-                        }
-                        else if (bpp != 16 || GetRedMask(dib) != FI16_565_RED_MASK || GetGreenMask(dib) != FI16_565_GREEN_MASK || GetBlueMask(dib) != FI16_565_BLUE_MASK)
-                        {
-                            result = ConvertTo16Bits565(dib);
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_24_BPP:
-
-                        if (forceGreyscale)
-                        {
-                            dibTemp = ConvertToGreyscale(dib);
-                            result = ConvertTo24Bits(dibTemp);
-                            Unload(dibTemp);
-                        }
-                        else if (bpp != 24)
-                        {
-                            result = ConvertTo24Bits(dib);
-                        }
-                        break;
-
-                    case FREE_IMAGE_COLOR_DEPTH.FICD_32_BPP:
-
-                        if (forceGreyscale)
-                        {
-                            dibTemp = ConvertToGreyscale(dib);
-                            result = ConvertTo32Bits(dibTemp);
-                            Unload(dibTemp);
-                        }
-                        else if (bpp != 32)
-                        {
-                            result = ConvertTo32Bits(dib);
-                        }
-                        break;
-                }
-            }
-
-            if (result.IsNull)
-            {
-                return dib;
-            }
-            if (unloadSource)
-            {
-                Unload(dib);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/>
-        /// method that provides additional options used to quantize a 24-bit image to any
-        /// number of colors (up to 256), as well as quantize a 24-bit image using a
-        /// provided palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
-        /// <param name="PaletteSize">Size of the desired output palette.</param>
-        /// <param name="ReservePalette">The provided palette.</param>
-        /// <param name="minColorDepth"><b>true</b> to create a bitmap with the smallest possible
-        /// color depth for the specified <paramref name="PaletteSize"/>.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, RGBQUAD[] ReservePalette, bool minColorDepth)
-        {
-            FIBITMAP result;
-            if (minColorDepth)
-            {
-                int bpp;
-                if (PaletteSize >= 256)
-                    bpp = 8;
-                else if (PaletteSize > 2)
-                    bpp = 4;
-                else
-                    bpp = 1;
-                result = ColorQuantizeEx(dib, quantize, PaletteSize, ReservePalette, bpp);
-            }
-            else
-            {
-                result = ColorQuantizeEx(dib, quantize, PaletteSize, ReservePalette, 8);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/>
-        /// method that provides additional options used to quantize a 24-bit image to any
-        /// number of colors (up to 256), as well as quantize a 24-bit image using a
-        /// partial or full provided palette.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
-        /// <param name="PaletteSize">Size of the desired output palette.</param>
-        /// <param name="ReservePalette">The provided palette.</param>
-        /// <param name="bpp">The desired color depth of the created image.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, RGBQUAD[] ReservePalette, int bpp)
-        {
-            unsafe
-            {
-                FIBITMAP result = FIBITMAP.Zero;
-                FIBITMAP temp = FIBITMAP.Zero;
-                int reservedSize = (ReservePalette == null) ? 0 : ReservePalette.Length;
-
-                if (bpp == 8)
-                {
-                    result = ColorQuantizeEx(dib, quantize, PaletteSize, reservedSize, ReservePalette);
-                }
-                else if (bpp == 4)
-                {
-                    temp = ColorQuantizeEx(dib, quantize, Math.Min(16, PaletteSize), reservedSize, ReservePalette);
-                    if (!temp.IsNull)
-                    {
-                        result = Allocate((int)GetWidth(temp), (int)GetHeight(temp), 4, 0, 0, 0);
-                        CloneMetadata(result, temp);
-                        CopyMemory(GetPalette(result), GetPalette(temp), sizeof(RGBQUAD) * 16);
-
-                        for (int y = (int)GetHeight(temp) - 1; y >= 0; y--)
-                        {
-                            Scanline<byte> srcScanline = new Scanline<byte>(temp, y);
-                            Scanline<FI4BIT> dstScanline = new Scanline<FI4BIT>(result, y);
-
-                            for (int x = (int)GetWidth(temp) - 1; x >= 0; x--)
-                            {
-                                dstScanline[x] = srcScanline[x];
-                            }
-                        }
-                    }
-                }
-                else if (bpp == 1)
-                {
-                    temp = ColorQuantizeEx(dib, quantize, 2, reservedSize, ReservePalette);
-                    if (!temp.IsNull)
-                    {
-                        result = Allocate((int)GetWidth(temp), (int)GetHeight(temp), 1, 0, 0, 0);
-                        CloneMetadata(result, temp);
-                        CopyMemory(GetPalette(result), GetPalette(temp), sizeof(RGBQUAD) * 2);
-
-                        for (int y = (int)GetHeight(temp) - 1; y >= 0; y--)
-                        {
-                            Scanline<byte> srcScanline = new Scanline<byte>(temp, y);
-                            Scanline<FI1BIT> dstScanline = new Scanline<FI1BIT>(result, y);
-
-                            for (int x = (int)GetWidth(temp) - 1; x >= 0; x--)
-                            {
-                                dstScanline[x] = srcScanline[x];
-                            }
-                        }
-                    }
-                }
-
-                UnloadEx(ref temp);
-                return result;
-            }
-        }
-
-        #endregion
-
-        #region Metadata
-
-        /// <summary>
-        /// Copies metadata from one FreeImage bitmap to another.
-        /// </summary>
-        /// <param name="src">Source FreeImage bitmap containing the metadata.</param>
-        /// <param name="dst">FreeImage bitmap to copy the metadata to.</param>
-        /// <param name="flags">Flags to switch different copy modes.</param>
-        /// <returns>Returns -1 on failure else the number of copied tags.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="src"/> or <paramref name="dst"/> is null.</exception>
-        public static int CloneMetadataEx(FIBITMAP src, FIBITMAP dst, FREE_IMAGE_METADATA_COPY flags)
-        {
-            if (src.IsNull)
-            {
-                throw new ArgumentNullException("src");
-            }
-            if (dst.IsNull)
-            {
-                throw new ArgumentNullException("dst");
-            }
-
-            FITAG tag = new FITAG(), tag2 = new FITAG();
-            int copied = 0;
-
-            // Clear all existing metadata
-            if ((flags & FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING) > 0)
-            {
-                foreach (FREE_IMAGE_MDMODEL model in FREE_IMAGE_MDMODELS)
-                {
-                    if (!SetMetadata(model, dst, null, tag))
-                    {
-                        return -1;
-                    }
-                }
-            }
-
-            bool keep = !((flags & FREE_IMAGE_METADATA_COPY.REPLACE_EXISTING) > 0);
-
-            foreach (FREE_IMAGE_MDMODEL model in FREE_IMAGE_MDMODELS)
-            {
-                FIMETADATA mData = FindFirstMetadata(model, src, out tag);
-                if (mData.IsNull) continue;
-                do
-                {
-                    string key = GetTagKey(tag);
-                    if (!(keep && GetMetadata(model, dst, key, out tag2)))
-                    {
-                        if (SetMetadata(model, dst, key, tag))
-                        {
-                            copied++;
-                        }
-                    }
-                }
-                while (FindNextMetadata(mData, out tag));
-                FindCloseMetadata(mData);
-            }
-
-            return copied;
-        }
-
-        /// <summary>
-        /// Returns the comment of a JPEG, PNG or GIF image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <returns>Comment of the FreeImage bitmp, or null in case no comment exists.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static string GetImageComment(FIBITMAP dib)
-        {
-            string result = null;
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            FITAG tag;
-            if (GetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", out tag))
-            {
-                MetadataTag metadataTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-                result = metadataTag.Value as string;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Sets the comment of a JPEG, PNG or GIF image.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="comment">New comment of the FreeImage bitmap.
-        /// Use null to remove the comment.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static bool SetImageComment(FIBITMAP dib, string comment)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            bool result;
-            if (comment != null)
-            {
-                FITAG tag = CreateTag();
-                MetadataTag metadataTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-                metadataTag.Value = comment;
-                result = SetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", tag);
-                DeleteTag(tag);
-            }
-            else
-            {
-                result = SetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", FITAG.Zero);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Retrieve a metadata attached to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="model">The metadata model to look for.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="key">The metadata field name.</param>
-        /// <param name="tag">A <see cref="MetadataTag"/> structure returned by the function.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static bool GetMetadata(
-            FREE_IMAGE_MDMODEL model,
-            FIBITMAP dib,
-            string key,
-            out MetadataTag tag)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-
-            FITAG _tag;
-            bool result;
-            if (GetMetadata(model, dib, key, out _tag))
-            {
-                tag = new MetadataTag(_tag, model);
-                result = true;
-            }
-            else
-            {
-                tag = null;
-                result = false;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Attach a new metadata tag to a FreeImage bitmap.
-        /// </summary>
-        /// <param name="model">The metadata model used to store the tag.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="key">The tag field name.</param>
-        /// <param name="tag">The <see cref="MetadataTag"/> to be attached.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static bool SetMetadata(
-            FREE_IMAGE_MDMODEL model,
-            FIBITMAP dib,
-            string key,
-            MetadataTag tag)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            return SetMetadata(model, dib, key, tag.tag);
-        }
-
-        /// <summary>
-        /// Provides information about the first instance of a tag that matches the metadata model.
-        /// </summary>
-        /// <param name="model">The model to match.</param>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="tag">Tag that matches the metadata model.</param>
-        /// <returns>Unique search handle that can be used to call FindNextMetadata or FindCloseMetadata.
-        /// Null if the metadata model does not exist.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static FIMETADATA FindFirstMetadata(
-            FREE_IMAGE_MDMODEL model,
-            FIBITMAP dib,
-            out MetadataTag tag)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-            FITAG _tag;
-            FIMETADATA result = FindFirstMetadata(model, dib, out _tag);
-            if (result.IsNull)
-            {
-                tag = null;
-                return result;
-            }
-            tag = new MetadataTag(_tag, model);
-            if (metaDataSearchHandler.ContainsKey(result))
-            {
-                metaDataSearchHandler[result] = model;
-            }
-            else
-            {
-                metaDataSearchHandler.Add(result, model);
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Find the next tag, if any, that matches the metadata model argument in a previous call
-        /// to FindFirstMetadata, and then alters the tag object contents accordingly.
-        /// </summary>
-        /// <param name="mdhandle">Unique search handle provided by FindFirstMetadata.</param>
-        /// <param name="tag">Tag that matches the metadata model.</param>
-        /// <returns>Returns true on success, false on failure.</returns>
-        public static bool FindNextMetadata(FIMETADATA mdhandle, out MetadataTag tag)
-        {
-            FITAG _tag;
-            bool result;
-            if (FindNextMetadata(mdhandle, out _tag))
-            {
-                tag = new MetadataTag(_tag, metaDataSearchHandler[mdhandle]);
-                result = true;
-            }
-            else
-            {
-                tag = null;
-                result = false;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Closes the specified metadata search handle and releases associated resources.
-        /// </summary>
-        /// <param name="mdhandle">The handle to close.</param>
-        public static void FindCloseMetadata(FIMETADATA mdhandle)
-        {
-            if (metaDataSearchHandler.ContainsKey(mdhandle))
-            {
-                metaDataSearchHandler.Remove(mdhandle);
-            }
-            FindCloseMetadata_(mdhandle);
-        }
-
-        /// <summary>
-        /// This dictionary links FIMETADATA handles and FREE_IMAGE_MDMODEL models.
-        /// </summary>
-        private static Dictionary<FIMETADATA, FREE_IMAGE_MDMODEL> metaDataSearchHandler
-            = new Dictionary<FIMETADATA, FREE_IMAGE_MDMODEL>(1);
-
-        #endregion
-
-        #region Rotation and Flipping
-
-        /// <summary>
-        /// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
-        /// 1-bit images rotation is limited to integer multiple of 90°.
-        /// <c>null</c> is returned for other values.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="angle">The angle of rotation.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP Rotate(FIBITMAP dib, double angle)
-        {
-            return Rotate(dib, angle, IntPtr.Zero);
-        }
-
-        /// <summary>
-        /// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
-        /// 1-bit images rotation is limited to integer multiple of 90°.
-        /// <c>null</c> is returned for other values.
-        /// </summary>
-        /// <typeparam name="T">The type of the color to use as background.</typeparam>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="angle">The angle of rotation.</param>
-        /// <param name="backgroundColor">The color used used to fill the bitmap's background.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        public static FIBITMAP Rotate<T>(FIBITMAP dib, double angle, T? backgroundColor) where T : struct
-        {
-            if (backgroundColor.HasValue)
-            {
-                GCHandle handle = new GCHandle();
-                try
-                {
-                    T[] buffer = new T[] { backgroundColor.Value };
-                    handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-                    return Rotate(dib, angle, handle.AddrOfPinnedObject());
-                }
-                finally
-                {
-                    if (handle.IsAllocated)
-                        handle.Free();
-                }
-            }
-            else
-            {
-                return Rotate(dib, angle, IntPtr.Zero);
-            }
-        }
-
-        /// <summary>
-        /// Rotates a 4-bit color FreeImage bitmap.
-        /// Allowed values for <paramref name="angle"/> are 90, 180 and 270.
-        /// In case <paramref name="angle"/> is 0 or 360 a clone is returned.
-        /// 0 is returned for other values or in case the rotation fails.
-        /// </summary>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="angle">The angle of rotation.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function is kind of temporary due to FreeImage's lack of
-        /// rotating 4-bit images. It's particularly used by <see cref="FreeImageBitmap"/>'s
-        /// method RotateFlip. This function will be removed as soon as FreeImage
-        /// supports rotating 4-bit images.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="dib"/> is null.</exception>
-        public static unsafe FIBITMAP Rotate4bit(FIBITMAP dib, double angle)
-        {
-            if (dib.IsNull)
-            {
-                throw new ArgumentNullException("dib");
-            }
-
-            FIBITMAP result = new FIBITMAP();
-            int ang = (int)angle;
-
-            if ((GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP) &&
-                (GetBPP(dib) == 4) &&
-                ((ang % 90) == 0))
-            {
-                int width, height, xOrg, yOrg;
-                Scanline<FI4BIT>[] src, dst;
-                width = (int)GetWidth(dib);
-                height = (int)GetHeight(dib);
-                byte index = 0;
-                switch (ang)
-                {
-                    case 90:
-                        result = Allocate(height, width, 4, 0, 0, 0);
-                        if (result.IsNull)
-                        {
-                            break;
-                        }
-                        CopyPalette(dib, result);
-                        src = Get04BitScanlines(dib);
-                        dst = Get04BitScanlines(result);
-                        for (int y = 0; y < width; y++)
-                        {
-                            yOrg = height - 1;
-                            for (int x = 0; x < height; x++, yOrg--)
-                            {
-                                index = src[yOrg][y];
-                                dst[y][x] = index;
-                            }
-                        }
-                        break;
-                    case 180:
-                        result = Allocate(width, height, 4, 0, 0, 0);
-                        if (result.IsNull)
-                        {
-                            break;
-                        }
-                        CopyPalette(dib, result);
-                        src = Get04BitScanlines(dib);
-                        dst = Get04BitScanlines(result);
-
-                        yOrg = height - 1;
-                        for (int y = 0; y < height; y++, yOrg--)
-                        {
-                            xOrg = width - 1;
-                            for (int x = 0; x < width; x++, xOrg--)
-                            {
-                                index = src[yOrg][xOrg];
-                                dst[y][x] = index;
-                            }
-                        }
-                        break;
-                    case 270:
-                        result = Allocate(height, width, 4, 0, 0, 0);
-                        if (result.IsNull)
-                        {
-                            break;
-                        }
-                        CopyPalette(dib, result);
-                        src = Get04BitScanlines(dib);
-                        dst = Get04BitScanlines(result);
-                        xOrg = width - 1;
-                        for (int y = 0; y < width; y++, xOrg--)
-                        {
-                            for (int x = 0; x < height; x++)
-                            {
-                                index = src[x][xOrg];
-                                dst[y][x] = index;
-                            }
-                        }
-                        break;
-                    case 0:
-                    case 360:
-                        result = Clone(dib);
-                        break;
-                }
-            }
-            return result;
-        }
-
-        #endregion
-
-        #region Upsampling / downsampling
-
-        /// <summary>
-        /// Enlarges or shrinks the FreeImage bitmap selectively per side and fills newly added areas
-        /// with the specified background color. See remarks for further details.
-        /// </summary>
-        /// <typeparam name="T">The type of the specified color.</typeparam>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="left">The number of pixels, the image should be enlarged on its left side.
-        /// Negative values shrink the image on its left side.</param>
-        /// <param name="top">The number of pixels, the image should be enlarged on its top side.
-        /// Negative values shrink the image on its top side.</param>
-        /// <param name="right">The number of pixels, the image should be enlarged on its right side.
-        /// Negative values shrink the image on its right side.</param>
-        /// <param name="bottom">The number of pixels, the image should be enlarged on its bottom side.
-        /// Negative values shrink the image on its bottom side.</param>
-        /// <param name="color">The color, the enlarged sides of the image should be filled with.</param>
-        /// <param name="options">Options that affect the color search process for palletized images.</param>
-        /// <returns>Handle to a FreeImage bitmap.</returns>
-        /// <remarks>
-        /// This function enlarges or shrinks an image selectively per side.
-        /// The main purpose of this function is to add borders to an image.
-        /// To add a border to any of the image's sides, a positive integer value must be passed in
-        /// any of the parameters <paramref name="left"/>, <paramref name="top"/>, <paramref name="right"/>
-        /// or <paramref name="bottom"/>. This value represents the border's
-        /// width in pixels. Newly created parts of the image (the border areas) are filled with the
-        /// specified <paramref name="color"/>.
-        /// Specifying a negative integer value for a certain side, will shrink or crop the image on
-        /// this side. Consequently, specifying zero for a certain side will not change the image's
-        /// extension on that side.
-        /// <para/>
-        /// So, calling this function with all parameters <paramref name="left"/>, <paramref name="top"/>,
-        /// <paramref name="right"/> and <paramref name="bottom"/> set to zero, is
-        /// effectively the same as calling function <see cref="Clone"/>; setting all parameters
-        /// <paramref name="left"/>, <paramref name="top"/>, <paramref name="right"/> and
-        /// <paramref name="bottom"/> to value equal to or smaller than zero, my easily be substituted
-        /// by a call to function <see cref="Copy"/>. Both these cases produce a new image, which is
-        /// guaranteed not to be larger than the input image. Thus, since the specified
-        /// <paramref name="color"/> is not needed in these cases, <paramref name="color"/>
-        /// may be <c>null</c>.
-        /// <para/>
-        /// Both parameters <paramref name="color"/> and <paramref name="options"/> work according to
-        /// function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the documentation of
-        /// <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters <paramref name="color"/>
-        /// and <paramref name="options"/>. For palletized images, the palette of the input image is
-        /// transparently copied to the newly created enlarged or shrunken image, so any color look-ups
-        /// are performed on this palette.
-        /// </remarks>
-        /// <example>
-        /// // create a white color<br/>
-        /// RGBQUAD c;<br/>
-        /// c.rgbRed = 0xFF;<br/>
-        /// c.rgbGreen = 0xFF;<br/>
-        /// c.rgbBlue = 0xFF;<br/>
-        /// c.rgbReserved = 0x00;<br/>
-        /// <br/>
-        /// // add a white, symmetric 10 pixel wide border to the image<br/>
-        /// dib2 = FreeImage_EnlargeCanvas(dib, 10, 10, 10, 10, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
-        /// <br/>
-        /// // add white, 20 pixel wide stripes to the top and bottom side of the image<br/>
-        /// dib3 = FreeImage_EnlargeCanvas(dib, 0, 20, 0, 20, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
-        /// <br/>
-        /// // add white, 30 pixel wide stripes to the right side of the image and<br/>
-        /// // cut off the 40 leftmost pixel columns<br/>
-        /// dib3 = FreeImage_EnlargeCanvas(dib, -40, 0, 30, 0, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
-        /// </example>
-        public static FIBITMAP EnlargeCanvas<T>(FIBITMAP dib, int left, int top, int right, int bottom,
-            T? color, FREE_IMAGE_COLOR_OPTIONS options) where T : struct
-        {
-            if (dib.IsNull)
-                return FIBITMAP.Zero;
-
-            if (color.HasValue)
-            {
-                if (!CheckColorType(GetImageType(dib), color.Value))
-                    return FIBITMAP.Zero;
-
-                GCHandle handle = new GCHandle();
-                try
-                {
-                    T[] buffer = new T[] { color.Value };
-                    handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-                    return EnlargeCanvas(dib, left, top, right, bottom, handle.AddrOfPinnedObject(), options);
-                }
-                finally
-                {
-                    if (handle.IsAllocated)
-                        handle.Free();
-                }
-            }
-            else
-            {
-                return EnlargeCanvas(dib, left, top, right, bottom, IntPtr.Zero, options);
-            }
-        }
-
-        #endregion
-
-        #region Color
-
-        /// <summary>
-        /// Sets all pixels of the specified image to the color provided through the
-        /// <paramref name="color"/> parameter. See remarks for further details.
-        /// </summary>
-        /// <typeparam name="T">The type of the specified color.</typeparam>
-        /// <param name="dib">Handle to a FreeImage bitmap.</param>
-        /// <param name="color">The color to fill the bitmap with. See remarks for further details.</param>
-        /// <param name="options">Options that affect the color search process for palletized images.</param>
-        /// <returns><c>true</c> on success, <c>false</c> on failure.</returns>
-        /// <remarks>
-        /// This function sets all pixels of an image to the color provided through
-        /// the <paramref name="color"/> parameter. <see cref="RGBQUAD"/> is used for standard type images.
-        /// For non standard type images the underlaying structure is used.
-        /// <para/>
-        /// So, <paramref name="color"/> must be of type <see cref="Double"/>, if the image to be filled is of type
-        /// <see cref="FREE_IMAGE_TYPE.FIT_DOUBLE"/> and must be a <see cref="FIRGBF"/> structure if the
-        /// image is of type <see cref="FREE_IMAGE_TYPE.FIT_RGBF"/> and so on.
-        /// <para/>
-        /// However, the fill color is always specified through a <see cref="RGBQUAD"/> structure
-        /// for all images of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/>.
-        /// So, for 32- and 24-bit images, the red, green and blue members of the <see cref="RGBQUAD"/>
-        /// structure are directly used for the image's red, green and blue channel respectively.
-        /// Although alpha transparent <see cref="RGBQUAD"/> colors are
-        /// supported, the alpha channel of a 32-bit image never gets modified by this function.
-        /// A fill color with an alpha value smaller than 255 gets blended with the image's actual
-        /// background color, which is determined from the image's bottom-left pixel.
-        /// So, currently using alpha enabled colors, assumes the image to be unicolor before the
-        /// fill operation. However, the <see cref="RGBQUAD.rgbReserved"/> field is only taken into account,
-        /// if option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_RGBA"/> has been specified.
-        /// <para/>
-        /// For 16-bit images, the red-, green- and blue components of the specified color are
-        /// transparently translated into either the 16-bit 555 or 565 representation. This depends
-        /// on the image's actual red- green- and blue masks.
-        /// <para/>
-        /// Special attention must be payed for palletized images. Generally, the RGB color specified
-        /// is looked up in the image's palette. The found palette index is then used to fill the image.
-        /// There are some option flags, that affect this lookup process:
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Value</term>
-        /// <description>Meaning</description>
-        /// </listheader>
-        /// <item>
-        /// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_DEFAULT"/></term>
-        /// <description>
-        /// Uses the color, that is nearest to the specified color.
-        /// This is the default behavior and should always find a
-        /// color in the palette. However, the visual result may
-        /// far from what was expected and mainly depends on the
-        /// image's palette.
-        /// </description>
-        /// </item>
-        /// <item>
-        /// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_EQUAL_COLOR"/></term>
-        /// <description>
-        /// Searches the image's palette for the specified color
-        /// but only uses the returned palette index, if the specified
-        /// color exactly matches the palette entry. Of course,
-        /// depending on the image's actual palette entries, this
-        /// operation may fail. In this case, the function falls back
-        /// to option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
-        /// and uses the RGBQUAD's rgbReserved member (or its low nibble for 4-bit images
-        /// or its least significant bit (LSB) for 1-bit images) as
-        /// the palette index used for the fill operation.
-        /// </description>
-        /// </item>
-        /// <item>
-        /// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/></term>
-        /// <description>
-        /// Does not perform any color lookup from the palette, but
-        /// uses the RGBQUAD's alpha channel member rgbReserved as
-        /// the palette index to be used for the fill operation.
-        /// However, for 4-bit images, only the low nibble of the
-        /// rgbReserved member are used and for 1-bit images, only
-        /// the least significant bit (LSB) is used.
-        /// </description>
-        /// </item>
-        /// </list>
-        /// </remarks>
-        public static bool FillBackground<T>(FIBITMAP dib, T color, FREE_IMAGE_COLOR_OPTIONS options)
-            where T : struct
-        {
-            if (dib.IsNull)
-                return false;
-
-            if (!CheckColorType(GetImageType(dib), color))
-                return false;
-
-            GCHandle handle = new GCHandle();
-            try
-            {
-                T[] buffer = new T[] { color };
-                handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-                return FillBackground(dib, handle.AddrOfPinnedObject(), options);
-            }
-            finally
-            {
-                if (handle.IsAllocated)
-                    handle.Free();
-            }
-        }
-
-        #endregion
-
-        #region Wrapper functions
-
-        /// <summary>
-        /// Returns the next higher possible color depth.
-        /// </summary>
-        /// <param name="bpp">Color depth to increase.</param>
-        /// <returns>The next higher color depth or 0 if there is no valid color depth.</returns>
-        internal static int GetNextColorDepth(int bpp)
-        {
-            int result = 0;
-            switch (bpp)
-            {
-                case 1:
-                    result = 4;
-                    break;
-                case 4:
-                    result = 8;
-                    break;
-                case 8:
-                    result = 16;
-                    break;
-                case 16:
-                    result = 24;
-                    break;
-                case 24:
-                    result = 32;
-                    break;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Returns the next lower possible color depth.
-        /// </summary>
-        /// <param name="bpp">Color depth to decrease.</param>
-        /// <returns>The next lower color depth or 0 if there is no valid color depth.</returns>
-        internal static int GetPrevousColorDepth(int bpp)
-        {
-            int result = 0;
-            switch (bpp)
-            {
-                case 32:
-                    result = 24;
-                    break;
-                case 24:
-                    result = 16;
-                    break;
-                case 16:
-                    result = 8;
-                    break;
-                case 8:
-                    result = 4;
-                    break;
-                case 4:
-                    result = 1;
-                    break;
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Reads a null-terminated c-string.
-        /// </summary>
-        /// <param name="ptr">Pointer to the first char of the string.</param>
-        /// <returns>The converted string.</returns>
-        internal static unsafe string PtrToStr(byte* ptr)
-        {
-            string result = null;
-            if (ptr != null)
-            {
-                System.Text.StringBuilder sb = new System.Text.StringBuilder();
-
-                while (*ptr != 0)
-                {
-                    sb.Append((char)(*(ptr++)));
-                }
-                result = sb.ToString();
-            }
-            return result;
-        }
-
-        internal static unsafe byte[] CreateShrunkenPaletteLUT(FIBITMAP dib, out int uniqueColors)
-        {
-            byte[] result = null;
-            uniqueColors = 0;
-
-            if ((!dib.IsNull) && (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP) && (GetBPP(dib) <= 8))
-            {
-                int size = (int)GetColorsUsed(dib);
-                List<RGBQUAD> newPalette = new List<RGBQUAD>(size);
-                List<byte> lut = new List<byte>(size);
-                RGBQUAD* palette = (RGBQUAD*)GetPalette(dib);
-                RGBQUAD color;
-                int index;
-
-                for (int i = 0; i < size; i++)
-                {
-                    color = palette[i];
-                    color.rgbReserved = 255; // ignore alpha
-
-                    index = newPalette.IndexOf(color);
-                    if (index < 0)
-                    {
-                        newPalette.Add(color);
-                        lut.Add((byte)(newPalette.Count - 1));
-                    }
-                    else
-                    {
-                        lut.Add((byte)index);
-                    }
-                }
-                result = lut.ToArray();
-                uniqueColors = newPalette.Count;
-            }
-            return result;
-        }
-
-        internal static PropertyItem CreatePropertyItem()
-        {
-            return (PropertyItem)Activator.CreateInstance(typeof(PropertyItem), true);
-        }
-
-        private static unsafe void CopyPalette(FIBITMAP src, FIBITMAP dst)
-        {
-            RGBQUAD* orgPal = (RGBQUAD*)GetPalette(src);
-            RGBQUAD* newPal = (RGBQUAD*)GetPalette(dst);
-            uint size = (uint)(sizeof(RGBQUAD) * GetColorsUsed(src));
-            CopyMemory(newPal, orgPal, size);
-        }
-
-        private static unsafe Scanline<FI4BIT>[] Get04BitScanlines(FIBITMAP dib)
-        {
-            int height = (int)GetHeight(dib);
-            Scanline<FI4BIT>[] array = new Scanline<FI4BIT>[height];
-            for (int i = 0; i < height; i++)
-            {
-                array[i] = new Scanline<FI4BIT>(dib, i);
-            }
-            return array;
-        }
-
-        /// <summary>
-        /// Changes a bitmaps color depth.
-        /// Used by SaveEx and SaveToStream.
-        /// </summary>
-        private static FIBITMAP PrepareBitmapColorDepth(FIBITMAP dibToSave, FREE_IMAGE_FORMAT format, FREE_IMAGE_COLOR_DEPTH colorDepth)
-        {
-            FREE_IMAGE_TYPE type = GetImageType(dibToSave);
-            if (type == FREE_IMAGE_TYPE.FIT_BITMAP)
-            {
-                int bpp = (int)GetBPP(dibToSave);
-                int targetBpp = (int)(colorDepth & FREE_IMAGE_COLOR_DEPTH.FICD_COLOR_MASK);
-
-                if (colorDepth != FREE_IMAGE_COLOR_DEPTH.FICD_AUTO)
-                {
-                    // A fix colordepth was chosen
-                    if (FIFSupportsExportBPP(format, targetBpp))
-                    {
-                        dibToSave = ConvertColorDepth(dibToSave, colorDepth, false);
-                    }
-                    else
-                    {
-                        throw new ArgumentException("FreeImage\n\nFreeImage Library plugin " +
-                            GetFormatFromFIF(format) + " is unable to write images with a color depth of " +
-                            targetBpp + " bpp.");
-                    }
-                }
-                else
-                {
-                    // Auto selection was chosen
-                    if (!FIFSupportsExportBPP(format, bpp))
-                    {
-                        // The color depth is not supported
-                        int bppUpper = bpp;
-                        int bppLower = bpp;
-                        // Check from the bitmaps current color depth in both directions
-                        do
-                        {
-                            bppUpper = GetNextColorDepth(bppUpper);
-                            if (FIFSupportsExportBPP(format, bppUpper))
-                            {
-                                dibToSave = ConvertColorDepth(dibToSave, (FREE_IMAGE_COLOR_DEPTH)bppUpper, false);
-                                break;
-                            }
-                            bppLower = GetPrevousColorDepth(bppLower);
-                            if (FIFSupportsExportBPP(format, bppLower))
-                            {
-                                dibToSave = ConvertColorDepth(dibToSave, (FREE_IMAGE_COLOR_DEPTH)bppLower, false);
-                                break;
-                            }
-                        } while (!((bppLower == 0) && (bppUpper == 0)));
-                    }
-                }
-            }
-            return dibToSave;
-        }
-
-        /// <summary>
-        /// Compares blocks of memory.
-        /// </summary>
-        /// <param name="buf1">A pointer to a block of memory to compare.</param>
-        /// <param name="buf2">A pointer to a block of memory to compare.</param>
-        /// <param name="length">Specifies the number of bytes to be compared.</param>
-        /// <returns>true, if all bytes compare as equal, false otherwise.</returns>
-        public static unsafe bool CompareMemory(void* buf1, void* buf2, uint length)
-        {
-            return PlatformCompareMemory(buf1, buf2, length);
-        }
-
-        /// <summary>
-        /// Compares blocks of memory.
-        /// </summary>
-        /// <param name="buf1">A pointer to a block of memory to compare.</param>
-        /// <param name="buf2">A pointer to a block of memory to compare.</param>
-        /// <param name="length">Specifies the number of bytes to be compared.</param>
-        /// <returns>true, if all bytes compare as equal, false otherwise.</returns>
-        public static unsafe bool CompareMemory(void* buf1, void* buf2, long length)
-        {
-            return PlatformCompareMemory(buf1, buf2, checked((uint)length));
-        }
-
-        /// <summary>
-        /// Compares blocks of memory.
-        /// </summary>
-        /// <param name="buf1">A pointer to a block of memory to compare.</param>
-        /// <param name="buf2">A pointer to a block of memory to compare.</param>
-        /// <param name="length">Specifies the number of bytes to be compared.</param>
-        /// <returns>true, if all bytes compare as equal, false otherwise.</returns>
-        public static unsafe bool CompareMemory(IntPtr buf1, IntPtr buf2, uint length)
-        {
-            return PlatformCompareMemory(buf1.ToPointer(), buf2.ToPointer(), length);
-        }
-
-        /// <summary>
-        /// Compares blocks of memory.
-        /// </summary>
-        /// <param name="buf1">A pointer to a block of memory to compare.</param>
-        /// <param name="buf2">A pointer to a block of memory to compare.</param>
-        /// <param name="length">Specifies the number of bytes to be compared.</param>
-        /// <returns>true, if all bytes compare as equal, false otherwise.</returns>
-        public static unsafe bool CompareMemory(IntPtr buf1, IntPtr buf2, long length)
-        {
-            return PlatformCompareMemory(buf1.ToPointer(), buf2.ToPointer(), checked((uint)length));
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, uint)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(byte* dest, byte* src, int len)
-        {
-            if (len >= 0x10)
-            {
-                do
-                {
-                    *((int*)dest) = *((int*)src);
-                    *((int*)(dest + 4)) = *((int*)(src + 4));
-                    *((int*)(dest + 8)) = *((int*)(src + 8));
-                    *((int*)(dest + 12)) = *((int*)(src + 12));
-                    dest += 0x10;
-                    src += 0x10;
-                }
-                while ((len -= 0x10) >= 0x10);
-            }
-            if (len > 0)
-            {
-                if ((len & 8) != 0)
-                {
-                    *((int*)dest) = *((int*)src);
-                    *((int*)(dest + 4)) = *((int*)(src + 4));
-                    dest += 8;
-                    src += 8;
-                }
-                if ((len & 4) != 0)
-                {
-                    *((int*)dest) = *((int*)src);
-                    dest += 4;
-                    src += 4;
-                }
-                if ((len & 2) != 0)
-                {
-                    *((short*)dest) = *((short*)src);
-                    dest += 2;
-                    src += 2;
-                }
-                if ((len & 1) != 0)
-                {
-                    *dest = *src;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, long)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(byte* dest, byte* src, long len)
-        {
-            CopyMemory(dest, src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, long)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(void* dest, void* src, long len)
-        {
-            CopyMemory((byte*)dest, (byte*)src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, uint)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(void* dest, void* src, int len)
-        {
-            CopyMemory((byte*)dest, (byte*)src, len);
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(IntPtr, IntPtr, uint)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(IntPtr dest, IntPtr src, int len)
-        {
-            CopyMemory((byte*)dest, (byte*)src, len);
-        }
-
-        /// <summary>
-        /// Copies a block of memory from one location to another.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        /// <remarks>
-        /// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(IntPtr, IntPtr, long)"/>.
-        /// However, if both blocks overlap the result is undefined.
-        /// </remarks>
-        public static unsafe void CopyMemory(IntPtr dest, IntPtr src, long len)
-        {
-            CopyMemory((byte*)dest, (byte*)src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies a block of memory into an array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, void* src, int len)
-        {
-            GCHandle handle = GCHandle.Alloc(dest, GCHandleType.Pinned);
-            try
-            {
-                CopyMemory((byte*)handle.AddrOfPinnedObject(), (byte*)src, len);
-            }
-            finally
-            {
-                handle.Free();
-            }
-        }
-
-        /// <summary>
-        /// Copies a block of memory into an array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, void* src, long len)
-        {
-            CopyMemory(dest, (byte*)src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies a block of memory into an array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, IntPtr src, int len)
-        {
-            CopyMemory(dest, (byte*)src, len);
-        }
-
-        /// <summary>
-        /// Copies a block of memory into an array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, IntPtr src, long len)
-        {
-            CopyMemory(dest, (byte*)src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies the content of an array to a memory location.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(void* dest, Array src, int len)
-        {
-            GCHandle handle = GCHandle.Alloc(src, GCHandleType.Pinned);
-            try
-            {
-                CopyMemory((byte*)dest, (byte*)handle.AddrOfPinnedObject(), len);
-            }
-            finally
-            {
-                handle.Free();
-            }
-        }
-
-        /// <summary>
-        /// Copies the content of an array to a memory location.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(void* dest, Array src, long len)
-        {
-            CopyMemory((byte*)dest, src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies the content of an array to a memory location.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(IntPtr dest, Array src, int len)
-        {
-            CopyMemory((byte*)dest, src, len);
-        }
-
-        /// <summary>
-        /// Copies the content of an array to a memory location.
-        /// </summary>
-        /// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the block of memory to copy, in bytes.</param>
-        public static unsafe void CopyMemory(IntPtr dest, Array src, long len)
-        {
-            CopyMemory((byte*)dest, src, checked((int)len));
-        }
-
-        /// <summary>
-        /// Copies the content of one array into another array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the content to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, Array src, int len)
-        {
-            GCHandle dHandle = GCHandle.Alloc(dest, GCHandleType.Pinned);
-            try
-            {
-                GCHandle sHandle = GCHandle.Alloc(src, GCHandleType.Pinned);
-                try
-                {
-                    CopyMemory((byte*)dHandle.AddrOfPinnedObject(), (byte*)sHandle.AddrOfPinnedObject(), len);
-                }
-                finally
-                {
-                    sHandle.Free();
-                }
-            }
-            finally
-            {
-                dHandle.Free();
-            }
-        }
-
-        /// <summary>
-        /// Copies the content of one array into another array.
-        /// </summary>
-        /// <param name="dest">An array used as the destination of the copy process.</param>
-        /// <param name="src">An array used as the source of the copy process.</param>
-        /// <param name="len">The size of the content to copy, in bytes.</param>
-        public static unsafe void CopyMemory(Array dest, Array src, long len)
-        {
-            CopyMemory(dest, src, checked((int)len));
-        }
-
-        internal static string ColorToString(Color color)
-        {
+		/// <summary>
+		/// Retrieves all parameters needed to create a new FreeImage bitmap from
+		/// raw bits <see cref="System.Drawing.Image"/>.
+		/// </summary>
+		/// <param name="type">The <see cref="FREE_IMAGE_TYPE"/>
+		/// of the data in memory.</param>
+		/// <param name="bpp">The color depth for the data.</param>
+		/// <param name="red_mask">Returns the red_mask for the data.</param>
+		/// <param name="green_mask">Returns the green_mask for the data.</param>
+		/// <param name="blue_mask">Returns the blue_mask for the data.</param>
+		/// <returns>True in case a matching conversion exists; else false.
+		/// </returns>
+		public static bool GetTypeParameters(
+			FREE_IMAGE_TYPE type,
+			int bpp,
+			out uint red_mask,
+			out uint green_mask,
+			out uint blue_mask)
+		{
+			bool result = false;
+			red_mask = 0;
+			green_mask = 0;
+			blue_mask = 0;
+			switch (type)
+			{
+				case FREE_IMAGE_TYPE.FIT_BITMAP:
+					switch (bpp)
+					{
+						case 1:
+						case 4:
+						case 8:
+							result = true;
+							break;
+						case 16:
+							result = true;
+							red_mask = FI16_555_RED_MASK;
+							green_mask = FI16_555_GREEN_MASK;
+							blue_mask = FI16_555_BLUE_MASK;
+							break;
+						case 24:
+						case 32:
+							result = true;
+							red_mask = FI_RGBA_RED_MASK;
+							green_mask = FI_RGBA_GREEN_MASK;
+							blue_mask = FI_RGBA_BLUE_MASK;
+							break;
+					}
+					break;
+				case FREE_IMAGE_TYPE.FIT_UNKNOWN:
+					break;
+				default:
+					result = true;
+					break;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Compares two FreeImage bitmaps.
+		/// </summary>
+		/// <param name="dib1">The first bitmap to compare.</param>
+		/// <param name="dib2">The second bitmap to compare.</param>
+		/// <param name="flags">Determines which components of the bitmaps will be compared.</param>
+		/// <returns>True in case both bitmaps match the compare conditions, false otherwise.</returns>
+		public static bool Compare(FIBITMAP dib1, FIBITMAP dib2, FREE_IMAGE_COMPARE_FLAGS flags)
+		{
+			// Check whether one bitmap is null
+			if (dib1.IsNull ^ dib2.IsNull)
+			{
+				return false;
+			}
+			// Check whether both pointers are the same
+			if (dib1 == dib2)
+			{
+				return true;
+			}
+			if (((flags & FREE_IMAGE_COMPARE_FLAGS.HEADER) > 0) && (!CompareHeader(dib1, dib2)))
+			{
+				return false;
+			}
+			if (((flags & FREE_IMAGE_COMPARE_FLAGS.PALETTE) > 0) && (!ComparePalette(dib1, dib2)))
+			{
+				return false;
+			}
+			if (((flags & FREE_IMAGE_COMPARE_FLAGS.DATA) > 0) && (!CompareData(dib1, dib2)))
+			{
+				return false;
+			}
+			if (((flags & FREE_IMAGE_COMPARE_FLAGS.METADATA) > 0) && (!CompareMetadata(dib1, dib2)))
+			{
+				return false;
+			}
+			return true;
+		}
+
+		private static unsafe bool CompareHeader(FIBITMAP dib1, FIBITMAP dib2)
+		{
+			IntPtr i1 = GetInfoHeader(dib1);
+			IntPtr i2 = GetInfoHeader(dib2);
+			return CompareMemory((void*)i1, (void*)i2, sizeof(BITMAPINFOHEADER));
+		}
+
+		private static unsafe bool ComparePalette(FIBITMAP dib1, FIBITMAP dib2)
+		{
+			IntPtr pal1 = GetPalette(dib1), pal2 = GetPalette(dib2);
+			bool hasPalette1 = pal1 != IntPtr.Zero;
+			bool hasPalette2 = pal2 != IntPtr.Zero;
+			if (hasPalette1 ^ hasPalette2)
+			{
+				return false;
+			}
+			if (!hasPalette1)
+			{
+				return true;
+			}
+			uint colors = GetColorsUsed(dib1);
+			if (colors != GetColorsUsed(dib2))
+			{
+				return false;
+			}
+			return CompareMemory((void*)pal1, (void*)pal2, sizeof(RGBQUAD) * colors);
+		}
+
+		private static unsafe bool CompareData(FIBITMAP dib1, FIBITMAP dib2)
+		{
+			uint width = GetWidth(dib1);
+			if (width != GetWidth(dib2))
+			{
+				return false;
+			}
+			uint height = GetHeight(dib1);
+			if (height != GetHeight(dib2))
+			{
+				return false;
+			}
+			uint bpp = GetBPP(dib1);
+			if (bpp != GetBPP(dib2))
+			{
+				return false;
+			}
+			if (GetColorType(dib1) != GetColorType(dib2))
+			{
+				return false;
+			}
+			FREE_IMAGE_TYPE type = GetImageType(dib1);
+			if (type != GetImageType(dib2))
+			{
+				return false;
+			}
+			if (GetRedMask(dib1) != GetRedMask(dib2))
+			{
+				return false;
+			}
+			if (GetGreenMask(dib1) != GetGreenMask(dib2))
+			{
+				return false;
+			}
+			if (GetBlueMask(dib1) != GetBlueMask(dib2))
+			{
+				return false;
+			}
+
+			byte* ptr1, ptr2;
+			int fullBytes;
+			int shift;
+			uint line = GetLine(dib1);
+
+			if (type == FREE_IMAGE_TYPE.FIT_BITMAP)
+			{
+				switch (bpp)
+				{
+					case 32:
+						for (int i = 0; i < height; i++)
+						{
+							ptr1 = (byte*)GetScanLine(dib1, i);
+							ptr2 = (byte*)GetScanLine(dib2, i);
+							if (!CompareMemory(ptr1, ptr2, line))
+							{
+								return false;
+							}
+						}
+						break;
+					case 24:
+						for (int i = 0; i < height; i++)
+						{
+							ptr1 = (byte*)GetScanLine(dib1, i);
+							ptr2 = (byte*)GetScanLine(dib2, i);
+							if (!CompareMemory(ptr1, ptr2, line))
+							{
+								return false;
+							}
+						}
+						break;
+					case 16:
+						short* sPtr1, sPtr2;
+						short mask = (short)(GetRedMask(dib1) | GetGreenMask(dib1) | GetBlueMask(dib1));
+						if (mask == -1)
+						{
+							for (int i = 0; i < height; i++)
+							{
+								sPtr1 = (short*)GetScanLine(dib1, i);
+								sPtr2 = (short*)GetScanLine(dib2, i);
+								if (!CompareMemory(sPtr1, sPtr1, line))
+								{
+									return false;
+								}
+							}
+						}
+						else
+						{
+							for (int i = 0; i < height; i++)
+							{
+								sPtr1 = (short*)GetScanLine(dib1, i);
+								sPtr2 = (short*)GetScanLine(dib2, i);
+								for (int x = 0; x < width; x++)
+								{
+									if ((sPtr1[x] & mask) != (sPtr2[x] & mask))
+									{
+										return false;
+									}
+								}
+							}
+						}
+						break;
+					case 8:
+						for (int i = 0; i < height; i++)
+						{
+							ptr1 = (byte*)GetScanLine(dib1, i);
+							ptr2 = (byte*)GetScanLine(dib2, i);
+							if (!CompareMemory(ptr1, ptr2, line))
+							{
+								return false;
+							}
+						}
+						break;
+					case 4:
+						fullBytes = (int)width / 2;
+						shift = (width % 2) == 0 ? 8 : 4;
+						for (int i = 0; i < height; i++)
+						{
+							ptr1 = (byte*)GetScanLine(dib1, i);
+							ptr2 = (byte*)GetScanLine(dib2, i);
+							if (fullBytes != 0)
+							{
+								if (!CompareMemory(ptr1, ptr2, fullBytes))
+								{
+									return false;
+								}
+								ptr1 += fullBytes;
+								ptr2 += fullBytes;
+							}
+							if (shift != 8)
+							{
+								if ((ptr1[0] >> shift) != (ptr2[0] >> shift))
+								{
+									return false;
+								}
+							}
+						}
+						break;
+					case 1:
+						fullBytes = (int)width / 8;
+						shift = 8 - ((int)width % 8);
+						for (int i = 0; i < height; i++)
+						{
+							ptr1 = (byte*)GetScanLine(dib1, i);
+							ptr2 = (byte*)GetScanLine(dib2, i);
+							if (fullBytes != 0)
+							{
+								if (!CompareMemory(ptr1, ptr2, fullBytes))
+								{
+									return false;
+								}
+								ptr1 += fullBytes;
+								ptr2 += fullBytes;
+							}
+							if (shift != 8)
+							{
+								if ((ptr1[0] >> shift) != (ptr2[0] >> shift))
+								{
+									return false;
+								}
+							}
+						}
+						break;
+					default:
+						throw new NotSupportedException("Only 1, 4, 8, 16, 24 and 32 bpp bitmaps are supported.");
+				}
+			}
+			else
+			{
+				for (int i = 0; i < height; i++)
+				{
+					ptr1 = (byte*)GetScanLine(dib1, i);
+					ptr2 = (byte*)GetScanLine(dib2, i);
+					if (!CompareMemory(ptr1, ptr2, line))
+					{
+						return false;
+					}
+				}
+			}
+			return true;
+		}
+
+		private static bool CompareMetadata(FIBITMAP dib1, FIBITMAP dib2)
+		{
+			MetadataTag tag1, tag2;
+
+			foreach (FREE_IMAGE_MDMODEL metadataModel in FREE_IMAGE_MDMODELS)
+			{
+				if (GetMetadataCount(metadataModel, dib1) !=
+					GetMetadataCount(metadataModel, dib2))
+				{
+					return false;
+				}
+				if (GetMetadataCount(metadataModel, dib1) == 0)
+				{
+					continue;
+				}
+
+				FIMETADATA mdHandle = FindFirstMetadata(metadataModel, dib1, out tag1);
+				if (mdHandle.IsNull)
+				{
+					continue;
+				}
+				do
+				{
+					if ((!GetMetadata(metadataModel, dib2, tag1.Key, out tag2)) || (tag1 != tag2))
+					{
+						FindCloseMetadata(mdHandle);
+						return false;
+					}
+				}
+				while (FindNextMetadata(mdHandle, out tag1));
+				FindCloseMetadata(mdHandle);
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Returns the FreeImage bitmap's transparency table.
+		/// The array is empty in case the bitmap has no transparency table.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>The FreeImage bitmap's transparency table.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static unsafe byte[] GetTransparencyTableEx(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			uint count = GetTransparencyCount(dib);
+			byte[] result = new byte[count];
+			byte* ptr = (byte*)GetTransparencyTable(dib);
+			fixed (byte* dst = result)
+			{
+				CopyMemory(dst, ptr, count);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Set the FreeImage bitmap's transparency table. Only affects palletised bitmaps.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="table">The FreeImage bitmap's new transparency table.</param>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> or <paramref name="table"/> is null.</exception>
+		public static void SetTransparencyTable(FIBITMAP dib, byte[] table)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			if (table == null)
+			{
+				throw new ArgumentNullException("table");
+			}
+			SetTransparencyTable(dib, table, table.Length);
+		}
+
+		/// <summary>
+		/// This function returns the number of unique colors actually used by the
+		/// specified 1-, 4-, 8-, 16-, 24- or 32-bit image. This might be different from
+		/// what function FreeImage_GetColorsUsed() returns, which actually returns the
+		/// palette size for palletised images. Works for
+		/// <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/> type images only.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Returns the number of unique colors used by the image specified or
+		/// zero, if the image type cannot be handled.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static unsafe int GetUniqueColors(FIBITMAP dib)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+
+			int result = 0;
+
+			if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
+			{
+				BitArray bitArray;
+				int uniquePalEnts;
+				int hashcode;
+				byte[] lut;
+				int width = (int)GetWidth(dib);
+				int height = (int)GetHeight(dib);
+
+				switch (GetBPP(dib))
+				{
+					case 1:
+
+						result = 1;
+						lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
+						if (uniquePalEnts == 1)
+						{
+							break;
+						}
+
+						if ((*(byte*)GetScanLine(dib, 0) & 0x80) == 0)
+						{
+							for (int y = 0; y < height; y++)
+							{
+								byte* scanline = (byte*)GetScanLine(dib, y);
+								int mask = 0x80;
+								for (int x = 0; x < width; x++)
+								{
+									if ((scanline[x / 8] & mask) > 0)
+									{
+										return 2;
+									}
+									mask = (mask == 0x1) ? 0x80 : (mask >> 1);
+								}
+							}
+						}
+						else
+						{
+							for (int y = 0; y < height; y++)
+							{
+								byte* scanline = (byte*)GetScanLine(dib, y);
+								int mask = 0x80;
+								for (int x = 0; x < width; x++)
+								{
+									if ((scanline[x / 8] & mask) == 0)
+									{
+										return 2;
+									}
+									mask = (mask == 0x1) ? 0x80 : (mask >> 1);
+								}
+							}
+						}
+						break;
+
+					case 4:
+
+						bitArray = new BitArray(0x10);
+						lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
+						if (uniquePalEnts == 1)
+						{
+							result = 1;
+							break;
+						}
+
+						for (int y = 0; (y < height) && (result < uniquePalEnts); y++)
+						{
+							byte* scanline = (byte*)GetScanLine(dib, y);
+							bool top = true;
+							for (int x = 0; (x < width) && (result < uniquePalEnts); x++)
+							{
+								if (top)
+								{
+									hashcode = lut[scanline[x / 2] >> 4];
+								}
+								else
+								{
+									hashcode = lut[scanline[x / 2] & 0xF];
+								}
+								top = !top;
+								if (!bitArray[hashcode])
+								{
+									bitArray[hashcode] = true;
+									result++;
+								}
+							}
+						}
+						break;
+
+					case 8:
+
+						bitArray = new BitArray(0x100);
+						lut = CreateShrunkenPaletteLUT(dib, out uniquePalEnts);
+						if (uniquePalEnts == 1)
+						{
+							result = 1;
+							break;
+						}
+
+						for (int y = 0; (y < height) && (result < uniquePalEnts); y++)
+						{
+							byte* scanline = (byte*)GetScanLine(dib, y);
+							for (int x = 0; (x < width) && (result < uniquePalEnts); x++)
+							{
+								hashcode = lut[scanline[x]];
+								if (!bitArray[hashcode])
+								{
+									bitArray[hashcode] = true;
+									result++;
+								}
+							}
+						}
+						break;
+
+					case 16:
+
+						bitArray = new BitArray(0x10000);
+
+						for (int y = 0; y < height; y++)
+						{
+							short* scanline = (short*)GetScanLine(dib, y);
+							for (int x = 0; x < width; x++, scanline++)
+							{
+								hashcode = *scanline;
+								if (!bitArray[hashcode])
+								{
+									bitArray[hashcode] = true;
+									result++;
+								}
+							}
+						}
+						break;
+
+					case 24:
+
+						bitArray = new BitArray(0x1000000);
+
+						for (int y = 0; y < height; y++)
+						{
+							byte* scanline = (byte*)GetScanLine(dib, y);
+							for (int x = 0; x < width; x++, scanline += 3)
+							{
+								hashcode = *((int*)scanline) & 0x00FFFFFF;
+								if (!bitArray[hashcode])
+								{
+									bitArray[hashcode] = true;
+									result++;
+								}
+							}
+						}
+						break;
+
+					case 32:
+
+						bitArray = new BitArray(0x1000000);
+
+						for (int y = 0; y < height; y++)
+						{
+							int* scanline = (int*)GetScanLine(dib, y);
+							for (int x = 0; x < width; x++, scanline++)
+							{
+								hashcode = *scanline & 0x00FFFFFF;
+								if (!bitArray[hashcode])
+								{
+									bitArray[hashcode] = true;
+									result++;
+								}
+							}
+						}
+						break;
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Verifies whether the FreeImage bitmap is 16bit 555.
+		/// </summary>
+		/// <param name="dib">The FreeImage bitmap to verify.</param>
+		/// <returns><b>true</b> if the bitmap is RGB16-555; otherwise <b>false</b>.</returns>
+		public static bool IsRGB555(FIBITMAP dib)
+		{
+			return ((GetRedMask(dib) == FI16_555_RED_MASK) &&
+				(GetGreenMask(dib) == FI16_555_GREEN_MASK) &&
+				(GetBlueMask(dib) == FI16_555_BLUE_MASK));
+		}
+
+		/// <summary>
+		/// Verifies whether the FreeImage bitmap is 16bit 565.
+		/// </summary>
+		/// <param name="dib">The FreeImage bitmap to verify.</param>
+		/// <returns><b>true</b> if the bitmap is RGB16-565; otherwise <b>false</b>.</returns>
+		public static bool IsRGB565(FIBITMAP dib)
+		{
+			return ((GetRedMask(dib) == FI16_565_RED_MASK) &&
+				(GetGreenMask(dib) == FI16_565_GREEN_MASK) &&
+				(GetBlueMask(dib) == FI16_565_BLUE_MASK));
+		}
+
+		#endregion
+
+		#region ICC profile functions
+
+		/// <summary>
+		/// Creates a new ICC-Profile for a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="data">The data of the new ICC-Profile.</param>
+		/// <returns>The new ICC-Profile of the bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIICCPROFILE CreateICCProfileEx(FIBITMAP dib, byte[] data)
+		{
+			return new FIICCPROFILE(dib, data);
+		}
+
+		/// <summary>
+		/// Creates a new ICC-Profile for a FreeImage bitmap.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="data">The data of the new ICC-Profile.</param>
+		/// <param name="size">The number of bytes of <paramref name="data"/> to use.</param>
+		/// <returns>The new ICC-Profile of the FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIICCPROFILE CreateICCProfileEx(FIBITMAP dib, byte[] data, int size)
+		{
+			return new FIICCPROFILE(dib, data, size);
+		}
+
+		#endregion
+
+		#region Conversion functions
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				FREE_IMAGE_DITHER.FID_FS,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				false);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			bool unloadSource)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				FREE_IMAGE_DITHER.FID_FS,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="threshold">Threshold value when converting with
+		/// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			byte threshold)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				threshold,
+				FREE_IMAGE_DITHER.FID_FS,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				false);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="ditherMethod">Dither algorithm when converting 
+		/// with <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			FREE_IMAGE_DITHER ditherMethod)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				ditherMethod,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				false);
+		}
+
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			FREE_IMAGE_QUANTIZE quantizationMethod)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				FREE_IMAGE_DITHER.FID_FS,
+				quantizationMethod,
+				false);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="threshold">Threshold value when converting with
+		/// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			byte threshold,
+			bool unloadSource)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				threshold,
+				FREE_IMAGE_DITHER.FID_FS,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="ditherMethod">Dither algorithm when converting with
+		/// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			FREE_IMAGE_DITHER ditherMethod,
+			bool unloadSource)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				ditherMethod,
+				FREE_IMAGE_QUANTIZE.FIQ_WUQUANT,
+				unloadSource);
+		}
+
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			FREE_IMAGE_QUANTIZE quantizationMethod,
+			bool unloadSource)
+		{
+			return ConvertColorDepth(
+				dib,
+				conversion,
+				128,
+				FREE_IMAGE_DITHER.FID_FS,
+				quantizationMethod,
+				unloadSource);
+		}
+
+		/// <summary>
+		/// Converts a FreeImage bitmap from one color depth to another.
+		/// If the conversion fails the original FreeImage bitmap is returned.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="conversion">The desired output format.</param>
+		/// <param name="threshold">Threshold value when converting with
+		/// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD"/>.</param>
+		/// <param name="ditherMethod">Dither algorithm when converting with
+		/// <see cref="FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER"/>.</param>
+		/// <param name="quantizationMethod">The quantization algorithm for conversion to 8-bit color depth.</param>
+		/// <param name="unloadSource">When true the structure will be unloaded on success.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		internal static FIBITMAP ConvertColorDepth(
+			FIBITMAP dib,
+			FREE_IMAGE_COLOR_DEPTH conversion,
+			byte threshold,
+			FREE_IMAGE_DITHER ditherMethod,
+			FREE_IMAGE_QUANTIZE quantizationMethod,
+			bool unloadSource)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+
+			FIBITMAP result = new FIBITMAP();
+			FIBITMAP dibTemp = new FIBITMAP();
+			uint bpp = GetBPP(dib);
+			bool reorderPalette = ((conversion & FREE_IMAGE_COLOR_DEPTH.FICD_REORDER_PALETTE) > 0);
+			bool forceGreyscale = ((conversion & FREE_IMAGE_COLOR_DEPTH.FICD_FORCE_GREYSCALE) > 0);
+
+			if (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP)
+			{
+				switch (conversion & (FREE_IMAGE_COLOR_DEPTH)0xFF)
+				{
+					case FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_THRESHOLD:
+
+						if (bpp != 1)
+						{
+							if (forceGreyscale)
+							{
+								result = Threshold(dib, threshold);
+							}
+							else
+							{
+								dibTemp = ConvertTo24Bits(dib);
+								result = ColorQuantizeEx(dibTemp, quantizationMethod, 2, null, 1);
+								Unload(dibTemp);
+							}
+						}
+						else
+						{
+							bool isGreyscale = IsGreyscaleImage(dib);
+							if ((forceGreyscale && (!isGreyscale)) ||
+								(reorderPalette && isGreyscale))
+							{
+								result = Threshold(dib, threshold);
+							}
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_01_BPP_DITHER:
+
+						if (bpp != 1)
+						{
+							if (forceGreyscale)
+							{
+								result = Dither(dib, ditherMethod);
+							}
+							else
+							{
+								dibTemp = ConvertTo24Bits(dib);
+								result = ColorQuantizeEx(dibTemp, quantizationMethod, 2, null, 1);
+								Unload(dibTemp);
+							}
+						}
+						else
+						{
+							bool isGreyscale = IsGreyscaleImage(dib);
+							if ((forceGreyscale && (!isGreyscale)) ||
+								(reorderPalette && isGreyscale))
+							{
+								result = Dither(dib, ditherMethod);
+							}
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_04_BPP:
+
+						if (bpp != 4)
+						{
+							// Special case when 1bpp and FIC_PALETTE
+							if (forceGreyscale ||
+								((bpp == 1) && (GetColorType(dib) == FREE_IMAGE_COLOR_TYPE.FIC_PALETTE)))
+							{
+								dibTemp = ConvertToGreyscale(dib);
+								result = ConvertTo4Bits(dibTemp);
+								Unload(dibTemp);
+							}
+							else
+							{
+								dibTemp = ConvertTo24Bits(dib);
+								result = ColorQuantizeEx(dibTemp, quantizationMethod, 16, null, 4);
+								Unload(dibTemp);
+							}
+						}
+						else
+						{
+							bool isGreyscale = IsGreyscaleImage(dib);
+							if ((forceGreyscale && (!isGreyscale)) ||
+								(reorderPalette && isGreyscale))
+							{
+								dibTemp = ConvertToGreyscale(dib);
+								result = ConvertTo4Bits(dibTemp);
+								Unload(dibTemp);
+							}
+						}
+
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_08_BPP:
+
+						if (bpp != 8)
+						{
+							if (forceGreyscale)
+							{
+								result = ConvertToGreyscale(dib);
+							}
+							else
+							{
+								dibTemp = ConvertTo24Bits(dib);
+								result = ColorQuantize(dibTemp, quantizationMethod);
+								Unload(dibTemp);
+							}
+						}
+						else
+						{
+							bool isGreyscale = IsGreyscaleImage(dib);
+							if ((forceGreyscale && (!isGreyscale)) || (reorderPalette && isGreyscale))
+							{
+								result = ConvertToGreyscale(dib);
+							}
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_16_BPP_555:
+
+						if (forceGreyscale)
+						{
+							dibTemp = ConvertToGreyscale(dib);
+							result = ConvertTo16Bits555(dibTemp);
+							Unload(dibTemp);
+						}
+						else if (bpp != 16 || GetRedMask(dib) != FI16_555_RED_MASK || GetGreenMask(dib) != FI16_555_GREEN_MASK || GetBlueMask(dib) != FI16_555_BLUE_MASK)
+						{
+							result = ConvertTo16Bits555(dib);
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_16_BPP:
+
+						if (forceGreyscale)
+						{
+							dibTemp = ConvertToGreyscale(dib);
+							result = ConvertTo16Bits565(dibTemp);
+							Unload(dibTemp);
+						}
+						else if (bpp != 16 || GetRedMask(dib) != FI16_565_RED_MASK || GetGreenMask(dib) != FI16_565_GREEN_MASK || GetBlueMask(dib) != FI16_565_BLUE_MASK)
+						{
+							result = ConvertTo16Bits565(dib);
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_24_BPP:
+
+						if (forceGreyscale)
+						{
+							dibTemp = ConvertToGreyscale(dib);
+							result = ConvertTo24Bits(dibTemp);
+							Unload(dibTemp);
+						}
+						else if (bpp != 24)
+						{
+							result = ConvertTo24Bits(dib);
+						}
+						break;
+
+					case FREE_IMAGE_COLOR_DEPTH.FICD_32_BPP:
+
+						if (forceGreyscale)
+						{
+							dibTemp = ConvertToGreyscale(dib);
+							result = ConvertTo32Bits(dibTemp);
+							Unload(dibTemp);
+						}
+						else if (bpp != 32)
+						{
+							result = ConvertTo32Bits(dib);
+						}
+						break;
+				}
+			}
+
+			if (result.IsNull)
+			{
+				return dib;
+			}
+			if (unloadSource)
+			{
+				Unload(dib);
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/>
+		/// method that provides additional options used to quantize a 24-bit image to any
+		/// number of colors (up to 256), as well as quantize a 24-bit image using a
+		/// provided palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
+		/// <param name="PaletteSize">Size of the desired output palette.</param>
+		/// <param name="ReservePalette">The provided palette.</param>
+		/// <param name="minColorDepth"><b>true</b> to create a bitmap with the smallest possible
+		/// color depth for the specified <paramref name="PaletteSize"/>.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, RGBQUAD[] ReservePalette, bool minColorDepth)
+		{
+			FIBITMAP result;
+			if (minColorDepth)
+			{
+				int bpp;
+				if (PaletteSize >= 256)
+					bpp = 8;
+				else if (PaletteSize > 2)
+					bpp = 4;
+				else
+					bpp = 1;
+				result = ColorQuantizeEx(dib, quantize, PaletteSize, ReservePalette, bpp);
+			}
+			else
+			{
+				result = ColorQuantizeEx(dib, quantize, PaletteSize, ReservePalette, 8);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// ColorQuantizeEx is an extension to the <see cref="ColorQuantize(FIBITMAP, FREE_IMAGE_QUANTIZE)"/>
+		/// method that provides additional options used to quantize a 24-bit image to any
+		/// number of colors (up to 256), as well as quantize a 24-bit image using a
+		/// partial or full provided palette.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="quantize">Specifies the color reduction algorithm to be used.</param>
+		/// <param name="PaletteSize">Size of the desired output palette.</param>
+		/// <param name="ReservePalette">The provided palette.</param>
+		/// <param name="bpp">The desired color depth of the created image.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP ColorQuantizeEx(FIBITMAP dib, FREE_IMAGE_QUANTIZE quantize, int PaletteSize, RGBQUAD[] ReservePalette, int bpp)
+		{
+			unsafe
+			{
+				FIBITMAP result = FIBITMAP.Zero;
+				FIBITMAP temp = FIBITMAP.Zero;
+				int reservedSize = (ReservePalette == null) ? 0 : ReservePalette.Length;
+
+				if (bpp == 8)
+				{
+					result = ColorQuantizeEx(dib, quantize, PaletteSize, reservedSize, ReservePalette);
+				}
+				else if (bpp == 4)
+				{
+					temp = ColorQuantizeEx(dib, quantize, Math.Min(16, PaletteSize), reservedSize, ReservePalette);
+					if (!temp.IsNull)
+					{
+						result = Allocate((int)GetWidth(temp), (int)GetHeight(temp), 4, 0, 0, 0);
+						CloneMetadata(result, temp);
+						CopyMemory(GetPalette(result), GetPalette(temp), sizeof(RGBQUAD) * 16);
+
+						for (int y = (int)GetHeight(temp) - 1; y >= 0; y--)
+						{
+							Scanline<byte> srcScanline = new Scanline<byte>(temp, y);
+							Scanline<FI4BIT> dstScanline = new Scanline<FI4BIT>(result, y);
+
+							for (int x = (int)GetWidth(temp) - 1; x >= 0; x--)
+							{
+								dstScanline[x] = srcScanline[x];
+							}
+						}
+					}
+				}
+				else if (bpp == 1)
+				{
+					temp = ColorQuantizeEx(dib, quantize, 2, reservedSize, ReservePalette);
+					if (!temp.IsNull)
+					{
+						result = Allocate((int)GetWidth(temp), (int)GetHeight(temp), 1, 0, 0, 0);
+						CloneMetadata(result, temp);
+						CopyMemory(GetPalette(result), GetPalette(temp), sizeof(RGBQUAD) * 2);
+
+						for (int y = (int)GetHeight(temp) - 1; y >= 0; y--)
+						{
+							Scanline<byte> srcScanline = new Scanline<byte>(temp, y);
+							Scanline<FI1BIT> dstScanline = new Scanline<FI1BIT>(result, y);
+
+							for (int x = (int)GetWidth(temp) - 1; x >= 0; x--)
+							{
+								dstScanline[x] = srcScanline[x];
+							}
+						}
+					}
+				}
+
+				UnloadEx(ref temp);
+				return result;
+			}
+		}
+
+		#endregion
+
+		#region Metadata
+
+		/// <summary>
+		/// Copies metadata from one FreeImage bitmap to another.
+		/// </summary>
+		/// <param name="src">Source FreeImage bitmap containing the metadata.</param>
+		/// <param name="dst">FreeImage bitmap to copy the metadata to.</param>
+		/// <param name="flags">Flags to switch different copy modes.</param>
+		/// <returns>Returns -1 on failure else the number of copied tags.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="src"/> or <paramref name="dst"/> is null.</exception>
+		public static int CloneMetadataEx(FIBITMAP src, FIBITMAP dst, FREE_IMAGE_METADATA_COPY flags)
+		{
+			if (src.IsNull)
+			{
+				throw new ArgumentNullException("src");
+			}
+			if (dst.IsNull)
+			{
+				throw new ArgumentNullException("dst");
+			}
+
+			FITAG tag = new FITAG(), tag2 = new FITAG();
+			int copied = 0;
+
+			// Clear all existing metadata
+			if ((flags & FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING) > 0)
+			{
+				foreach (FREE_IMAGE_MDMODEL model in FREE_IMAGE_MDMODELS)
+				{
+					if (!SetMetadata(model, dst, null, tag))
+					{
+						return -1;
+					}
+				}
+			}
+
+			bool keep = !((flags & FREE_IMAGE_METADATA_COPY.REPLACE_EXISTING) > 0);
+
+			foreach (FREE_IMAGE_MDMODEL model in FREE_IMAGE_MDMODELS)
+			{
+				FIMETADATA mData = FindFirstMetadata(model, src, out tag);
+				if (mData.IsNull) continue;
+				do
+				{
+					string key = GetTagKey(tag);
+					if (!(keep && GetMetadata(model, dst, key, out tag2)))
+					{
+						if (SetMetadata(model, dst, key, tag))
+						{
+							copied++;
+						}
+					}
+				}
+				while (FindNextMetadata(mData, out tag));
+				FindCloseMetadata(mData);
+			}
+
+			return copied;
+		}
+
+		/// <summary>
+		/// Returns the comment of a JPEG, PNG or GIF image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <returns>Comment of the FreeImage bitmp, or null in case no comment exists.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static string GetImageComment(FIBITMAP dib)
+		{
+			string result = null;
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			FITAG tag;
+			if (GetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", out tag))
+			{
+				MetadataTag metadataTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+				result = metadataTag.Value as string;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Sets the comment of a JPEG, PNG or GIF image.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="comment">New comment of the FreeImage bitmap.
+		/// Use null to remove the comment.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static bool SetImageComment(FIBITMAP dib, string comment)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			bool result;
+			if (comment != null)
+			{
+				FITAG tag = CreateTag();
+				MetadataTag metadataTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+				metadataTag.Value = comment;
+				result = SetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", tag);
+				DeleteTag(tag);
+			}
+			else
+			{
+				result = SetMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, "Comment", FITAG.Zero);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Retrieve a metadata attached to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="model">The metadata model to look for.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="key">The metadata field name.</param>
+		/// <param name="tag">A <see cref="MetadataTag"/> structure returned by the function.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static bool GetMetadata(
+			FREE_IMAGE_MDMODEL model,
+			FIBITMAP dib,
+			string key,
+			out MetadataTag tag)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+
+			FITAG _tag;
+			bool result;
+			if (GetMetadata(model, dib, key, out _tag))
+			{
+				tag = new MetadataTag(_tag, model);
+				result = true;
+			}
+			else
+			{
+				tag = null;
+				result = false;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Attach a new metadata tag to a FreeImage bitmap.
+		/// </summary>
+		/// <param name="model">The metadata model used to store the tag.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="key">The tag field name.</param>
+		/// <param name="tag">The <see cref="MetadataTag"/> to be attached.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static bool SetMetadata(
+			FREE_IMAGE_MDMODEL model,
+			FIBITMAP dib,
+			string key,
+			MetadataTag tag)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			return SetMetadata(model, dib, key, tag.tag);
+		}
+
+		/// <summary>
+		/// Provides information about the first instance of a tag that matches the metadata model.
+		/// </summary>
+		/// <param name="model">The model to match.</param>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="tag">Tag that matches the metadata model.</param>
+		/// <returns>Unique search handle that can be used to call FindNextMetadata or FindCloseMetadata.
+		/// Null if the metadata model does not exist.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static FIMETADATA FindFirstMetadata(
+			FREE_IMAGE_MDMODEL model,
+			FIBITMAP dib,
+			out MetadataTag tag)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+			FITAG _tag;
+			FIMETADATA result = FindFirstMetadata(model, dib, out _tag);
+			if (result.IsNull)
+			{
+				tag = null;
+				return result;
+			}
+			tag = new MetadataTag(_tag, model);
+			if (metaDataSearchHandler.ContainsKey(result))
+			{
+				metaDataSearchHandler[result] = model;
+			}
+			else
+			{
+				metaDataSearchHandler.Add(result, model);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Find the next tag, if any, that matches the metadata model argument in a previous call
+		/// to FindFirstMetadata, and then alters the tag object contents accordingly.
+		/// </summary>
+		/// <param name="mdhandle">Unique search handle provided by FindFirstMetadata.</param>
+		/// <param name="tag">Tag that matches the metadata model.</param>
+		/// <returns>Returns true on success, false on failure.</returns>
+		public static bool FindNextMetadata(FIMETADATA mdhandle, out MetadataTag tag)
+		{
+			FITAG _tag;
+			bool result;
+			if (FindNextMetadata(mdhandle, out _tag))
+			{
+				tag = new MetadataTag(_tag, metaDataSearchHandler[mdhandle]);
+				result = true;
+			}
+			else
+			{
+				tag = null;
+				result = false;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Closes the specified metadata search handle and releases associated resources.
+		/// </summary>
+		/// <param name="mdhandle">The handle to close.</param>
+		public static void FindCloseMetadata(FIMETADATA mdhandle)
+		{
+			if (metaDataSearchHandler.ContainsKey(mdhandle))
+			{
+				metaDataSearchHandler.Remove(mdhandle);
+			}
+			FindCloseMetadata_(mdhandle);
+		}
+
+		/// <summary>
+		/// This dictionary links FIMETADATA handles and FREE_IMAGE_MDMODEL models.
+		/// </summary>
+		private static Dictionary<FIMETADATA, FREE_IMAGE_MDMODEL> metaDataSearchHandler
+			= new Dictionary<FIMETADATA, FREE_IMAGE_MDMODEL>(1);
+
+		#endregion
+
+		#region Rotation and Flipping
+
+		/// <summary>
+		/// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
+		/// 1-bit images rotation is limited to integer multiple of 90°.
+		/// <c>null</c> is returned for other values.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="angle">The angle of rotation.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP Rotate(FIBITMAP dib, double angle)
+		{
+			return Rotate(dib, angle, IntPtr.Zero);
+		}
+
+		/// <summary>
+		/// This function rotates a 1-, 8-bit greyscale or a 24-, 32-bit color image by means of 3 shears.
+		/// 1-bit images rotation is limited to integer multiple of 90°.
+		/// <c>null</c> is returned for other values.
+		/// </summary>
+		/// <typeparam name="T">The type of the color to use as background.</typeparam>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="angle">The angle of rotation.</param>
+		/// <param name="backgroundColor">The color used used to fill the bitmap's background.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		public static FIBITMAP Rotate<T>(FIBITMAP dib, double angle, T? backgroundColor) where T : struct
+		{
+			if (backgroundColor.HasValue)
+			{
+				GCHandle handle = new GCHandle();
+				try
+				{
+					T[] buffer = new T[] { backgroundColor.Value };
+					handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+					return Rotate(dib, angle, handle.AddrOfPinnedObject());
+				}
+				finally
+				{
+					if (handle.IsAllocated)
+						handle.Free();
+				}
+			}
+			else
+			{
+				return Rotate(dib, angle, IntPtr.Zero);
+			}
+		}
+
+		/// <summary>
+		/// Rotates a 4-bit color FreeImage bitmap.
+		/// Allowed values for <paramref name="angle"/> are 90, 180 and 270.
+		/// In case <paramref name="angle"/> is 0 or 360 a clone is returned.
+		/// 0 is returned for other values or in case the rotation fails.
+		/// </summary>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="angle">The angle of rotation.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function is kind of temporary due to FreeImage's lack of
+		/// rotating 4-bit images. It's particularly used by <see cref="FreeImageBitmap"/>'s
+		/// method RotateFlip. This function will be removed as soon as FreeImage
+		/// supports rotating 4-bit images.
+		/// </remarks>
+		/// <exception cref="ArgumentNullException">
+		/// <paramref name="dib"/> is null.</exception>
+		public static unsafe FIBITMAP Rotate4bit(FIBITMAP dib, double angle)
+		{
+			if (dib.IsNull)
+			{
+				throw new ArgumentNullException("dib");
+			}
+
+			FIBITMAP result = new FIBITMAP();
+			int ang = (int)angle;
+
+			if ((GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP) &&
+				(GetBPP(dib) == 4) &&
+				((ang % 90) == 0))
+			{
+				int width, height, xOrg, yOrg;
+				Scanline<FI4BIT>[] src, dst;
+				width = (int)GetWidth(dib);
+				height = (int)GetHeight(dib);
+				byte index = 0;
+				switch (ang)
+				{
+					case 90:
+						result = Allocate(height, width, 4, 0, 0, 0);
+						if (result.IsNull)
+						{
+							break;
+						}
+						CopyPalette(dib, result);
+						src = Get04BitScanlines(dib);
+						dst = Get04BitScanlines(result);
+						for (int y = 0; y < width; y++)
+						{
+							yOrg = height - 1;
+							for (int x = 0; x < height; x++, yOrg--)
+							{
+								index = src[yOrg][y];
+								dst[y][x] = index;
+							}
+						}
+						break;
+					case 180:
+						result = Allocate(width, height, 4, 0, 0, 0);
+						if (result.IsNull)
+						{
+							break;
+						}
+						CopyPalette(dib, result);
+						src = Get04BitScanlines(dib);
+						dst = Get04BitScanlines(result);
+
+						yOrg = height - 1;
+						for (int y = 0; y < height; y++, yOrg--)
+						{
+							xOrg = width - 1;
+							for (int x = 0; x < width; x++, xOrg--)
+							{
+								index = src[yOrg][xOrg];
+								dst[y][x] = index;
+							}
+						}
+						break;
+					case 270:
+						result = Allocate(height, width, 4, 0, 0, 0);
+						if (result.IsNull)
+						{
+							break;
+						}
+						CopyPalette(dib, result);
+						src = Get04BitScanlines(dib);
+						dst = Get04BitScanlines(result);
+						xOrg = width - 1;
+						for (int y = 0; y < width; y++, xOrg--)
+						{
+							for (int x = 0; x < height; x++)
+							{
+								index = src[x][xOrg];
+								dst[y][x] = index;
+							}
+						}
+						break;
+					case 0:
+					case 360:
+						result = Clone(dib);
+						break;
+				}
+			}
+			return result;
+		}
+
+		#endregion
+
+		#region Upsampling / downsampling
+
+		/// <summary>
+		/// Enlarges or shrinks the FreeImage bitmap selectively per side and fills newly added areas
+		/// with the specified background color. See remarks for further details.
+		/// </summary>
+		/// <typeparam name="T">The type of the specified color.</typeparam>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="left">The number of pixels, the image should be enlarged on its left side.
+		/// Negative values shrink the image on its left side.</param>
+		/// <param name="top">The number of pixels, the image should be enlarged on its top side.
+		/// Negative values shrink the image on its top side.</param>
+		/// <param name="right">The number of pixels, the image should be enlarged on its right side.
+		/// Negative values shrink the image on its right side.</param>
+		/// <param name="bottom">The number of pixels, the image should be enlarged on its bottom side.
+		/// Negative values shrink the image on its bottom side.</param>
+		/// <param name="color">The color, the enlarged sides of the image should be filled with.</param>
+		/// <param name="options">Options that affect the color search process for palletized images.</param>
+		/// <returns>Handle to a FreeImage bitmap.</returns>
+		/// <remarks>
+		/// This function enlarges or shrinks an image selectively per side.
+		/// The main purpose of this function is to add borders to an image.
+		/// To add a border to any of the image's sides, a positive integer value must be passed in
+		/// any of the parameters <paramref name="left"/>, <paramref name="top"/>, <paramref name="right"/>
+		/// or <paramref name="bottom"/>. This value represents the border's
+		/// width in pixels. Newly created parts of the image (the border areas) are filled with the
+		/// specified <paramref name="color"/>.
+		/// Specifying a negative integer value for a certain side, will shrink or crop the image on
+		/// this side. Consequently, specifying zero for a certain side will not change the image's
+		/// extension on that side.
+		/// <para/>
+		/// So, calling this function with all parameters <paramref name="left"/>, <paramref name="top"/>,
+		/// <paramref name="right"/> and <paramref name="bottom"/> set to zero, is
+		/// effectively the same as calling function <see cref="Clone"/>; setting all parameters
+		/// <paramref name="left"/>, <paramref name="top"/>, <paramref name="right"/> and
+		/// <paramref name="bottom"/> to value equal to or smaller than zero, my easily be substituted
+		/// by a call to function <see cref="Copy"/>. Both these cases produce a new image, which is
+		/// guaranteed not to be larger than the input image. Thus, since the specified
+		/// <paramref name="color"/> is not needed in these cases, <paramref name="color"/>
+		/// may be <c>null</c>.
+		/// <para/>
+		/// Both parameters <paramref name="color"/> and <paramref name="options"/> work according to
+		/// function <see cref="FillBackground&lt;T&gt;"/>. So, please refer to the documentation of
+		/// <see cref="FillBackground&lt;T&gt;"/> to learn more about parameters <paramref name="color"/>
+		/// and <paramref name="options"/>. For palletized images, the palette of the input image is
+		/// transparently copied to the newly created enlarged or shrunken image, so any color look-ups
+		/// are performed on this palette.
+		/// </remarks>
+		/// <example>
+		/// // create a white color<br/>
+		/// RGBQUAD c;<br/>
+		/// c.rgbRed = 0xFF;<br/>
+		/// c.rgbGreen = 0xFF;<br/>
+		/// c.rgbBlue = 0xFF;<br/>
+		/// c.rgbReserved = 0x00;<br/>
+		/// <br/>
+		/// // add a white, symmetric 10 pixel wide border to the image<br/>
+		/// dib2 = FreeImage_EnlargeCanvas(dib, 10, 10, 10, 10, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
+		/// <br/>
+		/// // add white, 20 pixel wide stripes to the top and bottom side of the image<br/>
+		/// dib3 = FreeImage_EnlargeCanvas(dib, 0, 20, 0, 20, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
+		/// <br/>
+		/// // add white, 30 pixel wide stripes to the right side of the image and<br/>
+		/// // cut off the 40 leftmost pixel columns<br/>
+		/// dib3 = FreeImage_EnlargeCanvas(dib, -40, 0, 30, 0, c, FREE_IMAGE_COLOR_OPTIONS.FICO_RGB);<br/>
+		/// </example>
+		public static FIBITMAP EnlargeCanvas<T>(FIBITMAP dib, int left, int top, int right, int bottom,
+			T? color, FREE_IMAGE_COLOR_OPTIONS options) where T : struct
+		{
+			if (dib.IsNull)
+				return FIBITMAP.Zero;
+
+			if (color.HasValue)
+			{
+				if (!CheckColorType(GetImageType(dib), color.Value))
+					return FIBITMAP.Zero;
+
+				GCHandle handle = new GCHandle();
+				try
+				{
+					T[] buffer = new T[] { color.Value };
+					handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+					return EnlargeCanvas(dib, left, top, right, bottom, handle.AddrOfPinnedObject(), options);
+				}
+				finally
+				{
+					if (handle.IsAllocated)
+						handle.Free();
+				}
+			}
+			else
+			{
+				return EnlargeCanvas(dib, left, top, right, bottom, IntPtr.Zero, options);
+			}
+		}
+
+		#endregion
+
+		#region Color
+
+		/// <summary>
+		/// Sets all pixels of the specified image to the color provided through the
+		/// <paramref name="color"/> parameter. See remarks for further details.
+		/// </summary>
+		/// <typeparam name="T">The type of the specified color.</typeparam>
+		/// <param name="dib">Handle to a FreeImage bitmap.</param>
+		/// <param name="color">The color to fill the bitmap with. See remarks for further details.</param>
+		/// <param name="options">Options that affect the color search process for palletized images.</param>
+		/// <returns><c>true</c> on success, <c>false</c> on failure.</returns>
+		/// <remarks>
+		/// This function sets all pixels of an image to the color provided through
+		/// the <paramref name="color"/> parameter. <see cref="RGBQUAD"/> is used for standard type images.
+		/// For non standard type images the underlaying structure is used.
+		/// <para/>
+		/// So, <paramref name="color"/> must be of type <see cref="Double"/>, if the image to be filled is of type
+		/// <see cref="FREE_IMAGE_TYPE.FIT_DOUBLE"/> and must be a <see cref="FIRGBF"/> structure if the
+		/// image is of type <see cref="FREE_IMAGE_TYPE.FIT_RGBF"/> and so on.
+		/// <para/>
+		/// However, the fill color is always specified through a <see cref="RGBQUAD"/> structure
+		/// for all images of type <see cref="FREE_IMAGE_TYPE.FIT_BITMAP"/>.
+		/// So, for 32- and 24-bit images, the red, green and blue members of the <see cref="RGBQUAD"/>
+		/// structure are directly used for the image's red, green and blue channel respectively.
+		/// Although alpha transparent <see cref="RGBQUAD"/> colors are
+		/// supported, the alpha channel of a 32-bit image never gets modified by this function.
+		/// A fill color with an alpha value smaller than 255 gets blended with the image's actual
+		/// background color, which is determined from the image's bottom-left pixel.
+		/// So, currently using alpha enabled colors, assumes the image to be unicolor before the
+		/// fill operation. However, the <see cref="RGBQUAD.rgbReserved"/> field is only taken into account,
+		/// if option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_RGBA"/> has been specified.
+		/// <para/>
+		/// For 16-bit images, the red-, green- and blue components of the specified color are
+		/// transparently translated into either the 16-bit 555 or 565 representation. This depends
+		/// on the image's actual red- green- and blue masks.
+		/// <para/>
+		/// Special attention must be payed for palletized images. Generally, the RGB color specified
+		/// is looked up in the image's palette. The found palette index is then used to fill the image.
+		/// There are some option flags, that affect this lookup process:
+		/// <list type="table">
+		/// <listheader>
+		/// <term>Value</term>
+		/// <description>Meaning</description>
+		/// </listheader>
+		/// <item>
+		/// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_DEFAULT"/></term>
+		/// <description>
+		/// Uses the color, that is nearest to the specified color.
+		/// This is the default behavior and should always find a
+		/// color in the palette. However, the visual result may
+		/// far from what was expected and mainly depends on the
+		/// image's palette.
+		/// </description>
+		/// </item>
+		/// <item>
+		/// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_EQUAL_COLOR"/></term>
+		/// <description>
+		/// Searches the image's palette for the specified color
+		/// but only uses the returned palette index, if the specified
+		/// color exactly matches the palette entry. Of course,
+		/// depending on the image's actual palette entries, this
+		/// operation may fail. In this case, the function falls back
+		/// to option <see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/>
+		/// and uses the RGBQUAD's rgbReserved member (or its low nibble for 4-bit images
+		/// or its least significant bit (LSB) for 1-bit images) as
+		/// the palette index used for the fill operation.
+		/// </description>
+		/// </item>
+		/// <item>
+		/// <term><see cref="FREE_IMAGE_COLOR_OPTIONS.FICO_ALPHA_IS_INDEX"/></term>
+		/// <description>
+		/// Does not perform any color lookup from the palette, but
+		/// uses the RGBQUAD's alpha channel member rgbReserved as
+		/// the palette index to be used for the fill operation.
+		/// However, for 4-bit images, only the low nibble of the
+		/// rgbReserved member are used and for 1-bit images, only
+		/// the least significant bit (LSB) is used.
+		/// </description>
+		/// </item>
+		/// </list>
+		/// </remarks>
+		public static bool FillBackground<T>(FIBITMAP dib, T color, FREE_IMAGE_COLOR_OPTIONS options)
+			where T : struct
+		{
+			if (dib.IsNull)
+				return false;
+
+			if (!CheckColorType(GetImageType(dib), color))
+				return false;
+
+			GCHandle handle = new GCHandle();
+			try
+			{
+				T[] buffer = new T[] { color };
+				handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+				return FillBackground(dib, handle.AddrOfPinnedObject(), options);
+			}
+			finally
+			{
+				if (handle.IsAllocated)
+					handle.Free();
+			}
+		}
+
+		#endregion
+
+		#region Wrapper functions
+
+		/// <summary>
+		/// Returns the next higher possible color depth.
+		/// </summary>
+		/// <param name="bpp">Color depth to increase.</param>
+		/// <returns>The next higher color depth or 0 if there is no valid color depth.</returns>
+		internal static int GetNextColorDepth(int bpp)
+		{
+			int result = 0;
+			switch (bpp)
+			{
+				case 1:
+					result = 4;
+					break;
+				case 4:
+					result = 8;
+					break;
+				case 8:
+					result = 16;
+					break;
+				case 16:
+					result = 24;
+					break;
+				case 24:
+					result = 32;
+					break;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Returns the next lower possible color depth.
+		/// </summary>
+		/// <param name="bpp">Color depth to decrease.</param>
+		/// <returns>The next lower color depth or 0 if there is no valid color depth.</returns>
+		internal static int GetPrevousColorDepth(int bpp)
+		{
+			int result = 0;
+			switch (bpp)
+			{
+				case 32:
+					result = 24;
+					break;
+				case 24:
+					result = 16;
+					break;
+				case 16:
+					result = 8;
+					break;
+				case 8:
+					result = 4;
+					break;
+				case 4:
+					result = 1;
+					break;
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Reads a null-terminated c-string.
+		/// </summary>
+		/// <param name="ptr">Pointer to the first char of the string.</param>
+		/// <returns>The converted string.</returns>
+		internal static unsafe string PtrToStr(byte* ptr)
+		{
+			string result = null;
+			if (ptr != null)
+			{
+				System.Text.StringBuilder sb = new System.Text.StringBuilder();
+
+				while (*ptr != 0)
+				{
+					sb.Append((char)(*(ptr++)));
+				}
+				result = sb.ToString();
+			}
+			return result;
+		}
+
+		internal static unsafe byte[] CreateShrunkenPaletteLUT(FIBITMAP dib, out int uniqueColors)
+		{
+			byte[] result = null;
+			uniqueColors = 0;
+
+			if ((!dib.IsNull) && (GetImageType(dib) == FREE_IMAGE_TYPE.FIT_BITMAP) && (GetBPP(dib) <= 8))
+			{
+				int size = (int)GetColorsUsed(dib);
+				List<RGBQUAD> newPalette = new List<RGBQUAD>(size);
+				List<byte> lut = new List<byte>(size);
+				RGBQUAD* palette = (RGBQUAD*)GetPalette(dib);
+				RGBQUAD color;
+				int index;
+
+				for (int i = 0; i < size; i++)
+				{
+					color = palette[i];
+					color.rgbReserved = 255; // ignore alpha
+
+					index = newPalette.IndexOf(color);
+					if (index < 0)
+					{
+						newPalette.Add(color);
+						lut.Add((byte)(newPalette.Count - 1));
+					}
+					else
+					{
+						lut.Add((byte)index);
+					}
+				}
+				result = lut.ToArray();
+				uniqueColors = newPalette.Count;
+			}
+			return result;
+		}
+
+		internal static PropertyItem CreatePropertyItem()
+		{
+			return (PropertyItem)Activator.CreateInstance(typeof(PropertyItem), true);
+		}
+
+		private static unsafe void CopyPalette(FIBITMAP src, FIBITMAP dst)
+		{
+			RGBQUAD* orgPal = (RGBQUAD*)GetPalette(src);
+			RGBQUAD* newPal = (RGBQUAD*)GetPalette(dst);
+			uint size = (uint)(sizeof(RGBQUAD) * GetColorsUsed(src));
+			CopyMemory(newPal, orgPal, size);
+		}
+
+		private static unsafe Scanline<FI4BIT>[] Get04BitScanlines(FIBITMAP dib)
+		{
+			int height = (int)GetHeight(dib);
+			Scanline<FI4BIT>[] array = new Scanline<FI4BIT>[height];
+			for (int i = 0; i < height; i++)
+			{
+				array[i] = new Scanline<FI4BIT>(dib, i);
+			}
+			return array;
+		}
+
+		/// <summary>
+		/// Changes a bitmaps color depth.
+		/// Used by SaveEx and SaveToStream.
+		/// </summary>
+		private static FIBITMAP PrepareBitmapColorDepth(FIBITMAP dibToSave, FREE_IMAGE_FORMAT format, FREE_IMAGE_COLOR_DEPTH colorDepth)
+		{
+			FREE_IMAGE_TYPE type = GetImageType(dibToSave);
+			if (type == FREE_IMAGE_TYPE.FIT_BITMAP)
+			{
+				int bpp = (int)GetBPP(dibToSave);
+				int targetBpp = (int)(colorDepth & FREE_IMAGE_COLOR_DEPTH.FICD_COLOR_MASK);
+
+				if (colorDepth != FREE_IMAGE_COLOR_DEPTH.FICD_AUTO)
+				{
+					// A fix colordepth was chosen
+					if (FIFSupportsExportBPP(format, targetBpp))
+					{
+						dibToSave = ConvertColorDepth(dibToSave, colorDepth, false);
+					}
+					else
+					{
+						throw new ArgumentException("FreeImage\n\nFreeImage Library plugin " +
+							GetFormatFromFIF(format) + " is unable to write images with a color depth of " +
+							targetBpp + " bpp.");
+					}
+				}
+				else
+				{
+					// Auto selection was chosen
+					if (!FIFSupportsExportBPP(format, bpp))
+					{
+						// The color depth is not supported
+						int bppUpper = bpp;
+						int bppLower = bpp;
+						// Check from the bitmaps current color depth in both directions
+						do
+						{
+							bppUpper = GetNextColorDepth(bppUpper);
+							if (FIFSupportsExportBPP(format, bppUpper))
+							{
+								dibToSave = ConvertColorDepth(dibToSave, (FREE_IMAGE_COLOR_DEPTH)bppUpper, false);
+								break;
+							}
+							bppLower = GetPrevousColorDepth(bppLower);
+							if (FIFSupportsExportBPP(format, bppLower))
+							{
+								dibToSave = ConvertColorDepth(dibToSave, (FREE_IMAGE_COLOR_DEPTH)bppLower, false);
+								break;
+							}
+						} while (!((bppLower == 0) && (bppUpper == 0)));
+					}
+				}
+			}
+			return dibToSave;
+		}
+
+		/// <summary>
+		/// Compares blocks of memory.
+		/// </summary>
+		/// <param name="buf1">A pointer to a block of memory to compare.</param>
+		/// <param name="buf2">A pointer to a block of memory to compare.</param>
+		/// <param name="length">Specifies the number of bytes to be compared.</param>
+		/// <returns>true, if all bytes compare as equal, false otherwise.</returns>
+		public static unsafe bool CompareMemory(void* buf1, void* buf2, uint length)
+		{
+			return PlatformCompareMemory(buf1, buf2, length);
+		}
+
+		/// <summary>
+		/// Compares blocks of memory.
+		/// </summary>
+		/// <param name="buf1">A pointer to a block of memory to compare.</param>
+		/// <param name="buf2">A pointer to a block of memory to compare.</param>
+		/// <param name="length">Specifies the number of bytes to be compared.</param>
+		/// <returns>true, if all bytes compare as equal, false otherwise.</returns>
+		public static unsafe bool CompareMemory(void* buf1, void* buf2, long length)
+		{
+			return PlatformCompareMemory(buf1, buf2, checked((uint)length));
+		}
+
+		/// <summary>
+		/// Compares blocks of memory.
+		/// </summary>
+		/// <param name="buf1">A pointer to a block of memory to compare.</param>
+		/// <param name="buf2">A pointer to a block of memory to compare.</param>
+		/// <param name="length">Specifies the number of bytes to be compared.</param>
+		/// <returns>true, if all bytes compare as equal, false otherwise.</returns>
+		public static unsafe bool CompareMemory(IntPtr buf1, IntPtr buf2, uint length)
+		{
+			return PlatformCompareMemory(buf1.ToPointer(), buf2.ToPointer(), length);
+		}
+
+		/// <summary>
+		/// Compares blocks of memory.
+		/// </summary>
+		/// <param name="buf1">A pointer to a block of memory to compare.</param>
+		/// <param name="buf2">A pointer to a block of memory to compare.</param>
+		/// <param name="length">Specifies the number of bytes to be compared.</param>
+		/// <returns>true, if all bytes compare as equal, false otherwise.</returns>
+		public static unsafe bool CompareMemory(IntPtr buf1, IntPtr buf2, long length)
+		{
+			return PlatformCompareMemory(buf1.ToPointer(), buf2.ToPointer(), checked((uint)length));
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, uint)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(byte* dest, byte* src, int len)
+		{
+			if (len >= 0x10)
+			{
+				do
+				{
+					*((int*)dest) = *((int*)src);
+					*((int*)(dest + 4)) = *((int*)(src + 4));
+					*((int*)(dest + 8)) = *((int*)(src + 8));
+					*((int*)(dest + 12)) = *((int*)(src + 12));
+					dest += 0x10;
+					src += 0x10;
+				}
+				while ((len -= 0x10) >= 0x10);
+			}
+			if (len > 0)
+			{
+				if ((len & 8) != 0)
+				{
+					*((int*)dest) = *((int*)src);
+					*((int*)(dest + 4)) = *((int*)(src + 4));
+					dest += 8;
+					src += 8;
+				}
+				if ((len & 4) != 0)
+				{
+					*((int*)dest) = *((int*)src);
+					dest += 4;
+					src += 4;
+				}
+				if ((len & 2) != 0)
+				{
+					*((short*)dest) = *((short*)src);
+					dest += 2;
+					src += 2;
+				}
+				if ((len & 1) != 0)
+				{
+					*dest = *src;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, long)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(byte* dest, byte* src, long len)
+		{
+			CopyMemory(dest, src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, long)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(void* dest, void* src, long len)
+		{
+			CopyMemory((byte*)dest, (byte*)src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(void*, void*, uint)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(void* dest, void* src, int len)
+		{
+			CopyMemory((byte*)dest, (byte*)src, len);
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(IntPtr, IntPtr, uint)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(IntPtr dest, IntPtr src, int len)
+		{
+			CopyMemory((byte*)dest, (byte*)src, len);
+		}
+
+		/// <summary>
+		/// Copies a block of memory from one location to another.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		/// <remarks>
+		/// <b>CopyMemory</b> runs faster than <see cref="MoveMemory(IntPtr, IntPtr, long)"/>.
+		/// However, if both blocks overlap the result is undefined.
+		/// </remarks>
+		public static unsafe void CopyMemory(IntPtr dest, IntPtr src, long len)
+		{
+			CopyMemory((byte*)dest, (byte*)src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies a block of memory into an array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, void* src, int len)
+		{
+			GCHandle handle = GCHandle.Alloc(dest, GCHandleType.Pinned);
+			try
+			{
+				CopyMemory((byte*)handle.AddrOfPinnedObject(), (byte*)src, len);
+			}
+			finally
+			{
+				handle.Free();
+			}
+		}
+
+		/// <summary>
+		/// Copies a block of memory into an array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, void* src, long len)
+		{
+			CopyMemory(dest, (byte*)src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies a block of memory into an array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, IntPtr src, int len)
+		{
+			CopyMemory(dest, (byte*)src, len);
+		}
+
+		/// <summary>
+		/// Copies a block of memory into an array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">A pointer to the starting address of the block of memory to copy.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, IntPtr src, long len)
+		{
+			CopyMemory(dest, (byte*)src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies the content of an array to a memory location.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(void* dest, Array src, int len)
+		{
+			GCHandle handle = GCHandle.Alloc(src, GCHandleType.Pinned);
+			try
+			{
+				CopyMemory((byte*)dest, (byte*)handle.AddrOfPinnedObject(), len);
+			}
+			finally
+			{
+				handle.Free();
+			}
+		}
+
+		/// <summary>
+		/// Copies the content of an array to a memory location.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(void* dest, Array src, long len)
+		{
+			CopyMemory((byte*)dest, src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies the content of an array to a memory location.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(IntPtr dest, Array src, int len)
+		{
+			CopyMemory((byte*)dest, src, len);
+		}
+
+		/// <summary>
+		/// Copies the content of an array to a memory location.
+		/// </summary>
+		/// <param name="dest">A pointer to the starting address of the copied block's destination.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the block of memory to copy, in bytes.</param>
+		public static unsafe void CopyMemory(IntPtr dest, Array src, long len)
+		{
+			CopyMemory((byte*)dest, src, checked((int)len));
+		}
+
+		/// <summary>
+		/// Copies the content of one array into another array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the content to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, Array src, int len)
+		{
+			GCHandle dHandle = GCHandle.Alloc(dest, GCHandleType.Pinned);
+			try
+			{
+				GCHandle sHandle = GCHandle.Alloc(src, GCHandleType.Pinned);
+				try
+				{
+					CopyMemory((byte*)dHandle.AddrOfPinnedObject(), (byte*)sHandle.AddrOfPinnedObject(), len);
+				}
+				finally
+				{
+					sHandle.Free();
+				}
+			}
+			finally
+			{
+				dHandle.Free();
+			}
+		}
+
+		/// <summary>
+		/// Copies the content of one array into another array.
+		/// </summary>
+		/// <param name="dest">An array used as the destination of the copy process.</param>
+		/// <param name="src">An array used as the source of the copy process.</param>
+		/// <param name="len">The size of the content to copy, in bytes.</param>
+		public static unsafe void CopyMemory(Array dest, Array src, long len)
+		{
+			CopyMemory(dest, src, checked((int)len));
+		}
+
+		internal static string ColorToString(Color color)
+		{
 			return string.Format(
 				System.Globalization.CultureInfo.CurrentCulture,
 				"{{Name={0}, ARGB=({1}, {2}, {3}, {4})}}",
 				new object[] { color.Name, color.A, color.R, color.G, color.B });
-        }
+		}
 
-        internal static void Resize(ref string str, int length)
-        {
-            if ((str != null) && (length >= 0) && (str.Length != length))
-            {
-                char[] chars = str.ToCharArray();
-                Array.Resize(ref chars, length);
-                str = new string(chars);
-            }
-        }
+		internal static void Resize(ref string str, int length)
+		{
+			if ((str != null) && (length >= 0) && (str.Length != length))
+			{
+				char[] chars = str.ToCharArray();
+				Array.Resize(ref chars, length);
+				str = new string(chars);
+			}
+		}
 
-        internal static void Resize(ref string str, int min, int max)
-        {
-            if ((str != null) && (min >= 0) && (max >= 0) && (min <= max))
-            {
-                if (str.Length < min)
-                {
-                    char[] chars = str.ToCharArray();
-                    Array.Resize(ref chars, min);
-                    str = new string(chars);
-                }
-                else if (str.Length > max)
-                {
-                    char[] chars = str.ToCharArray();
-                    Array.Resize(ref chars, max);
-                    str = new string(chars);
-                }
-            }
-        }
+		internal static void Resize(ref string str, int min, int max)
+		{
+			if ((str != null) && (min >= 0) && (max >= 0) && (min <= max))
+			{
+				if (str.Length < min)
+				{
+					char[] chars = str.ToCharArray();
+					Array.Resize(ref chars, min);
+					str = new string(chars);
+				}
+				else if (str.Length > max)
+				{
+					char[] chars = str.ToCharArray();
+					Array.Resize(ref chars, max);
+					str = new string(chars);
+				}
+			}
+		}
 
-        internal static void Resize<T>(ref T[] array, int length)
-        {
-            if ((array != null) && (length >= 0) && (array.Length != length))
-            {
-                Array.Resize(ref array, length);
-            }
-        }
+		internal static void Resize<T>(ref T[] array, int length)
+		{
+			if ((array != null) && (length >= 0) && (array.Length != length))
+			{
+				Array.Resize(ref array, length);
+			}
+		}
 
-        internal static void Resize<T>(ref T[] array, int min, int max)
-        {
-            if ((array != null) && (min >= 0) && (max >= 0) && (min <= max))
-            {
-                if (array.Length < min)
-                {
-                    Array.Resize(ref array, min);
-                }
-                else if (array.Length > max)
-                {
-                    Array.Resize(ref array, max);
-                }
-            }
-        }
+		internal static void Resize<T>(ref T[] array, int min, int max)
+		{
+			if ((array != null) && (min >= 0) && (max >= 0) && (min <= max))
+			{
+				if (array.Length < min)
+				{
+					Array.Resize(ref array, min);
+				}
+				else if (array.Length > max)
+				{
+					Array.Resize(ref array, max);
+				}
+			}
+		}
 
-        internal static bool CheckColorType<T>(FREE_IMAGE_TYPE imageType, T color)
-        {
-            Type type = typeof(T);
-            bool result;
-            switch (imageType)
-            {
-                case FREE_IMAGE_TYPE.FIT_BITMAP:
-                    result = (type == typeof(RGBQUAD)); break;
-                case FREE_IMAGE_TYPE.FIT_COMPLEX:
-                    result = (type == typeof(FICOMPLEX)); break;
-                case FREE_IMAGE_TYPE.FIT_DOUBLE:
-                    result = (type == typeof(double)); break;
-                case FREE_IMAGE_TYPE.FIT_FLOAT:
-                    result = (type == typeof(float)); break;
-                case FREE_IMAGE_TYPE.FIT_INT16:
-                    result = (type == typeof(Int16)); break;
-                case FREE_IMAGE_TYPE.FIT_INT32:
-                    result = (type == typeof(Int32)); break;
-                case FREE_IMAGE_TYPE.FIT_RGB16:
-                    result = (type == typeof(FIRGB16)); break;
-                case FREE_IMAGE_TYPE.FIT_RGBA16:
-                    result = (type == typeof(FIRGBA16)); break;
-                case FREE_IMAGE_TYPE.FIT_RGBAF:
-                    result = (type == typeof(FIRGBAF)); break;
-                case FREE_IMAGE_TYPE.FIT_RGBF:
-                    result = (type == typeof(FIRGBF)); break;
-                case FREE_IMAGE_TYPE.FIT_UINT16:
-                    result = (type == typeof(UInt16)); break;
-                case FREE_IMAGE_TYPE.FIT_UINT32:
-                    result = (type == typeof(UInt32)); break;
-                default:
-                    result = false; break;
-            }
-            return result;
-        }
+		internal static bool CheckColorType<T>(FREE_IMAGE_TYPE imageType, T color)
+		{
+			Type type = typeof(T);
+			bool result;
+			switch (imageType)
+			{
+				case FREE_IMAGE_TYPE.FIT_BITMAP:
+					result = (type == typeof(RGBQUAD)); break;
+				case FREE_IMAGE_TYPE.FIT_COMPLEX:
+					result = (type == typeof(FICOMPLEX)); break;
+				case FREE_IMAGE_TYPE.FIT_DOUBLE:
+					result = (type == typeof(double)); break;
+				case FREE_IMAGE_TYPE.FIT_FLOAT:
+					result = (type == typeof(float)); break;
+				case FREE_IMAGE_TYPE.FIT_INT16:
+					result = (type == typeof(Int16)); break;
+				case FREE_IMAGE_TYPE.FIT_INT32:
+					result = (type == typeof(Int32)); break;
+				case FREE_IMAGE_TYPE.FIT_RGB16:
+					result = (type == typeof(FIRGB16)); break;
+				case FREE_IMAGE_TYPE.FIT_RGBA16:
+					result = (type == typeof(FIRGBA16)); break;
+				case FREE_IMAGE_TYPE.FIT_RGBAF:
+					result = (type == typeof(FIRGBAF)); break;
+				case FREE_IMAGE_TYPE.FIT_RGBF:
+					result = (type == typeof(FIRGBF)); break;
+				case FREE_IMAGE_TYPE.FIT_UINT16:
+					result = (type == typeof(UInt16)); break;
+				case FREE_IMAGE_TYPE.FIT_UINT32:
+					result = (type == typeof(UInt32)); break;
+				default:
+					result = false; break;
+			}
+			return result;
+		}
 
-        #endregion
+		#endregion
 
-        private static unsafe bool PlatformCompareMemory(void* buf1, void* buf2, uint count)
-        {
-            if (IsWindows) {
-                return Win32.RtlCompareMemory(buf1, buf2, count) == count;
-            }
-            else if(IsLinux)
-            {
-                return LibC.memcmp(buf1, buf2, count) == 0;
-            }
+		private static unsafe bool PlatformCompareMemory(void* buf1, void* buf2, uint count)
+		{
+			if (IsWindows)
+			{
+				return Win32.RtlCompareMemory(buf1, buf2, count) == count;
+			}
+			else if (IsLinux)
+			{
+				return LibC.memcmp(buf1, buf2, count) == 0;
+			}
 
-            return UnsafeHelpers.CompareMemory(buf1, buf2, count) == count;
-        }
-    }
+			return UnsafeHelpers.CompareMemory(buf1, buf2, count) == count;
+		}
+	}
 }

--- a/src/FreeImage.Standard/Structs/FIRational.cs
+++ b/src/FreeImage.Standard/Structs/FIRational.cs
@@ -406,7 +406,7 @@ namespace FreeImageAPI
 			return base.GetHashCode();
 		}
 
-#region Operators
+		#region Operators
 
 		/// <summary>
 		/// Standard implementation of the operator.
@@ -575,9 +575,9 @@ namespace FreeImageAPI
 			return (r1.numerator * (denominator / r1.denominator)) <= (r2.numerator * (denominator / r2.denominator));
 		}
 
-#endregion
+		#endregion
 
-#region Conversions
+		#region Conversions
 
 		/// <summary>
 		/// Converts the value of a <see cref="FIRational"/> structure to a <see cref="Boolean"/> structure.
@@ -841,9 +841,9 @@ namespace FreeImageAPI
 			return new FIRational((int)value, 1);
 		}
 
-#endregion
+		#endregion
 
-#region IConvertible Member
+		#region IConvertible Member
 
 		TypeCode IConvertible.GetTypeCode()
 		{
@@ -930,9 +930,9 @@ namespace FreeImageAPI
 			return (ulong)this;
 		}
 
-#endregion
+		#endregion
 
-#region IComparable Member
+		#region IComparable Member
 
 		/// <summary>
 		/// Compares this instance with a specified <see cref="Object"/>.
@@ -953,9 +953,9 @@ namespace FreeImageAPI
 			return CompareTo((FIRational)obj);
 		}
 
-#endregion
+		#endregion
 
-#region IFormattable Member
+		#region IFormattable Member
 
 		/// <summary>
 		/// Formats the value of the current instance using the specified format.
@@ -972,9 +972,9 @@ namespace FreeImageAPI
 			return String.Format(formatProvider, format, ((IConvertible)this).ToDouble(formatProvider));
 		}
 
-#endregion
+		#endregion
 
-#region IEquatable<FIRational> Member
+		#region IEquatable<FIRational> Member
 
 		/// <summary>
 		/// Tests whether the specified <see cref="FIRational"/> structure is equivalent to this <see cref="FIRational"/> structure.
@@ -987,9 +987,9 @@ namespace FreeImageAPI
 			return (this == other);
 		}
 
-#endregion
+		#endregion
 
-#region IComparable<FIRational> Member
+		#region IComparable<FIRational> Member
 
 		/// <summary>
 		/// Compares this instance with a specified <see cref="FIRational"/> object.
@@ -1001,11 +1001,14 @@ namespace FreeImageAPI
 		{
 			FIRational difference = this - other;
 			difference.Normalize();
-			if (difference.numerator > 0) return 1;
-			if (difference.numerator < 0) return -1;
-			else return 0;
+			if (difference.numerator > 0)
+				return 1;
+			if (difference.numerator < 0)
+				return -1;
+			else
+				return 0;
 		}
 
-#endregion
+		#endregion
 	}
 }

--- a/src/FreeImage.Standard/Structs/FIURational.cs
+++ b/src/FreeImage.Standard/Structs/FIURational.cs
@@ -394,7 +394,7 @@ namespace FreeImageAPI
 			return base.GetHashCode();
 		}
 
-#region Operators
+		#region Operators
 
 		/// <summary>
 		/// Standard implementation of the operator.
@@ -574,9 +574,9 @@ namespace FreeImageAPI
 				(right.numerator * (denominator / right.denominator));
 		}
 
-#endregion
+		#endregion
 
-#region Conversions
+		#region Conversions
 
 		/// <summary>
 		/// Converts the value of a <see cref="FIURational"/> structure to a <see cref="Boolean"/> structure.
@@ -840,9 +840,9 @@ namespace FreeImageAPI
 			return new FIURational((uint)value, 1u);
 		}
 
-#endregion
+		#endregion
 
-#region IConvertible Member
+		#region IConvertible Member
 
 		TypeCode IConvertible.GetTypeCode()
 		{
@@ -929,9 +929,9 @@ namespace FreeImageAPI
 			return (ulong)this;
 		}
 
-#endregion
+		#endregion
 
-#region IComparable Member
+		#region IComparable Member
 
 		/// <summary>
 		/// Compares this instance with a specified <see cref="Object"/>.
@@ -952,9 +952,9 @@ namespace FreeImageAPI
 			return CompareTo((FIURational)obj);
 		}
 
-#endregion
+		#endregion
 
-#region IFormattable Member
+		#region IFormattable Member
 
 		/// <summary>
 		/// Formats the value of the current instance using the specified format.
@@ -971,9 +971,9 @@ namespace FreeImageAPI
 			return String.Format(formatProvider, format, ((IConvertible)this).ToDouble(formatProvider));
 		}
 
-#endregion
+		#endregion
 
-#region IEquatable<FIURational> Member
+		#region IEquatable<FIURational> Member
 
 		/// <summary>
 		/// Tests whether the specified <see cref="FIURational"/> structure is equivalent to this <see cref="FIURational"/> structure.
@@ -986,9 +986,9 @@ namespace FreeImageAPI
 			return (this == other);
 		}
 
-#endregion
+		#endregion
 
-#region IComparable<FIURational> Member
+		#region IComparable<FIURational> Member
 
 		/// <summary>
 		/// Compares this instance with a specified <see cref="FIURational"/> object.
@@ -1000,11 +1000,14 @@ namespace FreeImageAPI
 		{
 			FIURational difference = this - other;
 			difference.Normalize();
-			if (difference.numerator > 0) return 1;
-			if (difference.numerator < 0) return -1;
-			else return 0;
+			if (difference.numerator > 0)
+				return 1;
+			if (difference.numerator < 0)
+				return -1;
+			else
+				return 0;
 		}
 
-#endregion
+		#endregion
 	}
 }

--- a/src/FreeImage.Standard/UnsafeHelpers.cs
+++ b/src/FreeImage.Standard/UnsafeHelpers.cs
@@ -1,4 +1,5 @@
-﻿namespace FreeImageAPI {
+﻿namespace FreeImageAPI
+{
 	internal unsafe class UnsafeHelpers
 	{
 		// TODO: This is 5-6x slower than calling RtlCompareMemory on Windows.

--- a/src/UnitTest/ImageManager.cs
+++ b/src/UnitTest/ImageManager.cs
@@ -158,7 +158,7 @@ namespace FreeImageNETUnitTest
 		}
 
 		private static string GetImageDataFolder()
-		{			
+		{
 			string solutionFolder = NativeLibraryLoader.GetSolutionFolder();
 			string imagesFolder = Path.Combine(solutionFolder, "UnitTestData", "Images");
 

--- a/src/UnitTest/SetUpFixture.cs
+++ b/src/UnitTest/SetUpFixture.cs
@@ -4,22 +4,22 @@ using System.Reflection;
 
 namespace FreeImageNETUnitTest
 {
-    [SetUpFixture]
-    public class SetUpFixture
-    {
+	[SetUpFixture]
+	public class SetUpFixture
+	{
 
-        [OneTimeSetUp]
-        public void Init()
-        {
-            string dir = Path.GetDirectoryName(typeof(SetUpFixture).GetTypeInfo().Assembly.Location);
-            Directory.SetCurrentDirectory(dir);
+		[OneTimeSetUp]
+		public void Init()
+		{
+			string dir = Path.GetDirectoryName(typeof(SetUpFixture).GetTypeInfo().Assembly.Location);
+			Directory.SetCurrentDirectory(dir);
 
-            NativeLibraryLoader.CopyFreeImageNativeDll();
-        }
+			NativeLibraryLoader.CopyFreeImageNativeDll();
+		}
 
-        [OneTimeTearDown]
-        public void DeInit()
-        {
-        }
-    }
+		[OneTimeTearDown]
+		public void DeInit()
+		{
+		}
+	}
 }

--- a/src/UnitTest/TestFixtures/FreeImageBitmapTest.cs
+++ b/src/UnitTest/TestFixtures/FreeImageBitmapTest.cs
@@ -13,7 +13,7 @@ namespace FreeImageNETUnitTest.TestFixtures
 	public class FreeImageBitmapTest
 	{
 		ImageManager iManager = new ImageManager();
-		FIBITMAP dib = new FIBITMAP();        
+		FIBITMAP dib = new FIBITMAP();
 
 		[SetUp]
 		public void InitEachTime()
@@ -239,7 +239,7 @@ namespace FreeImageNETUnitTest.TestFixtures
 			fib.Dispose();
 		}
 
-        [Test]
+		[Test]
 		public void GetBounds()
 		{
 			Random rand = new Random();

--- a/src/UnitTest/TestFixtures/ImportedFunctionsTest.cs
+++ b/src/UnitTest/TestFixtures/ImportedFunctionsTest.cs
@@ -15,10 +15,10 @@ namespace FreeImageNETUnitTest.TestFixtures
 		ImageManager iManager = new ImageManager();
 		FIBITMAP dib;
 
-        [SetUp]
+		[SetUp]
 		public void InitEachTime()
-        {
-        }
+		{
+		}
 
 		[TearDown]
 		public void DeInitEachTime()
@@ -39,9 +39,9 @@ namespace FreeImageNETUnitTest.TestFixtures
 			Assert.IsNotEmpty(copyright);
 		}
 
-        string freeImageCallback = null;
+		string freeImageCallback = null;
 
-        [Test]
+		[Test]
 		public void FreeImage_OutputMessageProc_SetOutputMessage()
 		{
 			Assert.IsNull(freeImageCallback);
@@ -50,14 +50,14 @@ namespace FreeImageNETUnitTest.TestFixtures
 			FreeImage.SetOutputMessage(null);
 			Assert.IsNotNull(freeImageCallback);
 			freeImageCallback = null;
-        }
+		}
 
-        void FreeImage_Message(FREE_IMAGE_FORMAT fif, string message)
-        {
-            freeImageCallback = message;
-        }
+		void FreeImage_Message(FREE_IMAGE_FORMAT fif, string message)
+		{
+			freeImageCallback = message;
+		}
 
-        [Test]
+		[Test]
 		public void FreeImage_Allocate()
 		{
 			dib = FreeImage.Allocate(
@@ -1318,8 +1318,8 @@ namespace FreeImageNETUnitTest.TestFixtures
 			Assert.That(!dib.IsNull);
 			FIBITMAP dib8 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_08_Greyscale_MinIsBlack);
 			Assert.AreNotEqual(0, dib8);
-            Assert.AreEqual(FreeImage.GetWidth(dib), FreeImage.GetWidth(dib8));
-            Assert.AreEqual(FreeImage.GetHeight(dib), FreeImage.GetHeight(dib8));
+			Assert.AreEqual(FreeImage.GetWidth(dib), FreeImage.GetWidth(dib8));
+			Assert.AreEqual(FreeImage.GetHeight(dib), FreeImage.GetHeight(dib8));
 
 			Assert.IsTrue(FreeImage.SetChannel(dib, dib8, FREE_IMAGE_COLOR_CHANNEL.FICC_BLUE));
 

--- a/src/UnitTest/TestFixtures/ImportedStructsTest.cs
+++ b/src/UnitTest/TestFixtures/ImportedStructsTest.cs
@@ -6,344 +6,348 @@ using NUnit.Framework;
 
 namespace FreeImageNETUnitTest.TestFixtures
 {
-    [TestFixture]
-    public class ImportedStructsTest
-    {
-        ImageManager iManager = new ImageManager();
-        FIBITMAP dib = new FIBITMAP();
-
-        [SetUp]
-        public void InitEachTime()
-        {
-        }
-
-        [TearDown]
-        public void DeInitEachTime()
-        {
-        }
-
-        public bool EqualColors(Color color1, Color color2)
-        {
-            if (color1.A != color2.A) return false;
-            if (color1.R != color2.R) return false;
-            if (color1.G != color2.G) return false;
-            if (color1.B != color2.B) return false;
-            return true;
-        }
-
-        [Test]
-        public void RGBQUAD()
-        {
-            RGBQUAD rgbq = new RGBQUAD();
-            Assert.AreEqual(0, rgbq.rgbBlue);
-            Assert.AreEqual(0, rgbq.rgbGreen);
-            Assert.AreEqual(0, rgbq.rgbRed);
-            Assert.AreEqual(0, rgbq.rgbReserved);
-
-            rgbq = new RGBQUAD(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgbq.Color));
-
-            rgbq = new RGBQUAD(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173, rgbq.rgbBlue);
-            Assert.AreEqual(95, rgbq.rgbGreen);
-            Assert.AreEqual(83, rgbq.rgbRed);
-            Assert.AreEqual(133, rgbq.rgbReserved);
-
-            rgbq.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgbq.Color));
-
-            rgbq.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgbq.Color));
-
-            rgbq.Color = Color.White;
-            Assert.AreEqual(255, rgbq.rgbBlue);
-            Assert.AreEqual(255, rgbq.rgbGreen);
-            Assert.AreEqual(255, rgbq.rgbRed);
-            Assert.AreEqual(255, rgbq.rgbReserved);
-
-            rgbq.Color = Color.Black;
-            Assert.AreEqual(0, rgbq.rgbBlue);
-            Assert.AreEqual(0, rgbq.rgbGreen);
-            Assert.AreEqual(0, rgbq.rgbRed);
-            Assert.AreEqual(255, rgbq.rgbReserved);
-
-            rgbq = Color.DarkGoldenrod;
-            Color color = rgbq;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Test]
-        public void RGBTRIPLE()
-        {
-            RGBTRIPLE rgbt = new RGBTRIPLE();
-            Assert.AreEqual(0, rgbt.rgbtBlue);
-            Assert.AreEqual(0, rgbt.rgbtGreen);
-            Assert.AreEqual(0, rgbt.rgbtRed);
-
-            rgbt = new RGBTRIPLE(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgbt.Color));
-
-            rgbt = new RGBTRIPLE(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173, rgbt.rgbtBlue);
-            Assert.AreEqual(95, rgbt.rgbtGreen);
-            Assert.AreEqual(83, rgbt.rgbtRed);
-
-            rgbt.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgbt.Color));
-
-            rgbt.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgbt.Color));
-
-            rgbt.Color = Color.White;
-            Assert.AreEqual(255, rgbt.rgbtBlue);
-            Assert.AreEqual(255, rgbt.rgbtGreen);
-            Assert.AreEqual(255, rgbt.rgbtRed);
-
-            rgbt.Color = Color.Black;
-            Assert.AreEqual(0, rgbt.rgbtBlue);
-            Assert.AreEqual(0, rgbt.rgbtGreen);
-            Assert.AreEqual(0, rgbt.rgbtRed);
-
-            rgbt = Color.DarkGoldenrod;
-            Color color = rgbt;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Test]
-        public void FIRGB16()
-        {
-            FIRGB16 rgb = new FIRGB16();
-            Assert.AreEqual(0 * 256, rgb.blue);
-            Assert.AreEqual(0 * 256, rgb.green);
-            Assert.AreEqual(0 * 256, rgb.red);
-
-            rgb = new FIRGB16(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
-
-            rgb = new FIRGB16(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173 * 256, rgb.blue);
-            Assert.AreEqual(95 * 256, rgb.green);
-            Assert.AreEqual(83 * 256, rgb.red);
-
-            rgb.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgb.Color));
-
-            rgb.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
-
-            rgb.Color = Color.White;
-            Assert.AreEqual(255 * 256, rgb.blue);
-            Assert.AreEqual(255 * 256, rgb.green);
-            Assert.AreEqual(255 * 256, rgb.red);
-
-            rgb.Color = Color.Black;
-            Assert.AreEqual(0 * 256, rgb.blue);
-            Assert.AreEqual(0 * 256, rgb.green);
-            Assert.AreEqual(0 * 256, rgb.red);
-
-            rgb = Color.DarkGoldenrod;
-            Color color = rgb;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Test]
-        public void FIRGBA16()
-        {
-            FIRGBA16 rgb = new FIRGBA16();
-            Assert.AreEqual(0 * 256, rgb.blue);
-            Assert.AreEqual(0 * 256, rgb.green);
-            Assert.AreEqual(0 * 256, rgb.red);
-            Assert.AreEqual(0 * 256, rgb.alpha);
-
-            rgb = new FIRGBA16(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
-
-            rgb = new FIRGBA16(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173 * 256, rgb.blue);
-            Assert.AreEqual(95 * 256, rgb.green);
-            Assert.AreEqual(83 * 256, rgb.red);
-            Assert.AreEqual(133 * 256, rgb.alpha);
-
-            rgb.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgb.Color));
-
-            rgb.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
-
-            rgb.Color = Color.White;
-            Assert.AreEqual(255 * 256, rgb.blue);
-            Assert.AreEqual(255 * 256, rgb.green);
-            Assert.AreEqual(255 * 256, rgb.red);
-            Assert.AreEqual(255 * 256, rgb.alpha);
-
-            rgb.Color = Color.Black;
-            Assert.AreEqual(0 * 256, rgb.blue);
-            Assert.AreEqual(0 * 256, rgb.green);
-            Assert.AreEqual(0 * 256, rgb.red);
-            Assert.AreEqual(255 * 256, rgb.alpha);
-
-            rgb = Color.DarkGoldenrod;
-            Color color = rgb;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Test]
-        public void FIRGBF()
-        {
-            FIRGBF rgb = new FIRGBF();
-            Assert.AreEqual(0 / 255f, rgb.blue);
-            Assert.AreEqual(0 / 255f, rgb.green);
-            Assert.AreEqual(0 / 255f, rgb.red);
-
-            rgb = new FIRGBF(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
-
-            rgb = new FIRGBF(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173 / 255f, rgb.blue);
-            Assert.AreEqual(95 / 255f, rgb.green);
-            Assert.AreEqual(83 / 255f, rgb.red);
-
-            rgb.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgb.Color));
-
-            rgb.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
-
-            rgb.Color = Color.White;
-            Assert.AreEqual(255 / 255f, rgb.blue);
-            Assert.AreEqual(255 / 255f, rgb.green);
-            Assert.AreEqual(255 / 255f, rgb.red);
-
-            rgb.Color = Color.Black;
-            Assert.AreEqual(0 / 255f, rgb.blue);
-            Assert.AreEqual(0 / 255f, rgb.green);
-            Assert.AreEqual(0 / 255f, rgb.red);
-
-            rgb = Color.DarkGoldenrod;
-            Color color = rgb;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Test]
-        public void FIRGBAF()
-        {
-            FIRGBAF rgb = new FIRGBAF();
-            Assert.AreEqual(0 / 255f, rgb.blue);
-            Assert.AreEqual(0 / 255f, rgb.green);
-            Assert.AreEqual(0 / 255f, rgb.red);
-            Assert.AreEqual(0 / 255f, rgb.alpha);
-
-            rgb = new FIRGBAF(Color.Chartreuse);
-            Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
-
-            rgb = new FIRGBAF(Color.FromArgb(133, 83, 95, 173));
-            Assert.AreEqual(173 / 255f, rgb.blue);
-            Assert.AreEqual(95 / 255f, rgb.green);
-            Assert.AreEqual(83 / 255f, rgb.red);
-            Assert.AreEqual(133 / 255f, rgb.alpha);
-
-            rgb.Color = Color.Crimson;
-            Assert.That(EqualColors(Color.Crimson, rgb.Color));
-
-            rgb.Color = Color.MidnightBlue;
-            Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
-
-            rgb.Color = Color.White;
-            Assert.AreEqual(255 / 255f, rgb.blue);
-            Assert.AreEqual(255 / 255f, rgb.green);
-            Assert.AreEqual(255 / 255f, rgb.red);
-            Assert.AreEqual(255 / 255f, rgb.alpha);
-
-            rgb.Color = Color.Black;
-            Assert.AreEqual(0 / 255f, rgb.blue);
-            Assert.AreEqual(0 / 255f, rgb.green);
-            Assert.AreEqual(0 / 255f, rgb.red);
-            Assert.AreEqual(255 / 255f, rgb.alpha);
-
-            rgb = Color.DarkGoldenrod;
-            Color color = rgb;
-            Assert.That(EqualColors(Color.DarkGoldenrod, color));
-        }
-
-        [Ignore("Ignoring FICOMPLEX")]
-        public void FICOMPLEX()
-        {
-        }
-
-        [Test]
-        public void FIBITMAP()
-        {
-            FIBITMAP var = new FIBITMAP();
-            Assert.IsTrue(var.IsNull);
-        }
-
-        [Test]
-        public void fi_handle()
-        {
-            fi_handle var = new fi_handle();
-            Assert.IsTrue(var.IsNull);
-
-            string test = "hello word!";
-            using (var = new fi_handle(test))
-            {
-                Assert.IsFalse(var.IsNull);
-
-                object obj = var.GetObject();
-                Assert.That(obj is string);
-                Assert.AreSame(obj, test);
-            }
-        }
-
-        [Test]
-        public void FIICCPROFILE()
-        {
-            Random rand = new Random(DateTime.Now.Millisecond);
-            FIICCPROFILE var = new FIICCPROFILE();
-            Assert.AreEqual(0, var.Data.Length);
-            Assert.AreEqual(IntPtr.Zero, var.DataPointer);
-            Assert.AreEqual(0, var.Size);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.That(!dib.IsNull);
-
-            byte[] data = new byte[512];
-            rand.NextBytes(data);
-
-            var = FreeImage.GetICCProfileEx(dib);
-            Assert.AreEqual(0, var.Size);
-
-            var = new FIICCPROFILE(dib, data, 256);
-            Assert.AreEqual(256, var.Data.Length);
-            Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
-            Assert.AreEqual(256, var.Size);
-            byte[] dataComp = var.Data;
-            for (int i = 0; i < data.Length && i < dataComp.Length; i++)
-                if (data[i] != dataComp[i])
-                    Assert.Fail();
-
-            FreeImage.DestroyICCProfile(dib);
-            var = FreeImage.GetICCProfileEx(dib);
-            Assert.AreEqual(0, var.Size);
-
-            var = new FIICCPROFILE(dib, data);
-            Assert.AreEqual(512, var.Data.Length);
-            Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
-            Assert.AreEqual(512, var.Size);
-            dataComp = var.Data;
-            for (int i = 0; i < data.Length && i < dataComp.Length; i++)
-                if (data[i] != dataComp[i])
-                    Assert.Fail();
-
-            var = FreeImage.GetICCProfileEx(dib);
-            Assert.AreEqual(512, var.Data.Length);
-            Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
-            Assert.AreEqual(512, var.Size);
-
-            FreeImage.DestroyICCProfile(dib);
-            var = FreeImage.GetICCProfileEx(dib);
-            Assert.AreEqual(0, var.Size);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-    }
+	[TestFixture]
+	public class ImportedStructsTest
+	{
+		ImageManager iManager = new ImageManager();
+		FIBITMAP dib = new FIBITMAP();
+
+		[SetUp]
+		public void InitEachTime()
+		{
+		}
+
+		[TearDown]
+		public void DeInitEachTime()
+		{
+		}
+
+		public bool EqualColors(Color color1, Color color2)
+		{
+			if (color1.A != color2.A)
+				return false;
+			if (color1.R != color2.R)
+				return false;
+			if (color1.G != color2.G)
+				return false;
+			if (color1.B != color2.B)
+				return false;
+			return true;
+		}
+
+		[Test]
+		public void RGBQUAD()
+		{
+			RGBQUAD rgbq = new RGBQUAD();
+			Assert.AreEqual(0, rgbq.rgbBlue);
+			Assert.AreEqual(0, rgbq.rgbGreen);
+			Assert.AreEqual(0, rgbq.rgbRed);
+			Assert.AreEqual(0, rgbq.rgbReserved);
+
+			rgbq = new RGBQUAD(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgbq.Color));
+
+			rgbq = new RGBQUAD(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173, rgbq.rgbBlue);
+			Assert.AreEqual(95, rgbq.rgbGreen);
+			Assert.AreEqual(83, rgbq.rgbRed);
+			Assert.AreEqual(133, rgbq.rgbReserved);
+
+			rgbq.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgbq.Color));
+
+			rgbq.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgbq.Color));
+
+			rgbq.Color = Color.White;
+			Assert.AreEqual(255, rgbq.rgbBlue);
+			Assert.AreEqual(255, rgbq.rgbGreen);
+			Assert.AreEqual(255, rgbq.rgbRed);
+			Assert.AreEqual(255, rgbq.rgbReserved);
+
+			rgbq.Color = Color.Black;
+			Assert.AreEqual(0, rgbq.rgbBlue);
+			Assert.AreEqual(0, rgbq.rgbGreen);
+			Assert.AreEqual(0, rgbq.rgbRed);
+			Assert.AreEqual(255, rgbq.rgbReserved);
+
+			rgbq = Color.DarkGoldenrod;
+			Color color = rgbq;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Test]
+		public void RGBTRIPLE()
+		{
+			RGBTRIPLE rgbt = new RGBTRIPLE();
+			Assert.AreEqual(0, rgbt.rgbtBlue);
+			Assert.AreEqual(0, rgbt.rgbtGreen);
+			Assert.AreEqual(0, rgbt.rgbtRed);
+
+			rgbt = new RGBTRIPLE(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgbt.Color));
+
+			rgbt = new RGBTRIPLE(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173, rgbt.rgbtBlue);
+			Assert.AreEqual(95, rgbt.rgbtGreen);
+			Assert.AreEqual(83, rgbt.rgbtRed);
+
+			rgbt.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgbt.Color));
+
+			rgbt.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgbt.Color));
+
+			rgbt.Color = Color.White;
+			Assert.AreEqual(255, rgbt.rgbtBlue);
+			Assert.AreEqual(255, rgbt.rgbtGreen);
+			Assert.AreEqual(255, rgbt.rgbtRed);
+
+			rgbt.Color = Color.Black;
+			Assert.AreEqual(0, rgbt.rgbtBlue);
+			Assert.AreEqual(0, rgbt.rgbtGreen);
+			Assert.AreEqual(0, rgbt.rgbtRed);
+
+			rgbt = Color.DarkGoldenrod;
+			Color color = rgbt;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Test]
+		public void FIRGB16()
+		{
+			FIRGB16 rgb = new FIRGB16();
+			Assert.AreEqual(0 * 256, rgb.blue);
+			Assert.AreEqual(0 * 256, rgb.green);
+			Assert.AreEqual(0 * 256, rgb.red);
+
+			rgb = new FIRGB16(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
+
+			rgb = new FIRGB16(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173 * 256, rgb.blue);
+			Assert.AreEqual(95 * 256, rgb.green);
+			Assert.AreEqual(83 * 256, rgb.red);
+
+			rgb.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgb.Color));
+
+			rgb.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
+
+			rgb.Color = Color.White;
+			Assert.AreEqual(255 * 256, rgb.blue);
+			Assert.AreEqual(255 * 256, rgb.green);
+			Assert.AreEqual(255 * 256, rgb.red);
+
+			rgb.Color = Color.Black;
+			Assert.AreEqual(0 * 256, rgb.blue);
+			Assert.AreEqual(0 * 256, rgb.green);
+			Assert.AreEqual(0 * 256, rgb.red);
+
+			rgb = Color.DarkGoldenrod;
+			Color color = rgb;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Test]
+		public void FIRGBA16()
+		{
+			FIRGBA16 rgb = new FIRGBA16();
+			Assert.AreEqual(0 * 256, rgb.blue);
+			Assert.AreEqual(0 * 256, rgb.green);
+			Assert.AreEqual(0 * 256, rgb.red);
+			Assert.AreEqual(0 * 256, rgb.alpha);
+
+			rgb = new FIRGBA16(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
+
+			rgb = new FIRGBA16(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173 * 256, rgb.blue);
+			Assert.AreEqual(95 * 256, rgb.green);
+			Assert.AreEqual(83 * 256, rgb.red);
+			Assert.AreEqual(133 * 256, rgb.alpha);
+
+			rgb.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgb.Color));
+
+			rgb.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
+
+			rgb.Color = Color.White;
+			Assert.AreEqual(255 * 256, rgb.blue);
+			Assert.AreEqual(255 * 256, rgb.green);
+			Assert.AreEqual(255 * 256, rgb.red);
+			Assert.AreEqual(255 * 256, rgb.alpha);
+
+			rgb.Color = Color.Black;
+			Assert.AreEqual(0 * 256, rgb.blue);
+			Assert.AreEqual(0 * 256, rgb.green);
+			Assert.AreEqual(0 * 256, rgb.red);
+			Assert.AreEqual(255 * 256, rgb.alpha);
+
+			rgb = Color.DarkGoldenrod;
+			Color color = rgb;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Test]
+		public void FIRGBF()
+		{
+			FIRGBF rgb = new FIRGBF();
+			Assert.AreEqual(0 / 255f, rgb.blue);
+			Assert.AreEqual(0 / 255f, rgb.green);
+			Assert.AreEqual(0 / 255f, rgb.red);
+
+			rgb = new FIRGBF(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
+
+			rgb = new FIRGBF(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173 / 255f, rgb.blue);
+			Assert.AreEqual(95 / 255f, rgb.green);
+			Assert.AreEqual(83 / 255f, rgb.red);
+
+			rgb.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgb.Color));
+
+			rgb.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
+
+			rgb.Color = Color.White;
+			Assert.AreEqual(255 / 255f, rgb.blue);
+			Assert.AreEqual(255 / 255f, rgb.green);
+			Assert.AreEqual(255 / 255f, rgb.red);
+
+			rgb.Color = Color.Black;
+			Assert.AreEqual(0 / 255f, rgb.blue);
+			Assert.AreEqual(0 / 255f, rgb.green);
+			Assert.AreEqual(0 / 255f, rgb.red);
+
+			rgb = Color.DarkGoldenrod;
+			Color color = rgb;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Test]
+		public void FIRGBAF()
+		{
+			FIRGBAF rgb = new FIRGBAF();
+			Assert.AreEqual(0 / 255f, rgb.blue);
+			Assert.AreEqual(0 / 255f, rgb.green);
+			Assert.AreEqual(0 / 255f, rgb.red);
+			Assert.AreEqual(0 / 255f, rgb.alpha);
+
+			rgb = new FIRGBAF(Color.Chartreuse);
+			Assert.That(EqualColors(Color.Chartreuse, rgb.Color));
+
+			rgb = new FIRGBAF(Color.FromArgb(133, 83, 95, 173));
+			Assert.AreEqual(173 / 255f, rgb.blue);
+			Assert.AreEqual(95 / 255f, rgb.green);
+			Assert.AreEqual(83 / 255f, rgb.red);
+			Assert.AreEqual(133 / 255f, rgb.alpha);
+
+			rgb.Color = Color.Crimson;
+			Assert.That(EqualColors(Color.Crimson, rgb.Color));
+
+			rgb.Color = Color.MidnightBlue;
+			Assert.That(EqualColors(Color.MidnightBlue, rgb.Color));
+
+			rgb.Color = Color.White;
+			Assert.AreEqual(255 / 255f, rgb.blue);
+			Assert.AreEqual(255 / 255f, rgb.green);
+			Assert.AreEqual(255 / 255f, rgb.red);
+			Assert.AreEqual(255 / 255f, rgb.alpha);
+
+			rgb.Color = Color.Black;
+			Assert.AreEqual(0 / 255f, rgb.blue);
+			Assert.AreEqual(0 / 255f, rgb.green);
+			Assert.AreEqual(0 / 255f, rgb.red);
+			Assert.AreEqual(255 / 255f, rgb.alpha);
+
+			rgb = Color.DarkGoldenrod;
+			Color color = rgb;
+			Assert.That(EqualColors(Color.DarkGoldenrod, color));
+		}
+
+		[Ignore("Ignoring FICOMPLEX")]
+		public void FICOMPLEX()
+		{
+		}
+
+		[Test]
+		public void FIBITMAP()
+		{
+			FIBITMAP var = new FIBITMAP();
+			Assert.IsTrue(var.IsNull);
+		}
+
+		[Test]
+		public void fi_handle()
+		{
+			fi_handle var = new fi_handle();
+			Assert.IsTrue(var.IsNull);
+
+			string test = "hello word!";
+			using (var = new fi_handle(test))
+			{
+				Assert.IsFalse(var.IsNull);
+
+				object obj = var.GetObject();
+				Assert.That(obj is string);
+				Assert.AreSame(obj, test);
+			}
+		}
+
+		[Test]
+		public void FIICCPROFILE()
+		{
+			Random rand = new Random(DateTime.Now.Millisecond);
+			FIICCPROFILE var = new FIICCPROFILE();
+			Assert.AreEqual(0, var.Data.Length);
+			Assert.AreEqual(IntPtr.Zero, var.DataPointer);
+			Assert.AreEqual(0, var.Size);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.That(!dib.IsNull);
+
+			byte[] data = new byte[512];
+			rand.NextBytes(data);
+
+			var = FreeImage.GetICCProfileEx(dib);
+			Assert.AreEqual(0, var.Size);
+
+			var = new FIICCPROFILE(dib, data, 256);
+			Assert.AreEqual(256, var.Data.Length);
+			Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
+			Assert.AreEqual(256, var.Size);
+			byte[] dataComp = var.Data;
+			for (int i = 0; i < data.Length && i < dataComp.Length; i++)
+				if (data[i] != dataComp[i])
+					Assert.Fail();
+
+			FreeImage.DestroyICCProfile(dib);
+			var = FreeImage.GetICCProfileEx(dib);
+			Assert.AreEqual(0, var.Size);
+
+			var = new FIICCPROFILE(dib, data);
+			Assert.AreEqual(512, var.Data.Length);
+			Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
+			Assert.AreEqual(512, var.Size);
+			dataComp = var.Data;
+			for (int i = 0; i < data.Length && i < dataComp.Length; i++)
+				if (data[i] != dataComp[i])
+					Assert.Fail();
+
+			var = FreeImage.GetICCProfileEx(dib);
+			Assert.AreEqual(512, var.Data.Length);
+			Assert.AreNotEqual(IntPtr.Zero, var.DataPointer);
+			Assert.AreEqual(512, var.Size);
+
+			FreeImage.DestroyICCProfile(dib);
+			var = FreeImage.GetICCProfileEx(dib);
+			Assert.AreEqual(0, var.Size);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+	}
 }

--- a/src/UnitTest/TestFixtures/UnsafeMethodsTest.cs
+++ b/src/UnitTest/TestFixtures/UnsafeMethodsTest.cs
@@ -14,12 +14,14 @@ namespace UnitTest.TestFixtures
 
 			uint actualCount;
 
-			fixed(byte* b1 = bytes1)
-			fixed(byte* b2 = bytes2) {
+			fixed (byte* b1 = bytes1)
+			fixed (byte* b2 = bytes2)
+			{
 				actualCount = UnsafeHelpers.CompareMemory(b1, b2, (uint)bytes1.Length);
 			}
 
-			Assert.AreEqual(expectedCount, actualCount); ;
+			Assert.AreEqual(expectedCount, actualCount);
+			;
 		}
 		[Test]
 		public void CompareMemory_Different()
@@ -38,7 +40,8 @@ namespace UnitTest.TestFixtures
 				actualCount = UnsafeHelpers.CompareMemory(b1, b2, (uint)bytes1.Length);
 			}
 
-			Assert.AreEqual(expectedCount, actualCount); ;
+			Assert.AreEqual(expectedCount, actualCount);
+			;
 		}
 	}
 }

--- a/src/UnitTest/TestFixtures/WrapperFunctionsTest.cs
+++ b/src/UnitTest/TestFixtures/WrapperFunctionsTest.cs
@@ -9,1561 +9,1577 @@ using NUnit.Framework;
 
 namespace FreeImageNETUnitTest.TestFixtures
 {
-    [TestFixture]
-    public class WrapperFunctionsTest
-    {
-        ImageManager iManager = new ImageManager();
-        FIBITMAP dib = new FIBITMAP();        
-
-        [SetUp]
-        public void InitEachTime()
-        {
-        }
-
-        [TearDown]
-        public void DeInitEachTime()
-        {
-        }
-
-        public bool EqualColors(Color color1, Color color2)
-        {
-            if (color1.A != color2.A) return false;
-            if (color1.R != color2.R) return false;
-            if (color1.G != color2.G) return false;
-            if (color1.B != color2.B) return false;
-            return true;
-        }
-
-        //
-        // Tests
-        //
-
-        [Test]
-        public void FreeImage_GetWrapperVersion()
-        {
-            //Assert.That(FreeImage.GetWrapperVersion() ==
-            //    String.Format("{0}.{1}.{2}",
-            //    FreeImage.FREEIMAGE_MAJOR_VERSION,
-            //    FreeImage.FREEIMAGE_MINOR_VERSION,
-            //    FreeImage.FREEIMAGE_RELEASE_SERIAL));
-        }
-
-        [Test]
-        public void FreeImage_IsAvailable()
-        {
-            Assert.DoesNotThrow(() => FreeImage.ValidateAvailability());
-        }
-
-        [Test]
-        public void FreeImage_GetBitmap()
-        {
-            Bitmap bitmap = null;
-
-            try
-            {
-                bitmap = FreeImage.GetBitmap(new FIBITMAP());
-            }
-            catch
-            {
-            }
-            Assert.IsNull(bitmap);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
-            Assert.That(!dib.IsNull);
-
-            bitmap = FreeImage.GetBitmap(dib);
-            Assert.IsNotNull(bitmap);
-            Assert.AreEqual((int)FreeImage.GetHeight(dib), bitmap.Height);
-            Assert.AreEqual((int)FreeImage.GetWidth(dib), bitmap.Width);
-
-            bitmap.Dispose();
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_CreateFromBitmap()
-        {
-            Bitmap bitmap = (Bitmap)Bitmap.FromFile(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_24));
-            Assert.IsNotNull(bitmap);
-
-            dib = FreeImage.CreateFromBitmap(bitmap);
-            Assert.That(!dib.IsNull);
-
-            Assert.AreEqual((int)FreeImage.GetHeight(dib), bitmap.Height);
-            Assert.AreEqual((int)FreeImage.GetWidth(dib), bitmap.Width);
-
-            bitmap.Dispose();
-            FreeImage.UnloadEx(ref dib);
-
-            try
-            {
-                dib = FreeImage.CreateFromBitmap(null);
-                Assert.Fail();
-            }
-            catch
-            {
-            }
-        }
-
-        [Test]
-        public void FreeImage_SaveBitmap()
-        {
-            Bitmap bitmap = (Bitmap)Bitmap.FromFile(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_24));
-            Assert.IsNotNull(bitmap);
-
-            Assert.IsTrue(FreeImage.SaveBitmap(bitmap, @"test.png", FREE_IMAGE_FORMAT.FIF_PNG, FREE_IMAGE_SAVE_FLAGS.DEFAULT));
-            bitmap.Dispose();
-
-            Assert.IsTrue(File.Exists(@"test.png"));
-
-            dib = FreeImage.Load(FREE_IMAGE_FORMAT.FIF_PNG, @"test.png", FREE_IMAGE_LOAD_FLAGS.DEFAULT);
-            Assert.That(!dib.IsNull);
-
-            FreeImage.UnloadEx(ref dib);
-
-            File.Delete(@"test.png");
-            Assert.IsFalse(File.Exists(@"test.png"));
-            bitmap.Dispose();
-        }
-
-        [Test]
-        public void FreeImage_LoadEx()
-        {
-            dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_555));
-            Assert.That(!dib.IsNull);
-            FreeImage.UnloadEx(ref dib);
-
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_TIFF;
-
-            dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), ref format);
-            Assert.That(dib.IsNull);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
-            FreeImage.UnloadEx(ref dib);
-
-            format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.JPEG, ImageColorType.Type_16_565),
-                FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-            Assert.That(!dib.IsNull);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_JPEG, format);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_UnloadEx()
-        {
-            Assert.That(dib.IsNull);
-            FreeImage.UnloadEx(ref dib);
-            Assert.That(dib.IsNull);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_555);
-            Assert.That(!dib.IsNull);
-
-            FreeImage.UnloadEx(ref dib);
-            Assert.That(dib.IsNull);
-        }
-
-        [Test]
-        public void FreeImage_SaveEx()
-        {
-            FREE_IMAGE_FORMAT format;
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_08);
-            Assert.That(!dib.IsNull);
-
-            Assert.IsTrue(FreeImage.SaveEx(dib, @"test.png"));
-            Assert.IsTrue(File.Exists(@"test.png"));
-            format = FreeImage.GetFileType(@"test.png", 0);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_PNG, format);
-            File.Delete(@"test.png");
-            Assert.IsFalse(File.Exists(@"test.png"));
-
-            Assert.IsTrue(FreeImage.SaveEx(ref dib, @"test.tiff", FREE_IMAGE_SAVE_FLAGS.DEFAULT, false));
-            Assert.IsTrue(File.Exists(@"test.tiff"));
-            format = FreeImage.GetFileType(@"test.tiff", 0);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
-            File.Delete(@"test.tiff");
-            Assert.IsFalse(File.Exists(@"test.tiff"));
-
-            Assert.IsTrue(FreeImage.SaveEx(
-                            ref dib,
-                            @"test.gif",
-                            FREE_IMAGE_FORMAT.FIF_UNKNOWN,
-                            FREE_IMAGE_SAVE_FLAGS.DEFAULT,
-                            FREE_IMAGE_COLOR_DEPTH.FICD_08_BPP,
-                            false));
-
-            Assert.IsTrue(File.Exists(@"test.gif"));
-            format = FreeImage.GetFileType(@"test.gif", 0);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_GIF, format);
-            File.Delete(@"test.gif");
-            Assert.IsFalse(File.Exists(@"test.gif"));
-
-            Assert.IsFalse(FreeImage.SaveEx(dib, @""));
-            Assert.IsFalse(FreeImage.SaveEx(dib, @"test.test"));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_LoadFromStream()
-        {
-            FREE_IMAGE_FORMAT format;
-            FileStream fStream;
-
-            fStream = new FileStream(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), FileMode.Open);
-            Assert.IsNotNull(fStream);
-
-            dib = FreeImage.LoadFromStream(fStream);
-            Assert.That(!dib.IsNull);
-            Assert.That(FreeImage.GetBPP(dib) == 16);
-            Assert.That(FreeImage.GetGreenMask(dib) == FreeImage.FI16_565_GREEN_MASK);
-
-            FreeImage.UnloadEx(ref dib);
-
-            fStream.Close();
-            fStream.Dispose();
-
-            fStream = new FileStream(iManager.GetBitmapPath(ImageType.Metadata, ImageColorType.Type_01_Dither), FileMode.Open);
-            Assert.IsNotNull(fStream);
-
-            format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            dib = FreeImage.LoadFromStream(fStream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-            Assert.That(!dib.IsNull);
-            Assert.That(FreeImage.GetBPP(dib) == 24);
-            Assert.That(format == FREE_IMAGE_FORMAT.FIF_JPEG);
-            FreeImage.UnloadEx(ref dib);
-
-            fStream.Close();
-            fStream.Dispose();
-
-            fStream = new FileStream(iManager.GetBitmapPath(ImageType.Even, ImageColorType.Type_32), FileMode.Open);
-            format = FREE_IMAGE_FORMAT.FIF_TIFF;
-            dib = FreeImage.LoadFromStream(fStream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
-            Assert.That(!dib.IsNull);
-            Assert.That(FreeImage.GetBPP(dib) == 32);
-            Assert.That(format == FREE_IMAGE_FORMAT.FIF_TIFF);
-
-            FreeImage.UnloadEx(ref dib);
-
-            Assert.That(dib.IsNull);
-            Assert.Throws<IOException>(() => FreeImage.LoadFromStream(new MemoryStream(new byte[] { })));
-            Assert.That(dib.IsNull);
-
-            format = FREE_IMAGE_FORMAT.FIF_BMP;
-            fStream.Position = 0;
-            dib = FreeImage.LoadFromStream(fStream, ref format);
-            Assert.That(dib.IsNull);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_BMP, format);
-
-            fStream.Close();
-            fStream.Dispose();
-        }
-
-        [Test]
-        public void FreeImage_SaveToStream()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_08_Greyscale_MinIsBlack);
-            Assert.That(!dib.IsNull);
-
-            Stream stream = new FileStream(@"out_stream.bmp", FileMode.Create);
-            Assert.IsNotNull(stream);
-
-            Assert.IsTrue(FreeImage.SaveEx(ref dib, @"out_file.bmp", FREE_IMAGE_FORMAT.FIF_BMP, false));
-            Assert.IsTrue(FreeImage.SaveToStream(dib, stream, FREE_IMAGE_FORMAT.FIF_BMP));
-            stream.Flush();
-            stream.Dispose();
-
-            Assert.IsTrue(File.Exists(@"out_stream.bmp"));
-            Assert.IsTrue(File.Exists(@"out_file.bmp"));
-            byte[] buffer1 = File.ReadAllBytes(@"out_stream.bmp");
-            byte[] buffer2 = File.ReadAllBytes(@"out_file.bmp");
-            Assert.AreEqual(buffer1.Length, buffer2.Length);
-            for (int i = 0; i < buffer1.Length; i++)
-                if (buffer1[i] != buffer2[i])
-                    Assert.Fail();
-
-            File.Delete(@"out_stream.bmp");
-            File.Delete(@"out_file.bmp");
-            Assert.IsFalse(File.Exists(@"out_stream.bmp"));
-            Assert.IsFalse(File.Exists(@"out_file.bmp"));
-
-            stream = new MemoryStream();
-            Assert.IsFalse(FreeImage.SaveToStream(dib, stream, FREE_IMAGE_FORMAT.FIF_FAXG3));
-            stream.Dispose();
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_IsExtensionValidForFIF()
-        {
-            Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "bmp", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "BMP", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsFalse(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "DUMMY", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_PCX, "pcx", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_TIFF, "tif", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_TIFF, "TIFF", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsFalse(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_ICO, "ICO", StringComparison.CurrentCulture));
-        }
-
-        [Test]
-        public void FreeImage_IsFilenameValidForFIF()
-        {
-            Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.jpg"));
-            Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.jpeg"));
-            Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.bmp"));
-            Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.gif"));
-            Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.GIF"));
-            Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.GIF", StringComparison.CurrentCultureIgnoreCase));
-            Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.txt"));
-            Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.jpg"));
-            Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.bmp"));
-            Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.tif"));
-        }
-
-        [Test]
-        public void FreeImage_GetPrimaryExtensionFromFIF()
-        {
-            Assert.AreEqual("gif", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_GIF));
-            Assert.AreEqual("tif", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_TIFF));
-            Assert.AreNotEqual("tiff", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_TIFF));
-            Assert.AreEqual("psd", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_PSD));
-            Assert.AreEqual("iff", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_IFF));
-            Assert.IsNull(FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN));
-        }
-
-        [Test]
-        public void FreeImage_OpenMultiBitmapEx()
-        {
-            FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
-            Assert.IsFalse(dib.IsNull);
-            Assert.AreEqual(4, FreeImage.GetPageCount(dib));
-            FreeImage.CloseMultiBitmap(dib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
-
-            FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
-            dib = FreeImage.OpenMultiBitmapEx(
-                iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_04), ref format, FREE_IMAGE_LOAD_FLAGS.DEFAULT,
-                false, true, true);
-            Assert.IsFalse(dib.IsNull);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
-            FreeImage.CloseMultiBitmap(dib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
-        }
-
-        [Test]
-        public void FreeImage_GetLockedPageCount()
-        {
-            FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
-            FIBITMAP page1, page2, page3;
-            Assert.IsFalse(dib.IsNull);
-            Assert.AreEqual(4, FreeImage.GetPageCount(dib));
-            Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
-
-            page1 = FreeImage.LockPage(dib, 0);
-            Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
-
-            page2 = FreeImage.LockPage(dib, 1);
-            Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
-
-            page3 = FreeImage.LockPage(dib, 2);
-            Assert.AreEqual(3, FreeImage.GetLockedPageCount(dib));
-
-            FreeImage.UnlockPage(dib, page3, true);
-            Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
-
-            FreeImage.UnlockPage(dib, page2, true);
-            Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
-
-            FreeImage.UnlockPage(dib, page1, true);
-            Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
-
-            FreeImage.CloseMultiBitmapEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetLockedPages()
-        {
-            FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
-            FIBITMAP page1, page2, page3;
-            int[] lockedList;
-            Assert.IsFalse(dib.IsNull);
-            Assert.AreEqual(4, FreeImage.GetPageCount(dib));
-            Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
-
-            page1 = FreeImage.LockPage(dib, 0);
-            Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.Contains(0, lockedList);
-
-            page2 = FreeImage.LockPage(dib, 1);
-            Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.Contains(0, lockedList);
-            Assert.Contains(1, lockedList);
-
-            page3 = FreeImage.LockPage(dib, 3);
-            Assert.AreEqual(3, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.Contains(0, lockedList);
-            Assert.Contains(1, lockedList);
-            Assert.Contains(3, lockedList);
-
-            FreeImage.UnlockPage(dib, page2, true);
-            Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.Contains(0, lockedList);
-            Assert.Contains(3, lockedList);
-
-            FreeImage.UnlockPage(dib, page1, true);
-            Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.Contains(3, lockedList);
-
-            FreeImage.UnlockPage(dib, page3, true);
-            Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
-            lockedList = FreeImage.GetLockedPages(dib);
-            Assert.AreEqual(0, lockedList.Length);
-
-            FreeImage.CloseMultiBitmapEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetFileTypeFromStream()
-        {
-            FileStream fStream = new FileStream(iManager.GetBitmapPath(ImageType.JPEG, ImageColorType.Type_01_Dither), FileMode.Open);
-            Assert.IsNotNull(fStream);
-
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_JPEG, FreeImage.GetFileTypeFromStream(fStream));
-            fStream.Dispose();
-
-            fStream = new FileStream(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), FileMode.Open);
-            Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_BMP, FreeImage.GetFileTypeFromStream(fStream));
-
-            fStream.Close();
-            fStream.Dispose();
-        }
+	[TestFixture]
+	public class WrapperFunctionsTest
+	{
+		ImageManager iManager = new ImageManager();
+		FIBITMAP dib = new FIBITMAP();
+
+		[SetUp]
+		public void InitEachTime()
+		{
+		}
+
+		[TearDown]
+		public void DeInitEachTime()
+		{
+		}
+
+		public bool EqualColors(Color color1, Color color2)
+		{
+			if (color1.A != color2.A)
+				return false;
+			if (color1.R != color2.R)
+				return false;
+			if (color1.G != color2.G)
+				return false;
+			if (color1.B != color2.B)
+				return false;
+			return true;
+		}
+
+		//
+		// Tests
+		//
+
+		[Test]
+		public void FreeImage_GetWrapperVersion()
+		{
+			//Assert.That(FreeImage.GetWrapperVersion() ==
+			//    String.Format("{0}.{1}.{2}",
+			//    FreeImage.FREEIMAGE_MAJOR_VERSION,
+			//    FreeImage.FREEIMAGE_MINOR_VERSION,
+			//    FreeImage.FREEIMAGE_RELEASE_SERIAL));
+		}
+
+		[Test]
+		public void FreeImage_IsAvailable()
+		{
+			Assert.DoesNotThrow(() => FreeImage.ValidateAvailability());
+		}
+
+		[Test]
+		public void FreeImage_GetBitmap()
+		{
+			Bitmap bitmap = null;
+
+			try
+			{
+				bitmap = FreeImage.GetBitmap(new FIBITMAP());
+			}
+			catch
+			{
+			}
+			Assert.IsNull(bitmap);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
+			Assert.That(!dib.IsNull);
+
+			bitmap = FreeImage.GetBitmap(dib);
+			Assert.IsNotNull(bitmap);
+			Assert.AreEqual((int)FreeImage.GetHeight(dib), bitmap.Height);
+			Assert.AreEqual((int)FreeImage.GetWidth(dib), bitmap.Width);
+
+			bitmap.Dispose();
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_CreateFromBitmap()
+		{
+			Bitmap bitmap = (Bitmap)Bitmap.FromFile(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_24));
+			Assert.IsNotNull(bitmap);
+
+			dib = FreeImage.CreateFromBitmap(bitmap);
+			Assert.That(!dib.IsNull);
+
+			Assert.AreEqual((int)FreeImage.GetHeight(dib), bitmap.Height);
+			Assert.AreEqual((int)FreeImage.GetWidth(dib), bitmap.Width);
+
+			bitmap.Dispose();
+			FreeImage.UnloadEx(ref dib);
+
+			try
+			{
+				dib = FreeImage.CreateFromBitmap(null);
+				Assert.Fail();
+			}
+			catch
+			{
+			}
+		}
+
+		[Test]
+		public void FreeImage_SaveBitmap()
+		{
+			Bitmap bitmap = (Bitmap)Bitmap.FromFile(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_24));
+			Assert.IsNotNull(bitmap);
+
+			Assert.IsTrue(FreeImage.SaveBitmap(bitmap, @"test.png", FREE_IMAGE_FORMAT.FIF_PNG, FREE_IMAGE_SAVE_FLAGS.DEFAULT));
+			bitmap.Dispose();
+
+			Assert.IsTrue(File.Exists(@"test.png"));
+
+			dib = FreeImage.Load(FREE_IMAGE_FORMAT.FIF_PNG, @"test.png", FREE_IMAGE_LOAD_FLAGS.DEFAULT);
+			Assert.That(!dib.IsNull);
+
+			FreeImage.UnloadEx(ref dib);
+
+			File.Delete(@"test.png");
+			Assert.IsFalse(File.Exists(@"test.png"));
+			bitmap.Dispose();
+		}
+
+		[Test]
+		public void FreeImage_LoadEx()
+		{
+			dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_555));
+			Assert.That(!dib.IsNull);
+			FreeImage.UnloadEx(ref dib);
+
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_TIFF;
+
+			dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), ref format);
+			Assert.That(dib.IsNull);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
+			FreeImage.UnloadEx(ref dib);
+
+			format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			dib = FreeImage.LoadEx(iManager.GetBitmapPath(ImageType.JPEG, ImageColorType.Type_16_565),
+				FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+			Assert.That(!dib.IsNull);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_JPEG, format);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_UnloadEx()
+		{
+			Assert.That(dib.IsNull);
+			FreeImage.UnloadEx(ref dib);
+			Assert.That(dib.IsNull);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_555);
+			Assert.That(!dib.IsNull);
+
+			FreeImage.UnloadEx(ref dib);
+			Assert.That(dib.IsNull);
+		}
+
+		[Test]
+		public void FreeImage_SaveEx()
+		{
+			FREE_IMAGE_FORMAT format;
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_08);
+			Assert.That(!dib.IsNull);
+
+			Assert.IsTrue(FreeImage.SaveEx(dib, @"test.png"));
+			Assert.IsTrue(File.Exists(@"test.png"));
+			format = FreeImage.GetFileType(@"test.png", 0);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_PNG, format);
+			File.Delete(@"test.png");
+			Assert.IsFalse(File.Exists(@"test.png"));
+
+			Assert.IsTrue(FreeImage.SaveEx(ref dib, @"test.tiff", FREE_IMAGE_SAVE_FLAGS.DEFAULT, false));
+			Assert.IsTrue(File.Exists(@"test.tiff"));
+			format = FreeImage.GetFileType(@"test.tiff", 0);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
+			File.Delete(@"test.tiff");
+			Assert.IsFalse(File.Exists(@"test.tiff"));
+
+			Assert.IsTrue(FreeImage.SaveEx(
+							ref dib,
+							@"test.gif",
+							FREE_IMAGE_FORMAT.FIF_UNKNOWN,
+							FREE_IMAGE_SAVE_FLAGS.DEFAULT,
+							FREE_IMAGE_COLOR_DEPTH.FICD_08_BPP,
+							false));
+
+			Assert.IsTrue(File.Exists(@"test.gif"));
+			format = FreeImage.GetFileType(@"test.gif", 0);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_GIF, format);
+			File.Delete(@"test.gif");
+			Assert.IsFalse(File.Exists(@"test.gif"));
+
+			Assert.IsFalse(FreeImage.SaveEx(dib, @""));
+			Assert.IsFalse(FreeImage.SaveEx(dib, @"test.test"));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_LoadFromStream()
+		{
+			FREE_IMAGE_FORMAT format;
+			FileStream fStream;
+
+			fStream = new FileStream(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), FileMode.Open);
+			Assert.IsNotNull(fStream);
+
+			dib = FreeImage.LoadFromStream(fStream);
+			Assert.That(!dib.IsNull);
+			Assert.That(FreeImage.GetBPP(dib) == 16);
+			Assert.That(FreeImage.GetGreenMask(dib) == FreeImage.FI16_565_GREEN_MASK);
+
+			FreeImage.UnloadEx(ref dib);
+
+			fStream.Close();
+			fStream.Dispose();
+
+			fStream = new FileStream(iManager.GetBitmapPath(ImageType.Metadata, ImageColorType.Type_01_Dither), FileMode.Open);
+			Assert.IsNotNull(fStream);
+
+			format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			dib = FreeImage.LoadFromStream(fStream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+			Assert.That(!dib.IsNull);
+			Assert.That(FreeImage.GetBPP(dib) == 24);
+			Assert.That(format == FREE_IMAGE_FORMAT.FIF_JPEG);
+			FreeImage.UnloadEx(ref dib);
+
+			fStream.Close();
+			fStream.Dispose();
+
+			fStream = new FileStream(iManager.GetBitmapPath(ImageType.Even, ImageColorType.Type_32), FileMode.Open);
+			format = FREE_IMAGE_FORMAT.FIF_TIFF;
+			dib = FreeImage.LoadFromStream(fStream, FREE_IMAGE_LOAD_FLAGS.DEFAULT, ref format);
+			Assert.That(!dib.IsNull);
+			Assert.That(FreeImage.GetBPP(dib) == 32);
+			Assert.That(format == FREE_IMAGE_FORMAT.FIF_TIFF);
+
+			FreeImage.UnloadEx(ref dib);
+
+			Assert.That(dib.IsNull);
+			Assert.Throws<IOException>(() => FreeImage.LoadFromStream(new MemoryStream(new byte[] { })));
+			Assert.That(dib.IsNull);
+
+			format = FREE_IMAGE_FORMAT.FIF_BMP;
+			fStream.Position = 0;
+			dib = FreeImage.LoadFromStream(fStream, ref format);
+			Assert.That(dib.IsNull);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_BMP, format);
+
+			fStream.Close();
+			fStream.Dispose();
+		}
+
+		[Test]
+		public void FreeImage_SaveToStream()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_08_Greyscale_MinIsBlack);
+			Assert.That(!dib.IsNull);
+
+			Stream stream = new FileStream(@"out_stream.bmp", FileMode.Create);
+			Assert.IsNotNull(stream);
+
+			Assert.IsTrue(FreeImage.SaveEx(ref dib, @"out_file.bmp", FREE_IMAGE_FORMAT.FIF_BMP, false));
+			Assert.IsTrue(FreeImage.SaveToStream(dib, stream, FREE_IMAGE_FORMAT.FIF_BMP));
+			stream.Flush();
+			stream.Dispose();
+
+			Assert.IsTrue(File.Exists(@"out_stream.bmp"));
+			Assert.IsTrue(File.Exists(@"out_file.bmp"));
+			byte[] buffer1 = File.ReadAllBytes(@"out_stream.bmp");
+			byte[] buffer2 = File.ReadAllBytes(@"out_file.bmp");
+			Assert.AreEqual(buffer1.Length, buffer2.Length);
+			for (int i = 0; i < buffer1.Length; i++)
+				if (buffer1[i] != buffer2[i])
+					Assert.Fail();
+
+			File.Delete(@"out_stream.bmp");
+			File.Delete(@"out_file.bmp");
+			Assert.IsFalse(File.Exists(@"out_stream.bmp"));
+			Assert.IsFalse(File.Exists(@"out_file.bmp"));
+
+			stream = new MemoryStream();
+			Assert.IsFalse(FreeImage.SaveToStream(dib, stream, FREE_IMAGE_FORMAT.FIF_FAXG3));
+			stream.Dispose();
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_IsExtensionValidForFIF()
+		{
+			Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "bmp", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "BMP", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsFalse(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_BMP, "DUMMY", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_PCX, "pcx", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_TIFF, "tif", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsTrue(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_TIFF, "TIFF", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsFalse(FreeImage.IsExtensionValidForFIF(FREE_IMAGE_FORMAT.FIF_ICO, "ICO", StringComparison.CurrentCulture));
+		}
+
+		[Test]
+		public void FreeImage_IsFilenameValidForFIF()
+		{
+			Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.jpg"));
+			Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.jpeg"));
+			Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_JPEG, "file.bmp"));
+			Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.gif"));
+			Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.GIF"));
+			Assert.IsTrue(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.GIF", StringComparison.CurrentCultureIgnoreCase));
+			Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_GIF, "file.txt"));
+			Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.jpg"));
+			Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.bmp"));
+			Assert.IsFalse(FreeImage.IsFilenameValidForFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN, "file.tif"));
+		}
+
+		[Test]
+		public void FreeImage_GetPrimaryExtensionFromFIF()
+		{
+			Assert.AreEqual("gif", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_GIF));
+			Assert.AreEqual("tif", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_TIFF));
+			Assert.AreNotEqual("tiff", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_TIFF));
+			Assert.AreEqual("psd", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_PSD));
+			Assert.AreEqual("iff", FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_IFF));
+			Assert.IsNull(FreeImage.GetPrimaryExtensionFromFIF(FREE_IMAGE_FORMAT.FIF_UNKNOWN));
+		}
+
+		[Test]
+		public void FreeImage_OpenMultiBitmapEx()
+		{
+			FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
+			Assert.IsFalse(dib.IsNull);
+			Assert.AreEqual(4, FreeImage.GetPageCount(dib));
+			FreeImage.CloseMultiBitmap(dib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
+
+			FREE_IMAGE_FORMAT format = FREE_IMAGE_FORMAT.FIF_UNKNOWN;
+			dib = FreeImage.OpenMultiBitmapEx(
+				iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_04), ref format, FREE_IMAGE_LOAD_FLAGS.DEFAULT,
+				false, true, true);
+			Assert.IsFalse(dib.IsNull);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_TIFF, format);
+			FreeImage.CloseMultiBitmap(dib, FREE_IMAGE_SAVE_FLAGS.DEFAULT);
+		}
+
+		[Test]
+		public void FreeImage_GetLockedPageCount()
+		{
+			FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
+			FIBITMAP page1, page2, page3;
+			Assert.IsFalse(dib.IsNull);
+			Assert.AreEqual(4, FreeImage.GetPageCount(dib));
+			Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
+
+			page1 = FreeImage.LockPage(dib, 0);
+			Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
+
+			page2 = FreeImage.LockPage(dib, 1);
+			Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
+
+			page3 = FreeImage.LockPage(dib, 2);
+			Assert.AreEqual(3, FreeImage.GetLockedPageCount(dib));
+
+			FreeImage.UnlockPage(dib, page3, true);
+			Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
+
+			FreeImage.UnlockPage(dib, page2, true);
+			Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
+
+			FreeImage.UnlockPage(dib, page1, true);
+			Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
+
+			FreeImage.CloseMultiBitmapEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetLockedPages()
+		{
+			FIMULTIBITMAP dib = FreeImage.OpenMultiBitmapEx(iManager.GetBitmapPath(ImageType.Multipaged, ImageColorType.Type_01_Dither));
+			FIBITMAP page1, page2, page3;
+			int[] lockedList;
+			Assert.IsFalse(dib.IsNull);
+			Assert.AreEqual(4, FreeImage.GetPageCount(dib));
+			Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
+
+			page1 = FreeImage.LockPage(dib, 0);
+			Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.Contains(0, lockedList);
+
+			page2 = FreeImage.LockPage(dib, 1);
+			Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.Contains(0, lockedList);
+			Assert.Contains(1, lockedList);
+
+			page3 = FreeImage.LockPage(dib, 3);
+			Assert.AreEqual(3, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.Contains(0, lockedList);
+			Assert.Contains(1, lockedList);
+			Assert.Contains(3, lockedList);
+
+			FreeImage.UnlockPage(dib, page2, true);
+			Assert.AreEqual(2, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.Contains(0, lockedList);
+			Assert.Contains(3, lockedList);
+
+			FreeImage.UnlockPage(dib, page1, true);
+			Assert.AreEqual(1, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.Contains(3, lockedList);
+
+			FreeImage.UnlockPage(dib, page3, true);
+			Assert.AreEqual(0, FreeImage.GetLockedPageCount(dib));
+			lockedList = FreeImage.GetLockedPages(dib);
+			Assert.AreEqual(0, lockedList.Length);
+
+			FreeImage.CloseMultiBitmapEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetFileTypeFromStream()
+		{
+			FileStream fStream = new FileStream(iManager.GetBitmapPath(ImageType.JPEG, ImageColorType.Type_01_Dither), FileMode.Open);
+			Assert.IsNotNull(fStream);
+
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_JPEG, FreeImage.GetFileTypeFromStream(fStream));
+			fStream.Dispose();
+
+			fStream = new FileStream(iManager.GetBitmapPath(ImageType.Odd, ImageColorType.Type_16_565), FileMode.Open);
+			Assert.AreEqual(FREE_IMAGE_FORMAT.FIF_BMP, FreeImage.GetFileTypeFromStream(fStream));
+
+			fStream.Close();
+			fStream.Dispose();
+		}
 
 #if NET472
-        [Test]
-        public void FreeImage_GetHbitmap()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
+		[Test]
+		public void FreeImage_GetHbitmap()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
 
-            IntPtr hBitmap = FreeImage.GetHbitmap(dib, IntPtr.Zero, false);
-            Bitmap bitmap = Bitmap.FromHbitmap(hBitmap);
-            Assert.IsNotNull(bitmap);
-            Assert.AreEqual(FreeImage.GetWidth(dib), bitmap.Width);
-            Assert.AreEqual(FreeImage.GetHeight(dib), bitmap.Height);
+			IntPtr hBitmap = FreeImage.GetHbitmap(dib, IntPtr.Zero, false);
+			Bitmap bitmap = Bitmap.FromHbitmap(hBitmap);
+			Assert.IsNotNull(bitmap);
+			Assert.AreEqual(FreeImage.GetWidth(dib), bitmap.Width);
+			Assert.AreEqual(FreeImage.GetHeight(dib), bitmap.Height);
 
-            bitmap.Dispose();
-            FreeImage.FreeHbitmap(hBitmap);
-            FreeImage.UnloadEx(ref dib);
+			bitmap.Dispose();
+			FreeImage.FreeHbitmap(hBitmap);
+			FreeImage.UnloadEx(ref dib);
 
-            try
-            {
-                hBitmap = FreeImage.GetHbitmap(dib, IntPtr.Zero, false);
-                Assert.Fail();
-            }
-            catch
-            {
-            }
-        }
+			try
+			{
+				hBitmap = FreeImage.GetHbitmap(dib, IntPtr.Zero, false);
+				Assert.Fail();
+			}
+			catch
+			{
+			}
+		}
 #endif
 
-        [Test]
-        public void FreeImage_GetResolutionX()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(72, FreeImage.GetResolutionX(dib));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetResolutionY()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(72, FreeImage.GetResolutionY(dib));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_SetResolutionX()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(72, FreeImage.GetResolutionX(dib));
-
-            FreeImage.SetResolutionX(dib, 12u);
-            Assert.AreEqual(12, FreeImage.GetResolutionX(dib));
-
-            FreeImage.SetResolutionX(dib, 1u);
-            Assert.AreEqual(1, FreeImage.GetResolutionX(dib));
-
-            FreeImage.SetResolutionX(dib, 66u);
-            Assert.AreEqual(66, FreeImage.GetResolutionX(dib));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_SetResolutionY()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(72, FreeImage.GetResolutionY(dib));
-
-            FreeImage.SetResolutionY(dib, 12u);
-            Assert.AreEqual(12, FreeImage.GetResolutionY(dib));
-
-            FreeImage.SetResolutionY(dib, 1u);
-            Assert.AreEqual(1, FreeImage.GetResolutionY(dib));
-
-            FreeImage.SetResolutionY(dib, 66u);
-            Assert.AreEqual(66, FreeImage.GetResolutionY(dib));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_IsGreyscaleImage()
-        {
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
-            Assert.IsFalse(FreeImage.IsGreyscaleImage(dib));
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_Unordered);
-            Assert.IsTrue(FreeImage.IsGreyscaleImage(dib));
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_MinIsBlack);
-            Assert.IsTrue(FreeImage.IsGreyscaleImage(dib));
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetPaletteEx()
-        {
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
-            Palette palette = null;
-
-            try
-            {
-                palette = FreeImage.GetPaletteEx(dib);
-                Assert.Fail();
-            }
-            catch
-            {
-            }
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_08_Greyscale_MinIsBlack);
-            try
-            {
-                palette = FreeImage.GetPaletteEx(dib);
-            }
-            catch
-            {
-                Assert.Fail();
-            }
-            Assert.AreEqual(256, palette.Length);
-            for (int index = 0; index < 256; index++)
-            {
-                Assert.AreEqual(index, palette[index].rgbRed);
-                Assert.AreEqual(index, palette[index].rgbGreen);
-                Assert.AreEqual(index, palette[index].rgbBlue);
-            }
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetInfoHeaderEx()
-        {
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04);
-            Assert.IsFalse(dib.IsNull);
-
-            BITMAPINFOHEADER iHeader = FreeImage.GetInfoHeaderEx(dib);
-            Assert.AreEqual(4, iHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-
-            iHeader = FreeImage.GetInfoHeaderEx(dib);
-            Assert.AreEqual(1, iHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
-            Assert.IsFalse(dib.IsNull);
-
-            iHeader = FreeImage.GetInfoHeaderEx(dib);
-            Assert.AreEqual(24, iHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetInfoEx()
-        {
-            BITMAPINFO info;
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_04_Greyscale_MinIsBlack);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_08_Greyscale_Unordered);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
-            Assert.That(!dib.IsNull);
-            info = FreeImage.GetInfoEx(dib);
-            Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
-            Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
-            Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetPixelFormat()
-        {
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_01_Threshold);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(PixelFormat.Format1bppIndexed, FreeImage.GetPixelFormat(dib));
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_04_Greyscale_Unordered);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(PixelFormat.Format4bppIndexed, FreeImage.GetPixelFormat(dib));
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_555);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(PixelFormat.Format16bppRgb555, FreeImage.GetPixelFormat(dib));
-            FreeImage.UnloadEx(ref dib);
-
-            dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_565);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.AreEqual(PixelFormat.Format16bppRgb565, FreeImage.GetPixelFormat(dib));
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetFormatParameters()
-        {
-            uint bpp, red, green, blue;
-            FREE_IMAGE_TYPE type;
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppArgb1555, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(16, bpp);
-            Assert.AreEqual(red, FreeImage.FI16_555_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI16_555_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI16_555_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppGrayScale, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(16, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_UINT16);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppRgb555, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(16, bpp);
-            Assert.AreEqual(red, FreeImage.FI16_555_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI16_555_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI16_555_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppRgb565, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(16, bpp);
-            Assert.AreEqual(red, FreeImage.FI16_565_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI16_565_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI16_565_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format1bppIndexed, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(1, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format24bppRgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(24, bpp);
-            Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppArgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(32, bpp);
-            Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppPArgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(32, bpp);
-            Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppRgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(32, bpp);
-            Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
-            Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
-            Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format48bppRgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(48, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGB16);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format4bppIndexed, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(4, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format64bppArgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(64, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGBA16);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format64bppPArgb, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(64, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGBA16);
-
-            Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format8bppIndexed, out type, out bpp, out red, out green, out blue));
-            Assert.AreEqual(8, bpp);
-            Assert.AreEqual(red, 0);
-            Assert.AreEqual(green, 0);
-            Assert.AreEqual(blue, 0);
-            Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
-        }
-
-        [Test]
-        public void FreeImage_Compare()
-        {
-            FIBITMAP dib2;
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-            dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Threshold);
-            Assert.IsFalse(dib2.IsNull);
-
-            Assert.IsFalse(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-            Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.HEADER));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_MinIsBlack);
-            dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_Unordered);
-
-            Assert.IsFalse(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
-            dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
-            Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-
-            dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-            dib2 = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib2.IsNull);
-
-            Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
-            Assert.IsFalse(dib.IsNull);
-            dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
-            Assert.IsFalse(dib2.IsNull);
-
-            Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-
-            dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
-            Assert.IsFalse(dib.IsNull);
-            dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
-            Assert.IsFalse(dib2.IsNull);
-
-            Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
-
-            FreeImage.UnloadEx(ref dib);
-            FreeImage.UnloadEx(ref dib2);
-        }
-
-        [Test]
-        public void FreeImage_CreateICCProfileEx()
-        {
-            FIICCPROFILE prof;
-            byte[] data = new byte[173];
-            Random rand = new Random(DateTime.Now.Millisecond);
-            dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            prof = FreeImage.GetICCProfileEx(dib);
-            Assert.That(prof.DataPointer == IntPtr.Zero);
-
-            rand.NextBytes(data);
-            prof = FreeImage.CreateICCProfileEx(dib, data);
-            Assert.That(prof.Size == data.Length);
-            for (int i = 0; i < data.Length; i++)
-                if (prof.Data[i] != data[i])
-                    Assert.Fail();
-
-            FreeImage.DestroyICCProfile(dib);
-            prof = FreeImage.GetICCProfileEx(dib);
-            Assert.That(prof.DataPointer == IntPtr.Zero);
-
-            FreeImage.CreateICCProfileEx(dib, new byte[0], 0);
-            prof = FreeImage.GetICCProfileEx(dib);
-            Assert.That(prof.DataPointer == IntPtr.Zero);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_ConvertColorDepth()
-        {
-            int bpp = 1;
-            FIBITMAP dib2;
-
-            dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 80, 80, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            do
-            {
-                dib2 = FreeImage.ConvertColorDepth(dib, (FREE_IMAGE_COLOR_DEPTH)bpp);
-                Assert.IsFalse(dib2.IsNull);
-                Assert.AreEqual(bpp, FreeImage.GetBPP(dib2));
-                if (dib != dib2)
-                    FreeImage.UnloadEx(ref dib2);
-            } while (0 != (bpp = FreeImage.GetNextColorDepth(bpp)));
-
-            FreeImage.UnloadEx(ref dib);
-
-            dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 80, 80, 32,
-                FreeImage.FI_RGBA_RED_MASK, FreeImage.FI_RGBA_GREEN_MASK, FreeImage.FI_RGBA_BLUE_MASK);
-            Assert.IsFalse(dib.IsNull);
-            bpp = 32;
-
-            do
-            {
-                dib2 = FreeImage.ConvertColorDepth(dib, (FREE_IMAGE_COLOR_DEPTH)bpp);
-                Assert.IsFalse(dib2.IsNull);
-                Assert.AreEqual(bpp, FreeImage.GetBPP(dib2));
-                if (dib != dib2)
-                    FreeImage.UnloadEx(ref dib2);
-            } while (0 != (bpp = FreeImage.GetPrevousColorDepth(bpp)));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetNextColorDepth()
-        {
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(5));
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(0));
-            Assert.AreEqual(4, FreeImage.GetNextColorDepth(1));
-            Assert.AreEqual(8, FreeImage.GetNextColorDepth(4));
-            Assert.AreEqual(16, FreeImage.GetNextColorDepth(8));
-            Assert.AreEqual(24, FreeImage.GetNextColorDepth(16));
-            Assert.AreEqual(32, FreeImage.GetNextColorDepth(24));
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(32));
-        }
-
-        [Test]
-        public void FreeImage_GetPrevousColorDepth()
-        {
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(5));
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(0));
-            Assert.AreEqual(4, FreeImage.GetNextColorDepth(1));
-            Assert.AreEqual(8, FreeImage.GetNextColorDepth(4));
-            Assert.AreEqual(16, FreeImage.GetNextColorDepth(8));
-            Assert.AreEqual(24, FreeImage.GetNextColorDepth(16));
-            Assert.AreEqual(32, FreeImage.GetNextColorDepth(24));
-            Assert.AreEqual(0, FreeImage.GetNextColorDepth(32));
-        }
-
-        [Test]
-        public unsafe void FreeImage_PtrToStr()
-        {
-            string testString;
-            string resString;
-            IntPtr buffer;
-            int index;
-
-            testString = "Test string";
-            buffer = Marshal.AllocHGlobal(testString.Length + 1);
-
-            for (index = 0; index < testString.Length; index++)
-            {
-                Marshal.WriteByte(buffer, index, (byte)testString[index]);
-            }
-            Marshal.WriteByte(buffer, index, (byte)0);
-
-            resString = FreeImage.PtrToStr((byte*)buffer);
-            Assert.That(resString == testString);
-
-            Marshal.FreeHGlobal(buffer);
-
-            testString = @"äöü?=§%/!)§(%&)(§";
-            buffer = Marshal.AllocHGlobal(testString.Length + 1);
-
-            for (index = 0; index < testString.Length; index++)
-            {
-                Marshal.WriteByte(buffer, index, (byte)testString[index]);
-            }
-            Marshal.WriteByte(buffer, index, (byte)0);
-
-            resString = FreeImage.PtrToStr((byte*)buffer);
-            Assert.That(resString == testString);
-
-            Marshal.FreeHGlobal(buffer);
-        }
-
-        [Test]
-        public void FreeImage_CopyMetadata()
-        {
-            dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-            int mdCount = 0;
-
-            FIBITMAP dib2 = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib2.IsNull);
-
-            FREE_IMAGE_MDMODEL[] modelList = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
-            FITAG tag, tag2;
-            FIMETADATA mdHandle;
-
-            foreach (FREE_IMAGE_MDMODEL model in modelList)
-            {
-                mdHandle = FreeImage.FindFirstMetadata(model, dib2, out tag);
-                Assert.IsTrue(mdHandle.IsNull);
-                mdCount += (int)FreeImage.GetMetadataCount(model, dib);
-            }
-
-            Assert.AreEqual(mdCount, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING));
-
-            foreach (FREE_IMAGE_MDMODEL model in modelList)
-            {
-                mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
-                if (!mdHandle.IsNull)
-                {
-                    do
-                    {
-                        Assert.IsTrue(FreeImage.GetMetadata(model, dib2, FreeImage.GetTagKey(tag), out tag2));
-                        Assert.That(FreeImage.GetTagCount(tag) == FreeImage.GetTagCount(tag2));
-                        Assert.That(FreeImage.GetTagDescription(tag) == FreeImage.GetTagDescription(tag2));
-                        Assert.That(FreeImage.GetTagID(tag) == FreeImage.GetTagID(tag2));
-                        Assert.That(FreeImage.GetTagKey(tag) == FreeImage.GetTagKey(tag2));
-                        Assert.That(FreeImage.GetTagLength(tag) == FreeImage.GetTagLength(tag2));
-                        Assert.That(FreeImage.GetTagType(tag) == FreeImage.GetTagType(tag2));
-                    }
-                    while (FreeImage.FindNextMetadata(mdHandle, out tag));
-                    FreeImage.FindCloseMetadata(mdHandle);
-                }
-            }
-
-            Assert.AreEqual(0, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.KEEP_EXISITNG));
-
-            foreach (FREE_IMAGE_MDMODEL model in modelList)
-            {
-                mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
-                if (!mdHandle.IsNull)
-                {
-                    do
-                    {
-                        Assert.IsTrue(FreeImage.GetMetadata(model, dib2, FreeImage.GetTagKey(tag), out tag2));
-                        Assert.AreEqual(FreeImage.GetTagCount(tag), FreeImage.GetTagCount(tag2));
-                        Assert.AreEqual(FreeImage.GetTagDescription(tag), FreeImage.GetTagDescription(tag2));
-                        Assert.AreEqual(FreeImage.GetTagID(tag), FreeImage.GetTagID(tag2));
-                        Assert.AreEqual(FreeImage.GetTagKey(tag), FreeImage.GetTagKey(tag2));
-                        Assert.AreEqual(FreeImage.GetTagLength(tag), FreeImage.GetTagLength(tag2));
-                        Assert.AreEqual(FreeImage.GetTagType(tag), FreeImage.GetTagType(tag2));
-                    }
-                    while (FreeImage.FindNextMetadata(mdHandle, out tag));
-                    FreeImage.FindCloseMetadata(mdHandle);
-                }
-            }
-
-            const string newTagDescription = "NEW_TAG_DESCRIPTION";
-
-            Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "Copyright", out tag));
-            Assert.IsTrue(FreeImage.SetTagDescription(tag, newTagDescription));
-            Assert.AreEqual(mdCount, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.REPLACE_EXISTING));
-            Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib2, "Copyright", out tag2));
-            Assert.AreEqual(newTagDescription, FreeImage.GetTagDescription(tag2));
-
-            FreeImage.UnloadEx(ref dib2);
-            FreeImage.UnloadEx(ref dib);
-
-            dib2 = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-
-            Assert.AreEqual(0, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING));
-
-            FreeImage.UnloadEx(ref dib2);
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetImageComment()
-        {
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-            const string comment = "C O M M E N T";
-
-            Assert.IsNull(FreeImage.GetImageComment(dib));
-            Assert.IsTrue(FreeImage.SetImageComment(dib, comment));
-            Assert.AreEqual(comment, FreeImage.GetImageComment(dib));
-            Assert.IsTrue(FreeImage.SetImageComment(dib, null));
-            Assert.IsNull(FreeImage.GetImageComment(dib));
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_SetImageComment()
-        {
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-            const string comment = "C O M M E N T";
-
-            Assert.IsNull(FreeImage.GetImageComment(dib));
-            Assert.IsTrue(FreeImage.SetImageComment(dib, comment));
-            Assert.AreEqual(comment, FreeImage.GetImageComment(dib));
-            Assert.IsTrue(FreeImage.SetImageComment(dib, null));
-            Assert.IsNull(FreeImage.GetImageComment(dib));
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetMetadata()
-        {
-            MetadataTag tag;
-
-            dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.IsFalse(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "~~~~~", out tag));
-            Assert.IsNull(tag);
-
-            Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "Artist", out tag));
-            Assert.IsFalse(tag.tag.IsNull);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_SetMetadata()
-        {
-            MetadataTag tag;
-            Random rand = new Random();
-
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            ushort value = (ushort)rand.Next();
-
-            tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_CUSTOM);
-            tag.ID = value;
-
-            Assert.IsTrue(FreeImage.SetMetadata(FREE_IMAGE_MDMODEL.FIMD_CUSTOM, dib, "~~~~~", tag));
-            Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_CUSTOM, dib, "~~~~~", out tag));
-            Assert.AreEqual(value, tag.ID);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_FindFirstMetadata()
-        {
-            MetadataTag tag;
-            FIMETADATA mdHandle;
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            FREE_IMAGE_MDMODEL[] models = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
-            foreach (FREE_IMAGE_MDMODEL model in models)
-            {
-                mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
-                Assert.IsTrue(mdHandle.IsNull);
-            }
-
-            tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-            tag.Key = "KEY";
-            tag.Value = 12345;
-            tag.AddToImage(dib);
-
-            mdHandle = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, out tag);
-            Assert.IsFalse(mdHandle.IsNull);
-
-            FreeImage.FindCloseMetadata(mdHandle);
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_FindNextMetadata()
-        {
-            MetadataTag tag;
-            FIMETADATA mdHandle;
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            FREE_IMAGE_MDMODEL[] models = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
-            foreach (FREE_IMAGE_MDMODEL model in models)
-            {
-                mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
-                Assert.IsTrue(mdHandle.IsNull);
-            }
-
-            tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-            tag.Key = "KEY1";
-            tag.Value = 12345;
-            tag.AddToImage(dib);
-
-            tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-            tag.Key = "KEY2";
-            tag.Value = 54321;
-            tag.AddToImage(dib);
-
-            mdHandle = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, out tag);
-            Assert.IsFalse(mdHandle.IsNull);
-
-            Assert.IsTrue(FreeImage.FindNextMetadata(mdHandle, out tag));
-            Assert.IsFalse(FreeImage.FindNextMetadata(mdHandle, out tag));
-
-            FreeImage.FindCloseMetadata(mdHandle);
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_SetGetTransparencyTableEx()
-        {
-            dib = FreeImage.Allocate(10, 10, 6, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            byte[] transTable = FreeImage.GetTransparencyTableEx(dib);
-            Assert.That(transTable.Length == 0);
-
-            Random rand = new Random();
-            transTable = new byte[rand.Next(0, 255)];
-            int length = transTable.Length;
-
-            for (int i = 0; i < transTable.Length; i++)
-                transTable[i] = (byte)i;
-
-            FreeImage.SetTransparencyTable(dib, transTable);
-            transTable = null;
-            transTable = FreeImage.GetTransparencyTableEx(dib);
-            Assert.That(transTable.Length == length);
-            for (int i = 0; i < transTable.Length; i++)
-                Assert.That(transTable[i] == i);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_GetUniqueColors()
-        {
-            Palette palette;
-
-            //
-            // 1bpp
-            //
-
-            dib = FreeImage.Allocate(10, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            palette = new Palette(dib);
-            palette[0] = Color.FromArgb(43, 255, 255, 255);
-            palette[1] = Color.FromArgb(222, 0, 0, 0);
-
-            Scanline<FI1BIT> sl1bit = new Scanline<FI1BIT>(dib, 0);
-            for (int x = 0; x < sl1bit.Length; x++)
-            {
-                sl1bit[x] = 0;
-            }
-
-            Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
-
-            sl1bit[5] = 1;
-            Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
-
-            palette[1] = Color.FromArgb(222, 255, 255, 255);
-            Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
-
-            sl1bit[5] = 0;
-            Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
-
-            FreeImage.UnloadEx(ref dib);
-
-            //
-            // 4bpp
-            //
-
-            dib = FreeImage.Allocate(10, 1, 4, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            palette = new Palette(dib);
-            palette[0] = new RGBQUAD(Color.FromArgb(43, 255, 255, 255));
-            palette[1] = new RGBQUAD(Color.FromArgb(222, 51, 2, 211));
-            palette[2] = new RGBQUAD(Color.FromArgb(29, 25, 31, 52));
-            palette[3] = new RGBQUAD(Color.FromArgb(173, 142, 61, 178));
-            palette[4] = new RGBQUAD(Color.FromArgb(143, 41, 67, 199));
-            palette[5] = new RGBQUAD(Color.FromArgb(2, 0, 2, 221));
-
-            Scanline<FI4BIT> sl4bit = new Scanline<FI4BIT>(dib, 0);
-
-            for (int x = 0; x < sl4bit.Length; x++)
-            {
-                sl4bit[x] = 0;
-            }
-
-            Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[1] = 1;
-            Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[2] = 1;
-            Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[3] = 2;
-            Assert.AreEqual(3, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[4] = 3;
-            Assert.AreEqual(4, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[5] = 4;
-            Assert.AreEqual(5, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[6] = 5;
-            Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[7] = 6;
-            Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[8] = 7;
-            Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
-
-            sl4bit[9] = 7;
-            Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
-
-            FreeImage.UnloadEx(ref dib);
-
-            //
-            // 8bpp
-            //
-
-            dib = FreeImage.Allocate(10, 1, 8, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            palette = new Palette(dib);
-            palette[0] = new RGBQUAD(Color.FromArgb(43, 255, 255, 255));
-            palette[1] = new RGBQUAD(Color.FromArgb(222, 51, 2, 211));
-            palette[2] = new RGBQUAD(Color.FromArgb(29, 25, 31, 52));
-            palette[3] = new RGBQUAD(Color.FromArgb(173, 142, 61, 178));
-            palette[4] = new RGBQUAD(Color.FromArgb(143, 41, 67, 199));
-            palette[5] = new RGBQUAD(Color.FromArgb(2, 0, 2, 221));
-
-            Scanline<byte> sl8bit = new Scanline<byte>(dib, 0);
-
-            for (int x = 0; x < sl8bit.Length; x++)
-            {
-                sl8bit[x] = 0;
-            }
-
-            Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[1] = 1;
-            Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[2] = 2;
-            Assert.AreEqual(3, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[3] = 3;
-            Assert.AreEqual(4, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[4] = 4;
-            Assert.AreEqual(5, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[5] = 6;
-            Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[5] = 7;
-            Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
-
-            sl8bit[5] = 8;
-            Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_CreateShrunkenPaletteLUT()
-        {
-            Random rand = new Random();
-            dib = FreeImage.Allocate(1, 1, 8, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            Palette palette = new Palette(dib);
-            byte[] lut;
-            int colors;
-
-            for (int x = 0; x < palette.Length; x++)
-            {
-                palette[x] = 0xFF000000;
-            }
-
-            lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
-            Assert.AreEqual(1, colors);
-
-            for (int x = 0; x < palette.Length; x++)
-            {
-                Assert.AreEqual(0, lut[x]);
-            }
-
-            palette[1] = 0x00000001;
-            lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
-            Assert.AreEqual(2, colors);
-
-            Assert.AreEqual(0, lut[0]);
-            Assert.AreEqual(1, lut[1]);
-
-            for (int x = 2; x < palette.Length; x++)
-            {
-                Assert.AreEqual(0, lut[x]);
-            }
-
-            for (int x = 0; x < palette.Length; x++)
-            {
-                palette[x] = (uint)x;
-            }
-
-            lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
-            Assert.AreEqual(256, colors);
-
-            for (int x = 0; x < palette.Length; x++)
-            {
-                Assert.AreEqual(x, lut[x]);
-            }
-
-            uint[] testColors = new uint[] { 0xFF4F387C, 0xFF749178, 0xFF84D51A, 0xFF746B71, 0x74718163, 0x91648106 };
-            palette[0] = testColors[0];
-            palette[1] = testColors[1];
-            palette[2] = testColors[2];
-            palette[3] = testColors[3];
-            palette[4] = testColors[4];
-            palette[5] = testColors[5];
-
-            for (int x = testColors.Length; x < palette.Length; x++)
-            {
-                palette[x] = testColors[rand.Next(0, testColors.Length - 1)];
-            }
-
-            lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
-            Assert.AreEqual(testColors.Length, colors);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void FreeImage_Rotate4bit()
-        {
-            Palette orgPal, rotPal;
-            FIBITMAP rotated;
-            byte index;
-            dib = FreeImage.Allocate(2, 3, 4, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            index = 1; if (!FreeImage.SetPixelIndex(dib, 0, 0, ref index)) throw new Exception();
-            index = 2; if (!FreeImage.SetPixelIndex(dib, 1, 0, ref index)) throw new Exception();
-            index = 3; if (!FreeImage.SetPixelIndex(dib, 0, 1, ref index)) throw new Exception();
-            index = 4; if (!FreeImage.SetPixelIndex(dib, 1, 1, ref index)) throw new Exception();
-            index = 5; if (!FreeImage.SetPixelIndex(dib, 0, 2, ref index)) throw new Exception();
-            index = 6; if (!FreeImage.SetPixelIndex(dib, 1, 2, ref index)) throw new Exception();
-
-            //
-            // 90 deg
-            //
-
-            rotated = FreeImage.Rotate4bit(dib, 90d);
-            Assert.IsFalse(rotated.IsNull);
-            Assert.AreEqual(3, FreeImage.GetWidth(rotated));
-            Assert.AreEqual(2, FreeImage.GetHeight(rotated));
-            Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
-            Assert.AreEqual(4, FreeImage.GetBPP(rotated));
-            orgPal = new Palette(dib);
-            rotPal = new Palette(rotated);
-            Assert.IsNotNull(orgPal);
-            Assert.IsNotNull(rotPal);
-            Assert.AreEqual(orgPal.Length, rotPal.Length);
-            for (int i = 0; i < orgPal.Length; i++)
-            {
-                Assert.AreEqual(orgPal[i], rotPal[i]);
-            }
-
-            FreeImage.GetPixelIndex(rotated, 0, 0, out index);
-            Assert.AreEqual(5, index);
-            FreeImage.GetPixelIndex(rotated, 1, 0, out index);
-            Assert.AreEqual(3, index);
-            FreeImage.GetPixelIndex(rotated, 2, 0, out index);
-            Assert.AreEqual(1, index);
-            FreeImage.GetPixelIndex(rotated, 0, 1, out index);
-            Assert.AreEqual(6, index);
-            FreeImage.GetPixelIndex(rotated, 1, 1, out index);
-            Assert.AreEqual(4, index);
-            FreeImage.GetPixelIndex(rotated, 2, 1, out index);
-            Assert.AreEqual(2, index);
-            FreeImage.UnloadEx(ref rotated);
-
-            //
-            // 180 deg
-            //
-
-            rotated = FreeImage.Rotate4bit(dib, 180d);
-            Assert.IsFalse(rotated.IsNull);
-            Assert.AreEqual(FreeImage.GetWidth(dib), FreeImage.GetWidth(rotated));
-            Assert.AreEqual(FreeImage.GetHeight(dib), FreeImage.GetHeight(rotated));
-            Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
-            Assert.AreEqual(4, FreeImage.GetBPP(rotated));
-            orgPal = new Palette(dib);
-            rotPal = new Palette(rotated);
-            Assert.IsNotNull(orgPal);
-            Assert.IsNotNull(rotPal);
-            Assert.AreEqual(orgPal.Length, rotPal.Length);
-            for (int i = 0; i < orgPal.Length; i++)
-            {
-                Assert.AreEqual(orgPal[i], rotPal[i]);
-            }
-
-            FreeImage.GetPixelIndex(rotated, 0, 0, out index);
-            Assert.AreEqual(6, index);
-            FreeImage.GetPixelIndex(rotated, 1, 0, out index);
-            Assert.AreEqual(5, index);
-            FreeImage.GetPixelIndex(rotated, 0, 1, out index);
-            Assert.AreEqual(4, index);
-            FreeImage.GetPixelIndex(rotated, 1, 1, out index);
-            Assert.AreEqual(3, index);
-            FreeImage.GetPixelIndex(rotated, 0, 2, out index);
-            Assert.AreEqual(2, index);
-            FreeImage.GetPixelIndex(rotated, 1, 2, out index);
-            Assert.AreEqual(1, index);
-            FreeImage.UnloadEx(ref rotated);
-
-            //
-            // 270 deg
-            //
-
-            rotated = FreeImage.Rotate4bit(dib, 270d);
-            Assert.IsFalse(rotated.IsNull);
-            Assert.AreEqual(3, FreeImage.GetWidth(rotated));
-            Assert.AreEqual(2, FreeImage.GetHeight(rotated));
-            Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
-            Assert.AreEqual(4, FreeImage.GetBPP(rotated));
-            orgPal = new Palette(dib);
-            rotPal = new Palette(rotated);
-            Assert.IsNotNull(orgPal);
-            Assert.IsNotNull(rotPal);
-            Assert.AreEqual(orgPal.Length, rotPal.Length);
-            for (int i = 0; i < orgPal.Length; i++)
-            {
-                Assert.AreEqual(orgPal[i], rotPal[i]);
-            }
-
-            FreeImage.GetPixelIndex(rotated, 0, 0, out index);
-            Assert.AreEqual(2, index);
-            FreeImage.GetPixelIndex(rotated, 1, 0, out index);
-            Assert.AreEqual(4, index);
-            FreeImage.GetPixelIndex(rotated, 2, 0, out index);
-            Assert.AreEqual(6, index);
-            FreeImage.GetPixelIndex(rotated, 0, 1, out index);
-            Assert.AreEqual(1, index);
-            FreeImage.GetPixelIndex(rotated, 1, 1, out index);
-            Assert.AreEqual(3, index);
-            FreeImage.GetPixelIndex(rotated, 2, 1, out index);
-            Assert.AreEqual(5, index);
-            FreeImage.UnloadEx(ref rotated);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-    }
+		[Test]
+		public void FreeImage_GetResolutionX()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(72, FreeImage.GetResolutionX(dib));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetResolutionY()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(72, FreeImage.GetResolutionY(dib));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_SetResolutionX()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(72, FreeImage.GetResolutionX(dib));
+
+			FreeImage.SetResolutionX(dib, 12u);
+			Assert.AreEqual(12, FreeImage.GetResolutionX(dib));
+
+			FreeImage.SetResolutionX(dib, 1u);
+			Assert.AreEqual(1, FreeImage.GetResolutionX(dib));
+
+			FreeImage.SetResolutionX(dib, 66u);
+			Assert.AreEqual(66, FreeImage.GetResolutionX(dib));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_SetResolutionY()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(72, FreeImage.GetResolutionY(dib));
+
+			FreeImage.SetResolutionY(dib, 12u);
+			Assert.AreEqual(12, FreeImage.GetResolutionY(dib));
+
+			FreeImage.SetResolutionY(dib, 1u);
+			Assert.AreEqual(1, FreeImage.GetResolutionY(dib));
+
+			FreeImage.SetResolutionY(dib, 66u);
+			Assert.AreEqual(66, FreeImage.GetResolutionY(dib));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_IsGreyscaleImage()
+		{
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
+			Assert.IsFalse(FreeImage.IsGreyscaleImage(dib));
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_Unordered);
+			Assert.IsTrue(FreeImage.IsGreyscaleImage(dib));
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_MinIsBlack);
+			Assert.IsTrue(FreeImage.IsGreyscaleImage(dib));
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetPaletteEx()
+		{
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
+			Palette palette = null;
+
+			try
+			{
+				palette = FreeImage.GetPaletteEx(dib);
+				Assert.Fail();
+			}
+			catch
+			{
+			}
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_08_Greyscale_MinIsBlack);
+			try
+			{
+				palette = FreeImage.GetPaletteEx(dib);
+			}
+			catch
+			{
+				Assert.Fail();
+			}
+			Assert.AreEqual(256, palette.Length);
+			for (int index = 0; index < 256; index++)
+			{
+				Assert.AreEqual(index, palette[index].rgbRed);
+				Assert.AreEqual(index, palette[index].rgbGreen);
+				Assert.AreEqual(index, palette[index].rgbBlue);
+			}
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetInfoHeaderEx()
+		{
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04);
+			Assert.IsFalse(dib.IsNull);
+
+			BITMAPINFOHEADER iHeader = FreeImage.GetInfoHeaderEx(dib);
+			Assert.AreEqual(4, iHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+
+			iHeader = FreeImage.GetInfoHeaderEx(dib);
+			Assert.AreEqual(1, iHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
+			Assert.IsFalse(dib.IsNull);
+
+			iHeader = FreeImage.GetInfoHeaderEx(dib);
+			Assert.AreEqual(24, iHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), iHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), iHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetInfoEx()
+		{
+			BITMAPINFO info;
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_04_Greyscale_MinIsBlack);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_08_Greyscale_Unordered);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_24);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
+			Assert.That(!dib.IsNull);
+			info = FreeImage.GetInfoEx(dib);
+			Assert.AreEqual(FreeImage.GetBPP(dib), info.bmiHeader.biBitCount);
+			Assert.AreEqual(FreeImage.GetWidth(dib), info.bmiHeader.biWidth);
+			Assert.AreEqual(FreeImage.GetHeight(dib), info.bmiHeader.biHeight);
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetPixelFormat()
+		{
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_01_Threshold);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(PixelFormat.Format1bppIndexed, FreeImage.GetPixelFormat(dib));
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_04_Greyscale_Unordered);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(PixelFormat.Format4bppIndexed, FreeImage.GetPixelFormat(dib));
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_555);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(PixelFormat.Format16bppRgb555, FreeImage.GetPixelFormat(dib));
+			FreeImage.UnloadEx(ref dib);
+
+			dib = iManager.GetBitmap(ImageType.Odd, ImageColorType.Type_16_565);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.AreEqual(PixelFormat.Format16bppRgb565, FreeImage.GetPixelFormat(dib));
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetFormatParameters()
+		{
+			uint bpp, red, green, blue;
+			FREE_IMAGE_TYPE type;
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppArgb1555, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(16, bpp);
+			Assert.AreEqual(red, FreeImage.FI16_555_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI16_555_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI16_555_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppGrayScale, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(16, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_UINT16);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppRgb555, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(16, bpp);
+			Assert.AreEqual(red, FreeImage.FI16_555_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI16_555_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI16_555_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format16bppRgb565, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(16, bpp);
+			Assert.AreEqual(red, FreeImage.FI16_565_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI16_565_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI16_565_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format1bppIndexed, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(1, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format24bppRgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(24, bpp);
+			Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppArgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(32, bpp);
+			Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppPArgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(32, bpp);
+			Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format32bppRgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(32, bpp);
+			Assert.AreEqual(red, FreeImage.FI_RGBA_RED_MASK);
+			Assert.AreEqual(green, FreeImage.FI_RGBA_GREEN_MASK);
+			Assert.AreEqual(blue, FreeImage.FI_RGBA_BLUE_MASK);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format48bppRgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(48, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGB16);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format4bppIndexed, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(4, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format64bppArgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(64, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGBA16);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format64bppPArgb, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(64, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_RGBA16);
+
+			Assert.IsTrue(FreeImage.GetFormatParameters(PixelFormat.Format8bppIndexed, out type, out bpp, out red, out green, out blue));
+			Assert.AreEqual(8, bpp);
+			Assert.AreEqual(red, 0);
+			Assert.AreEqual(green, 0);
+			Assert.AreEqual(blue, 0);
+			Assert.AreEqual(type, FREE_IMAGE_TYPE.FIT_BITMAP);
+		}
+
+		[Test]
+		public void FreeImage_Compare()
+		{
+			FIBITMAP dib2;
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+			dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_01_Threshold);
+			Assert.IsFalse(dib2.IsNull);
+
+			Assert.IsFalse(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+			Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.HEADER));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_MinIsBlack);
+			dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_04_Greyscale_Unordered);
+
+			Assert.IsFalse(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
+			dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_32);
+			Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+
+			dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+			dib2 = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib2.IsNull);
+
+			Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
+			Assert.IsFalse(dib.IsNull);
+			dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_555);
+			Assert.IsFalse(dib2.IsNull);
+
+			Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+
+			dib = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
+			Assert.IsFalse(dib.IsNull);
+			dib2 = iManager.GetBitmap(ImageType.Even, ImageColorType.Type_16_565);
+			Assert.IsFalse(dib2.IsNull);
+
+			Assert.IsTrue(FreeImage.Compare(dib, dib2, FREE_IMAGE_COMPARE_FLAGS.COMPLETE));
+
+			FreeImage.UnloadEx(ref dib);
+			FreeImage.UnloadEx(ref dib2);
+		}
+
+		[Test]
+		public void FreeImage_CreateICCProfileEx()
+		{
+			FIICCPROFILE prof;
+			byte[] data = new byte[173];
+			Random rand = new Random(DateTime.Now.Millisecond);
+			dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			prof = FreeImage.GetICCProfileEx(dib);
+			Assert.That(prof.DataPointer == IntPtr.Zero);
+
+			rand.NextBytes(data);
+			prof = FreeImage.CreateICCProfileEx(dib, data);
+			Assert.That(prof.Size == data.Length);
+			for (int i = 0; i < data.Length; i++)
+				if (prof.Data[i] != data[i])
+					Assert.Fail();
+
+			FreeImage.DestroyICCProfile(dib);
+			prof = FreeImage.GetICCProfileEx(dib);
+			Assert.That(prof.DataPointer == IntPtr.Zero);
+
+			FreeImage.CreateICCProfileEx(dib, new byte[0], 0);
+			prof = FreeImage.GetICCProfileEx(dib);
+			Assert.That(prof.DataPointer == IntPtr.Zero);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_ConvertColorDepth()
+		{
+			int bpp = 1;
+			FIBITMAP dib2;
+
+			dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 80, 80, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			do
+			{
+				dib2 = FreeImage.ConvertColorDepth(dib, (FREE_IMAGE_COLOR_DEPTH)bpp);
+				Assert.IsFalse(dib2.IsNull);
+				Assert.AreEqual(bpp, FreeImage.GetBPP(dib2));
+				if (dib != dib2)
+					FreeImage.UnloadEx(ref dib2);
+			} while (0 != (bpp = FreeImage.GetNextColorDepth(bpp)));
+
+			FreeImage.UnloadEx(ref dib);
+
+			dib = FreeImage.AllocateT(FREE_IMAGE_TYPE.FIT_BITMAP, 80, 80, 32,
+				FreeImage.FI_RGBA_RED_MASK, FreeImage.FI_RGBA_GREEN_MASK, FreeImage.FI_RGBA_BLUE_MASK);
+			Assert.IsFalse(dib.IsNull);
+			bpp = 32;
+
+			do
+			{
+				dib2 = FreeImage.ConvertColorDepth(dib, (FREE_IMAGE_COLOR_DEPTH)bpp);
+				Assert.IsFalse(dib2.IsNull);
+				Assert.AreEqual(bpp, FreeImage.GetBPP(dib2));
+				if (dib != dib2)
+					FreeImage.UnloadEx(ref dib2);
+			} while (0 != (bpp = FreeImage.GetPrevousColorDepth(bpp)));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetNextColorDepth()
+		{
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(5));
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(0));
+			Assert.AreEqual(4, FreeImage.GetNextColorDepth(1));
+			Assert.AreEqual(8, FreeImage.GetNextColorDepth(4));
+			Assert.AreEqual(16, FreeImage.GetNextColorDepth(8));
+			Assert.AreEqual(24, FreeImage.GetNextColorDepth(16));
+			Assert.AreEqual(32, FreeImage.GetNextColorDepth(24));
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(32));
+		}
+
+		[Test]
+		public void FreeImage_GetPrevousColorDepth()
+		{
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(5));
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(0));
+			Assert.AreEqual(4, FreeImage.GetNextColorDepth(1));
+			Assert.AreEqual(8, FreeImage.GetNextColorDepth(4));
+			Assert.AreEqual(16, FreeImage.GetNextColorDepth(8));
+			Assert.AreEqual(24, FreeImage.GetNextColorDepth(16));
+			Assert.AreEqual(32, FreeImage.GetNextColorDepth(24));
+			Assert.AreEqual(0, FreeImage.GetNextColorDepth(32));
+		}
+
+		[Test]
+		public unsafe void FreeImage_PtrToStr()
+		{
+			string testString;
+			string resString;
+			IntPtr buffer;
+			int index;
+
+			testString = "Test string";
+			buffer = Marshal.AllocHGlobal(testString.Length + 1);
+
+			for (index = 0; index < testString.Length; index++)
+			{
+				Marshal.WriteByte(buffer, index, (byte)testString[index]);
+			}
+			Marshal.WriteByte(buffer, index, (byte)0);
+
+			resString = FreeImage.PtrToStr((byte*)buffer);
+			Assert.That(resString == testString);
+
+			Marshal.FreeHGlobal(buffer);
+
+			testString = @"äöü?=§%/!)§(%&)(§";
+			buffer = Marshal.AllocHGlobal(testString.Length + 1);
+
+			for (index = 0; index < testString.Length; index++)
+			{
+				Marshal.WriteByte(buffer, index, (byte)testString[index]);
+			}
+			Marshal.WriteByte(buffer, index, (byte)0);
+
+			resString = FreeImage.PtrToStr((byte*)buffer);
+			Assert.That(resString == testString);
+
+			Marshal.FreeHGlobal(buffer);
+		}
+
+		[Test]
+		public void FreeImage_CopyMetadata()
+		{
+			dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+			int mdCount = 0;
+
+			FIBITMAP dib2 = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib2.IsNull);
+
+			FREE_IMAGE_MDMODEL[] modelList = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
+			FITAG tag, tag2;
+			FIMETADATA mdHandle;
+
+			foreach (FREE_IMAGE_MDMODEL model in modelList)
+			{
+				mdHandle = FreeImage.FindFirstMetadata(model, dib2, out tag);
+				Assert.IsTrue(mdHandle.IsNull);
+				mdCount += (int)FreeImage.GetMetadataCount(model, dib);
+			}
+
+			Assert.AreEqual(mdCount, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING));
+
+			foreach (FREE_IMAGE_MDMODEL model in modelList)
+			{
+				mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
+				if (!mdHandle.IsNull)
+				{
+					do
+					{
+						Assert.IsTrue(FreeImage.GetMetadata(model, dib2, FreeImage.GetTagKey(tag), out tag2));
+						Assert.That(FreeImage.GetTagCount(tag) == FreeImage.GetTagCount(tag2));
+						Assert.That(FreeImage.GetTagDescription(tag) == FreeImage.GetTagDescription(tag2));
+						Assert.That(FreeImage.GetTagID(tag) == FreeImage.GetTagID(tag2));
+						Assert.That(FreeImage.GetTagKey(tag) == FreeImage.GetTagKey(tag2));
+						Assert.That(FreeImage.GetTagLength(tag) == FreeImage.GetTagLength(tag2));
+						Assert.That(FreeImage.GetTagType(tag) == FreeImage.GetTagType(tag2));
+					}
+					while (FreeImage.FindNextMetadata(mdHandle, out tag));
+					FreeImage.FindCloseMetadata(mdHandle);
+				}
+			}
+
+			Assert.AreEqual(0, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.KEEP_EXISITNG));
+
+			foreach (FREE_IMAGE_MDMODEL model in modelList)
+			{
+				mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
+				if (!mdHandle.IsNull)
+				{
+					do
+					{
+						Assert.IsTrue(FreeImage.GetMetadata(model, dib2, FreeImage.GetTagKey(tag), out tag2));
+						Assert.AreEqual(FreeImage.GetTagCount(tag), FreeImage.GetTagCount(tag2));
+						Assert.AreEqual(FreeImage.GetTagDescription(tag), FreeImage.GetTagDescription(tag2));
+						Assert.AreEqual(FreeImage.GetTagID(tag), FreeImage.GetTagID(tag2));
+						Assert.AreEqual(FreeImage.GetTagKey(tag), FreeImage.GetTagKey(tag2));
+						Assert.AreEqual(FreeImage.GetTagLength(tag), FreeImage.GetTagLength(tag2));
+						Assert.AreEqual(FreeImage.GetTagType(tag), FreeImage.GetTagType(tag2));
+					}
+					while (FreeImage.FindNextMetadata(mdHandle, out tag));
+					FreeImage.FindCloseMetadata(mdHandle);
+				}
+			}
+
+			const string newTagDescription = "NEW_TAG_DESCRIPTION";
+
+			Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "Copyright", out tag));
+			Assert.IsTrue(FreeImage.SetTagDescription(tag, newTagDescription));
+			Assert.AreEqual(mdCount, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.REPLACE_EXISTING));
+			Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib2, "Copyright", out tag2));
+			Assert.AreEqual(newTagDescription, FreeImage.GetTagDescription(tag2));
+
+			FreeImage.UnloadEx(ref dib2);
+			FreeImage.UnloadEx(ref dib);
+
+			dib2 = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+
+			Assert.AreEqual(0, FreeImage.CloneMetadataEx(dib, dib2, FREE_IMAGE_METADATA_COPY.CLEAR_EXISTING));
+
+			FreeImage.UnloadEx(ref dib2);
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetImageComment()
+		{
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+			const string comment = "C O M M E N T";
+
+			Assert.IsNull(FreeImage.GetImageComment(dib));
+			Assert.IsTrue(FreeImage.SetImageComment(dib, comment));
+			Assert.AreEqual(comment, FreeImage.GetImageComment(dib));
+			Assert.IsTrue(FreeImage.SetImageComment(dib, null));
+			Assert.IsNull(FreeImage.GetImageComment(dib));
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_SetImageComment()
+		{
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+			const string comment = "C O M M E N T";
+
+			Assert.IsNull(FreeImage.GetImageComment(dib));
+			Assert.IsTrue(FreeImage.SetImageComment(dib, comment));
+			Assert.AreEqual(comment, FreeImage.GetImageComment(dib));
+			Assert.IsTrue(FreeImage.SetImageComment(dib, null));
+			Assert.IsNull(FreeImage.GetImageComment(dib));
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetMetadata()
+		{
+			MetadataTag tag;
+
+			dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.IsFalse(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "~~~~~", out tag));
+			Assert.IsNull(tag);
+
+			Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, "Artist", out tag));
+			Assert.IsFalse(tag.tag.IsNull);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_SetMetadata()
+		{
+			MetadataTag tag;
+			Random rand = new Random();
+
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			ushort value = (ushort)rand.Next();
+
+			tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_CUSTOM);
+			tag.ID = value;
+
+			Assert.IsTrue(FreeImage.SetMetadata(FREE_IMAGE_MDMODEL.FIMD_CUSTOM, dib, "~~~~~", tag));
+			Assert.IsTrue(FreeImage.GetMetadata(FREE_IMAGE_MDMODEL.FIMD_CUSTOM, dib, "~~~~~", out tag));
+			Assert.AreEqual(value, tag.ID);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_FindFirstMetadata()
+		{
+			MetadataTag tag;
+			FIMETADATA mdHandle;
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			FREE_IMAGE_MDMODEL[] models = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
+			foreach (FREE_IMAGE_MDMODEL model in models)
+			{
+				mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
+				Assert.IsTrue(mdHandle.IsNull);
+			}
+
+			tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+			tag.Key = "KEY";
+			tag.Value = 12345;
+			tag.AddToImage(dib);
+
+			mdHandle = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, out tag);
+			Assert.IsFalse(mdHandle.IsNull);
+
+			FreeImage.FindCloseMetadata(mdHandle);
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_FindNextMetadata()
+		{
+			MetadataTag tag;
+			FIMETADATA mdHandle;
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			FREE_IMAGE_MDMODEL[] models = (FREE_IMAGE_MDMODEL[])Enum.GetValues(typeof(FREE_IMAGE_MDMODEL));
+			foreach (FREE_IMAGE_MDMODEL model in models)
+			{
+				mdHandle = FreeImage.FindFirstMetadata(model, dib, out tag);
+				Assert.IsTrue(mdHandle.IsNull);
+			}
+
+			tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+			tag.Key = "KEY1";
+			tag.Value = 12345;
+			tag.AddToImage(dib);
+
+			tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+			tag.Key = "KEY2";
+			tag.Value = 54321;
+			tag.AddToImage(dib);
+
+			mdHandle = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, dib, out tag);
+			Assert.IsFalse(mdHandle.IsNull);
+
+			Assert.IsTrue(FreeImage.FindNextMetadata(mdHandle, out tag));
+			Assert.IsFalse(FreeImage.FindNextMetadata(mdHandle, out tag));
+
+			FreeImage.FindCloseMetadata(mdHandle);
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_SetGetTransparencyTableEx()
+		{
+			dib = FreeImage.Allocate(10, 10, 6, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			byte[] transTable = FreeImage.GetTransparencyTableEx(dib);
+			Assert.That(transTable.Length == 0);
+
+			Random rand = new Random();
+			transTable = new byte[rand.Next(0, 255)];
+			int length = transTable.Length;
+
+			for (int i = 0; i < transTable.Length; i++)
+				transTable[i] = (byte)i;
+
+			FreeImage.SetTransparencyTable(dib, transTable);
+			transTable = null;
+			transTable = FreeImage.GetTransparencyTableEx(dib);
+			Assert.That(transTable.Length == length);
+			for (int i = 0; i < transTable.Length; i++)
+				Assert.That(transTable[i] == i);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_GetUniqueColors()
+		{
+			Palette palette;
+
+			//
+			// 1bpp
+			//
+
+			dib = FreeImage.Allocate(10, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			palette = new Palette(dib);
+			palette[0] = Color.FromArgb(43, 255, 255, 255);
+			palette[1] = Color.FromArgb(222, 0, 0, 0);
+
+			Scanline<FI1BIT> sl1bit = new Scanline<FI1BIT>(dib, 0);
+			for (int x = 0; x < sl1bit.Length; x++)
+			{
+				sl1bit[x] = 0;
+			}
+
+			Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
+
+			sl1bit[5] = 1;
+			Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
+
+			palette[1] = Color.FromArgb(222, 255, 255, 255);
+			Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
+
+			sl1bit[5] = 0;
+			Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
+
+			FreeImage.UnloadEx(ref dib);
+
+			//
+			// 4bpp
+			//
+
+			dib = FreeImage.Allocate(10, 1, 4, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			palette = new Palette(dib);
+			palette[0] = new RGBQUAD(Color.FromArgb(43, 255, 255, 255));
+			palette[1] = new RGBQUAD(Color.FromArgb(222, 51, 2, 211));
+			palette[2] = new RGBQUAD(Color.FromArgb(29, 25, 31, 52));
+			palette[3] = new RGBQUAD(Color.FromArgb(173, 142, 61, 178));
+			palette[4] = new RGBQUAD(Color.FromArgb(143, 41, 67, 199));
+			palette[5] = new RGBQUAD(Color.FromArgb(2, 0, 2, 221));
+
+			Scanline<FI4BIT> sl4bit = new Scanline<FI4BIT>(dib, 0);
+
+			for (int x = 0; x < sl4bit.Length; x++)
+			{
+				sl4bit[x] = 0;
+			}
+
+			Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[1] = 1;
+			Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[2] = 1;
+			Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[3] = 2;
+			Assert.AreEqual(3, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[4] = 3;
+			Assert.AreEqual(4, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[5] = 4;
+			Assert.AreEqual(5, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[6] = 5;
+			Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[7] = 6;
+			Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[8] = 7;
+			Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
+
+			sl4bit[9] = 7;
+			Assert.AreEqual(7, FreeImage.GetUniqueColors(dib));
+
+			FreeImage.UnloadEx(ref dib);
+
+			//
+			// 8bpp
+			//
+
+			dib = FreeImage.Allocate(10, 1, 8, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			palette = new Palette(dib);
+			palette[0] = new RGBQUAD(Color.FromArgb(43, 255, 255, 255));
+			palette[1] = new RGBQUAD(Color.FromArgb(222, 51, 2, 211));
+			palette[2] = new RGBQUAD(Color.FromArgb(29, 25, 31, 52));
+			palette[3] = new RGBQUAD(Color.FromArgb(173, 142, 61, 178));
+			palette[4] = new RGBQUAD(Color.FromArgb(143, 41, 67, 199));
+			palette[5] = new RGBQUAD(Color.FromArgb(2, 0, 2, 221));
+
+			Scanline<byte> sl8bit = new Scanline<byte>(dib, 0);
+
+			for (int x = 0; x < sl8bit.Length; x++)
+			{
+				sl8bit[x] = 0;
+			}
+
+			Assert.AreEqual(1, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[1] = 1;
+			Assert.AreEqual(2, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[2] = 2;
+			Assert.AreEqual(3, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[3] = 3;
+			Assert.AreEqual(4, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[4] = 4;
+			Assert.AreEqual(5, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[5] = 6;
+			Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[5] = 7;
+			Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
+
+			sl8bit[5] = 8;
+			Assert.AreEqual(6, FreeImage.GetUniqueColors(dib));
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_CreateShrunkenPaletteLUT()
+		{
+			Random rand = new Random();
+			dib = FreeImage.Allocate(1, 1, 8, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			Palette palette = new Palette(dib);
+			byte[] lut;
+			int colors;
+
+			for (int x = 0; x < palette.Length; x++)
+			{
+				palette[x] = 0xFF000000;
+			}
+
+			lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
+			Assert.AreEqual(1, colors);
+
+			for (int x = 0; x < palette.Length; x++)
+			{
+				Assert.AreEqual(0, lut[x]);
+			}
+
+			palette[1] = 0x00000001;
+			lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
+			Assert.AreEqual(2, colors);
+
+			Assert.AreEqual(0, lut[0]);
+			Assert.AreEqual(1, lut[1]);
+
+			for (int x = 2; x < palette.Length; x++)
+			{
+				Assert.AreEqual(0, lut[x]);
+			}
+
+			for (int x = 0; x < palette.Length; x++)
+			{
+				palette[x] = (uint)x;
+			}
+
+			lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
+			Assert.AreEqual(256, colors);
+
+			for (int x = 0; x < palette.Length; x++)
+			{
+				Assert.AreEqual(x, lut[x]);
+			}
+
+			uint[] testColors = new uint[] { 0xFF4F387C, 0xFF749178, 0xFF84D51A, 0xFF746B71, 0x74718163, 0x91648106 };
+			palette[0] = testColors[0];
+			palette[1] = testColors[1];
+			palette[2] = testColors[2];
+			palette[3] = testColors[3];
+			palette[4] = testColors[4];
+			palette[5] = testColors[5];
+
+			for (int x = testColors.Length; x < palette.Length; x++)
+			{
+				palette[x] = testColors[rand.Next(0, testColors.Length - 1)];
+			}
+
+			lut = FreeImage.CreateShrunkenPaletteLUT(dib, out colors);
+			Assert.AreEqual(testColors.Length, colors);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void FreeImage_Rotate4bit()
+		{
+			Palette orgPal, rotPal;
+			FIBITMAP rotated;
+			byte index;
+			dib = FreeImage.Allocate(2, 3, 4, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			index = 1;
+			if (!FreeImage.SetPixelIndex(dib, 0, 0, ref index))
+				throw new Exception();
+			index = 2;
+			if (!FreeImage.SetPixelIndex(dib, 1, 0, ref index))
+				throw new Exception();
+			index = 3;
+			if (!FreeImage.SetPixelIndex(dib, 0, 1, ref index))
+				throw new Exception();
+			index = 4;
+			if (!FreeImage.SetPixelIndex(dib, 1, 1, ref index))
+				throw new Exception();
+			index = 5;
+			if (!FreeImage.SetPixelIndex(dib, 0, 2, ref index))
+				throw new Exception();
+			index = 6;
+			if (!FreeImage.SetPixelIndex(dib, 1, 2, ref index))
+				throw new Exception();
+
+			//
+			// 90 deg
+			//
+
+			rotated = FreeImage.Rotate4bit(dib, 90d);
+			Assert.IsFalse(rotated.IsNull);
+			Assert.AreEqual(3, FreeImage.GetWidth(rotated));
+			Assert.AreEqual(2, FreeImage.GetHeight(rotated));
+			Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
+			Assert.AreEqual(4, FreeImage.GetBPP(rotated));
+			orgPal = new Palette(dib);
+			rotPal = new Palette(rotated);
+			Assert.IsNotNull(orgPal);
+			Assert.IsNotNull(rotPal);
+			Assert.AreEqual(orgPal.Length, rotPal.Length);
+			for (int i = 0; i < orgPal.Length; i++)
+			{
+				Assert.AreEqual(orgPal[i], rotPal[i]);
+			}
+
+			FreeImage.GetPixelIndex(rotated, 0, 0, out index);
+			Assert.AreEqual(5, index);
+			FreeImage.GetPixelIndex(rotated, 1, 0, out index);
+			Assert.AreEqual(3, index);
+			FreeImage.GetPixelIndex(rotated, 2, 0, out index);
+			Assert.AreEqual(1, index);
+			FreeImage.GetPixelIndex(rotated, 0, 1, out index);
+			Assert.AreEqual(6, index);
+			FreeImage.GetPixelIndex(rotated, 1, 1, out index);
+			Assert.AreEqual(4, index);
+			FreeImage.GetPixelIndex(rotated, 2, 1, out index);
+			Assert.AreEqual(2, index);
+			FreeImage.UnloadEx(ref rotated);
+
+			//
+			// 180 deg
+			//
+
+			rotated = FreeImage.Rotate4bit(dib, 180d);
+			Assert.IsFalse(rotated.IsNull);
+			Assert.AreEqual(FreeImage.GetWidth(dib), FreeImage.GetWidth(rotated));
+			Assert.AreEqual(FreeImage.GetHeight(dib), FreeImage.GetHeight(rotated));
+			Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
+			Assert.AreEqual(4, FreeImage.GetBPP(rotated));
+			orgPal = new Palette(dib);
+			rotPal = new Palette(rotated);
+			Assert.IsNotNull(orgPal);
+			Assert.IsNotNull(rotPal);
+			Assert.AreEqual(orgPal.Length, rotPal.Length);
+			for (int i = 0; i < orgPal.Length; i++)
+			{
+				Assert.AreEqual(orgPal[i], rotPal[i]);
+			}
+
+			FreeImage.GetPixelIndex(rotated, 0, 0, out index);
+			Assert.AreEqual(6, index);
+			FreeImage.GetPixelIndex(rotated, 1, 0, out index);
+			Assert.AreEqual(5, index);
+			FreeImage.GetPixelIndex(rotated, 0, 1, out index);
+			Assert.AreEqual(4, index);
+			FreeImage.GetPixelIndex(rotated, 1, 1, out index);
+			Assert.AreEqual(3, index);
+			FreeImage.GetPixelIndex(rotated, 0, 2, out index);
+			Assert.AreEqual(2, index);
+			FreeImage.GetPixelIndex(rotated, 1, 2, out index);
+			Assert.AreEqual(1, index);
+			FreeImage.UnloadEx(ref rotated);
+
+			//
+			// 270 deg
+			//
+
+			rotated = FreeImage.Rotate4bit(dib, 270d);
+			Assert.IsFalse(rotated.IsNull);
+			Assert.AreEqual(3, FreeImage.GetWidth(rotated));
+			Assert.AreEqual(2, FreeImage.GetHeight(rotated));
+			Assert.AreEqual(FREE_IMAGE_TYPE.FIT_BITMAP, FreeImage.GetImageType(rotated));
+			Assert.AreEqual(4, FreeImage.GetBPP(rotated));
+			orgPal = new Palette(dib);
+			rotPal = new Palette(rotated);
+			Assert.IsNotNull(orgPal);
+			Assert.IsNotNull(rotPal);
+			Assert.AreEqual(orgPal.Length, rotPal.Length);
+			for (int i = 0; i < orgPal.Length; i++)
+			{
+				Assert.AreEqual(orgPal[i], rotPal[i]);
+			}
+
+			FreeImage.GetPixelIndex(rotated, 0, 0, out index);
+			Assert.AreEqual(2, index);
+			FreeImage.GetPixelIndex(rotated, 1, 0, out index);
+			Assert.AreEqual(4, index);
+			FreeImage.GetPixelIndex(rotated, 2, 0, out index);
+			Assert.AreEqual(6, index);
+			FreeImage.GetPixelIndex(rotated, 0, 1, out index);
+			Assert.AreEqual(1, index);
+			FreeImage.GetPixelIndex(rotated, 1, 1, out index);
+			Assert.AreEqual(3, index);
+			FreeImage.GetPixelIndex(rotated, 2, 1, out index);
+			Assert.AreEqual(5, index);
+			FreeImage.UnloadEx(ref rotated);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+	}
 }

--- a/src/UnitTest/TestFixtures/WrapperStructsTest.cs
+++ b/src/UnitTest/TestFixtures/WrapperStructsTest.cs
@@ -11,1186 +11,1191 @@ using NUnit.Framework;
 
 namespace FreeImageNETUnitTest.TestFixtures
 {
-    [TestFixture]
-    public class WrapperStructsTest
-    {
-        ImageManager iManager = new ImageManager();
-        FIBITMAP dib = new FIBITMAP();
-
-        [SetUp]
-        public void InitEachTime()
-        {
-        }
-
-        [TearDown]
-        public void DeInitEachTime()
-        {
-        }
-
-        public bool EqualColors(Color color1, Color color2)
-        {
-            if (color1.A != color2.A) return false;
-            if (color1.R != color2.R) return false;
-            if (color1.G != color2.G) return false;
-            if (color1.B != color2.B) return false;
-            return true;
-        }
-
-        [Test]
-        public void FIRational()
-        {
-            FIRational rational1 = new FIRational();
-            FIRational rational2 = new FIRational();
-            FIRational rational3 = new FIRational();
-
-            //
-            // Constructors
-            //
-
-            Assert.That(rational1.Numerator == 0);
-            Assert.That(rational1.Denominator == 0);
-
-            rational1 = new FIRational(412, 33);
-            Assert.That(rational1.Numerator == 412);
-            Assert.That(rational1.Denominator == 33);
-
-            rational2 = new FIRational(rational1);
-            Assert.That(rational2.Numerator == 412);
-            Assert.That(rational2.Denominator == 33);
-
-            rational3 = new FIRational(5.75m);
-            Assert.That(rational3.Numerator == 23);
-            Assert.That(rational3.Denominator == 4);
-
-            //
-            // == !=
-            //
-
-            rational1 = new FIRational(421, 51);
-            rational2 = rational1;
-            Assert.That(rational1 == rational2);
-            Assert.That(!(rational1 != rational2));
-
-            rational2 = new FIRational(1, 7);
-            Assert.That(rational1 != rational2);
-            Assert.That(!(rational1 == rational2));
-
-            //
-            // > >= < <=
-            //
-
-            rational1 = new FIRational(51, 4);
-            rational2 = new FIRational(27, 9);
-            Assert.That(rational1 != rational2);
-            Assert.That(rational1 > rational2);
-            Assert.That(rational1 >= rational2);
-
-            rational1 = new FIRational(-412, 4);
-            Assert.That(rational1 != rational2);
-            Assert.That(rational1 < rational2);
-            Assert.That(rational1 <= rational2);
-
-            //
-            // + / -
-            //
-
-            rational1 = new FIRational(41, 3);
-            rational2 = new FIRational(612, 412);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(-7852, 63);
-            rational2 = new FIRational(666111, -7654);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(-513, 88);
-            rational2 = new FIRational(413, 5);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(-513, 88);
-            rational2 = new FIRational(413, 5);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(7531, 23144);
-            rational2 = new FIRational(-412, 78777);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(513, -42123);
-            rational2 = new FIRational(-42, 77);
-            rational3 = rational1 - rational2;
-            Assert.That((rational3 + rational2) == rational1);
-
-            rational1 = new FIRational(44, 11);
-            rational1 = -rational1;
-            Assert.That(rational1.Numerator == -4 && rational1.Denominator == 1);
-
-            //
-            // %
-            //
-
-            rational1 = new FIRational(23, 8);
-            rational2 = new FIRational(77, 777);
-            Assert.That((rational1 % rational2) == 0);
-
-            rational2 = -rational2;
-            Assert.That((rational1 % rational2) == 0);
-
-            rational2 = new FIRational(7, 4);
-            rational3 = new FIRational(9, 8);
-            Assert.That((rational1 % rational2) == rational3);
-
-            rational2 = -rational2;
-            Assert.That((rational1 % rational2) == rational3);
-
-            //
-            // ~
-            //
-
-            rational1 = new FIRational(41, 77);
-            rational1 = ~rational1;
-            Assert.That(rational1.Numerator == 77 && rational1.Denominator == 41);
-
-            //
-            // -
-            //
-
-            rational1 = new FIRational(52, 4);
-            rational1 = -rational1;
-            Assert.That(rational1 < 0);
-
-            //
-            // ++ --
-            //
-
-            rational1 = new FIRational(5, 3);
-            rational1++;
-            rational2 = new FIRational(8, 3);
-            Assert.That(rational1 == rational2);
-
-            rational1 = new FIRational(41, -43);
-            rational1++;
-            Assert.That(rational1 > 0.0f);
-
-            rational1--;
-            Assert.That(rational1 == new FIRational(41, -43));
-
-            rational1 = new FIRational(8134, 312);
-            Assert.That(rational1 != 26);
-
-            //
-            // Direct assigns
-            //
-
-            rational1 = (FIRational)0.75m;
-            Assert.That(rational1.Numerator == 3 && rational1.Denominator == 4);
-            rational1 = (FIRational)0.33;
-            Assert.That(rational1.Numerator == 33 && rational1.Denominator == 100);
-            rational1 = (FIRational)62.975m;
-            Assert.That(((decimal)rational1.Numerator / (decimal)rational1.Denominator) == 62.975m);
-            rational1 = (FIRational)(-73.0975m);
-            Assert.That(((decimal)rational1.Numerator / (decimal)rational1.Denominator) == -73.0975m);
-            rational1 = (FIRational)(7m / 9m);
-            Assert.That(rational1.Numerator == 7 && rational1.Denominator == 9);
-            rational1 = (FIRational)(-15m / 9m);
-            Assert.That(rational1.Numerator == -5 && rational1.Denominator == 3);
-            rational1 = (FIRational)(0.7777m);
-            Assert.That(rational1.Denominator != 9);
-
-            //
-            // Properties
-            //
-
-            rational1 = new FIRational(515, 5);
-            Assert.That(rational1.IsInteger);
-
-            rational1 = new FIRational(876, 77);
-            Assert.That(rational1.Truncate() == (876 / 77));
-
-            //
-            // Special cases
-            //
-
-            rational1 = new FIRational(0, 10000);
-            Assert.That(rational1 == 0m);
-
-            rational1 = new FIRational(10000, 0);
-            Assert.That(rational1 == 0f);
-
-            rational1 = new FIRational(0, 0);
-            Assert.That(rational1 == 0d);
-
-            rational1 = new FIRational(-1, 0);
-            Assert.That(rational1 == 0);
-
-            rational1 = new FIRational(0, -1);
-            Assert.That(rational1 == 0);
-        }
-
-        [Ignore("Ignoring StreamWrapper")]
-        public void StreamWrapper()
-        {
-            string url = @"http://freeimage.sourceforge.net/images/logo.jpg";
-
-            //
-            // Non blocking
-            //
-
-            HttpWebRequest req = (HttpWebRequest)HttpWebRequest.Create(url);
-            Assert.IsNotNull(req);
-
-            req.Timeout = 1000;
-            HttpWebResponse resp;
-            try
-            {
-                resp = (HttpWebResponse)req.GetResponse();
-            }
-            catch
-            {
-                return;
-            }
-            Assert.IsNotNull(resp);
-
-            Stream stream = resp.GetResponseStream();
-            Assert.IsNotNull(stream);
-
-            StreamWrapper wrapper = new StreamWrapper(stream, false);
-            Assert.IsNotNull(wrapper);
-            Assert.IsTrue(wrapper.CanRead && wrapper.CanSeek && !wrapper.CanWrite);
-
-            byte[] buffer = new byte[1024 * 100];
-            int read;
-            int count = 0;
-
-            do
-            {
-                read = wrapper.Read(buffer, count, buffer.Length - count);
-                count += read;
-            } while (read != 0);
-
-            Assert.AreEqual(7972, count);
-            Assert.AreEqual(7972, wrapper.Length);
-
-            wrapper.Position = 0;
-            Assert.AreEqual(0, wrapper.Position);
-
-            byte[] test = new byte[buffer.Length];
-            int countTest = 0;
-
-            do
-            {
-                read = wrapper.Read(test, countTest, test.Length - countTest);
-                countTest += read;
-            } while (read != 0);
-
-            Assert.AreEqual(count, countTest);
-
-            for (int i = 0; i < countTest; i++)
-                if (buffer[i] != test[i])
-                    Assert.Fail();
-
-            resp.Close();
-            wrapper.Dispose();
-            stream.Dispose();
-
-            //
-            // Blocking
-            //
-
-            req = (HttpWebRequest)HttpWebRequest.Create(url);
-            Assert.IsNotNull(req);
-
-            resp = (HttpWebResponse)req.GetResponse();
-            Assert.IsNotNull(resp);
-
-            stream = resp.GetResponseStream();
-            Assert.IsNotNull(stream);
-
-            wrapper = new StreamWrapper(stream, true);
-            Assert.IsNotNull(wrapper);
-            Assert.IsTrue(wrapper.CanRead && wrapper.CanSeek && !wrapper.CanWrite);
-
-            buffer = new byte[1024 * 100];
-            count = 0;
-
-            count = wrapper.Read(buffer, 0, buffer.Length);
-            Assert.AreEqual(7972, count);
-
-            resp.Close();
-            stream.Dispose();
-            wrapper.Dispose();
-
-            //
-            // Position & Read byte
-            //
-
-            buffer = new byte[] { 0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD };
-            stream = new MemoryStream(buffer);
-            wrapper = new StreamWrapper(stream, false);
-
-            Assert.That(0x00 == wrapper.ReadByte());
-            Assert.That(0x01 == wrapper.ReadByte());
-            Assert.That(0x02 == wrapper.ReadByte());
-            Assert.That(0xFF == wrapper.ReadByte());
-            Assert.That(0xFE == wrapper.ReadByte());
-            Assert.That(0xFD == wrapper.ReadByte());
-            Assert.That(-1 == wrapper.ReadByte());
-
-            Assert.That(wrapper.Length == buffer.Length);
-
-            wrapper.Seek(0, SeekOrigin.Begin);
-            Assert.That(0x00 == wrapper.ReadByte());
-            wrapper.Seek(3, SeekOrigin.Begin);
-            Assert.That(0xFF == wrapper.ReadByte());
-            wrapper.Seek(0, SeekOrigin.End);
-            Assert.That(-1 == wrapper.ReadByte());
-            wrapper.Seek(-2, SeekOrigin.End);
-            Assert.That(0xFE == wrapper.ReadByte());
-            wrapper.Seek(0, SeekOrigin.Begin);
-            Assert.That(0x00 == wrapper.ReadByte());
-            wrapper.Seek(2, SeekOrigin.Current);
-            Assert.That(0xFF == wrapper.ReadByte());
-            wrapper.Seek(1, SeekOrigin.Current);
-            Assert.That(0xFD == wrapper.ReadByte());
-            Assert.That(wrapper.Position != 0);
-            wrapper.Reset();
-            Assert.That(wrapper.Position == 0);
-
-            wrapper.Dispose();
-            stream.Position = 0;
-            wrapper = new StreamWrapper(stream, false);
-
-            wrapper.Seek(10, SeekOrigin.Begin);
-            Assert.That(wrapper.Position == buffer.Length);
-
-            wrapper.Dispose();
-            stream.Dispose();
-        }
-
-        [Ignore("Ignoring LocalPlugin")]
-        public void LocalPlugin()
-        {
-        }
-
-        [Test]
-        public void FreeImageStreamIO()
-        {
-            Random rand = new Random();
-            byte[] bBuffer = new byte[256];
-            IntPtr buffer = Marshal.AllocHGlobal(256);
-
-            MemoryStream stream = new MemoryStream();
-            Assert.IsNotNull(stream);
-            using (fi_handle handle = new fi_handle(stream))
-            {
-
-                FreeImageIO io = FreeImageAPI.IO.FreeImageStreamIO.io;
-                Assert.IsNotNull(io.readProc);
-                Assert.IsNotNull(io.writeProc);
-                Assert.IsNotNull(io.seekProc);
-                Assert.IsNotNull(io.tellProc);
-
-                //
-                // Procs
-                //
-
-                rand.NextBytes(bBuffer);
-
-                stream.Write(bBuffer, 0, bBuffer.Length);
-                Assert.That(io.tellProc(handle) == stream.Position);
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
-                Assert.That(io.tellProc(handle) == 0);
-                Assert.That(io.tellProc(handle) == stream.Position);
-
-                // Read one block
-                Assert.That(io.readProc(buffer, (uint)bBuffer.Length, 1, handle) == 1);
-                for (int i = 0; i < bBuffer.Length; i++)
-                    Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
-
-                Assert.That(io.tellProc(handle) == stream.Position);
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
-                Assert.That(io.tellProc(handle) == stream.Position);
-
-                // Read 1 byte block
-                Assert.That(io.readProc(buffer, 1, (uint)bBuffer.Length, handle) == bBuffer.Length);
-                for (int i = 0; i < bBuffer.Length; i++)
-                    Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
-
-                Assert.That(io.tellProc(handle) == stream.Position);
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
-                Assert.That(io.tellProc(handle) == stream.Position);
-
-                rand.NextBytes(bBuffer);
-                for (int i = 0; i < bBuffer.Length; i++)
-                    Marshal.WriteByte(buffer, i, bBuffer[i]);
-
-                // Write one block
-
-                Assert.That(io.writeProc(buffer, (uint)bBuffer.Length, 1, handle) == 1);
-                for (int i = 0; i < bBuffer.Length; i++)
-                    Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
-                Assert.That(io.tellProc(handle) == stream.Position);
-
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
-                Assert.That(io.tellProc(handle) == 0);
-
-                // write 1 byte block
-
-                Assert.That(io.writeProc(buffer, 1, (uint)bBuffer.Length, handle) == bBuffer.Length);
-                for (int i = 0; i < bBuffer.Length; i++)
-                    Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
-                Assert.That(io.tellProc(handle) == stream.Position);
-
-                // Seek and tell
-
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
-                Assert.That(io.tellProc(handle) == 0);
-
-                Assert.That(io.seekProc(handle, 127, SeekOrigin.Current) == 0);
-                Assert.That(io.tellProc(handle) == 127);
-
-                Assert.That(io.seekProc(handle, 0, SeekOrigin.End) == 0);
-                Assert.That(io.tellProc(handle) == 256);
-
-                Marshal.FreeHGlobal(buffer);
-                stream.Dispose();
-            }
-        }
-
-        [Test]
-        public void MetadataTag()
-        {
-            FITAG tag;
-            MetadataTag metaTag;
-
-            Random rand = new Random();
-            dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
-            Assert.IsFalse(dib.IsNull);
-
-            Assert.That(FreeImage.GetMetadataCount(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib) > 0);
-
-            FIMETADATA mData = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, out tag);
-            Assert.IsFalse(tag.IsNull);
-            Assert.IsFalse(mData.IsNull);
-
-            //
-            // Constructors
-            //
-
-            metaTag = new MetadataTag(tag, dib);
-            Assert.That(metaTag.Model == FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
-
-            metaTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
-            Assert.That(metaTag.Model == FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
-
-            //
-            // Properties
-            //
-
-            metaTag.ID = ushort.MinValue;
-            Assert.That(metaTag.ID == ushort.MinValue);
-
-            metaTag.ID = ushort.MaxValue;
-            Assert.That(metaTag.ID == ushort.MaxValue);
-
-            metaTag.ID = ushort.MaxValue / 2;
-            Assert.That(metaTag.ID == ushort.MaxValue / 2);
-
-            metaTag.Description = "";
-            Assert.That(metaTag.Description == "");
-
-            metaTag.Description = "A";
-            Assert.That(metaTag.Description == "A");
-
-            metaTag.Description = "ABCDEFG";
-            Assert.That(metaTag.Description == "ABCDEFG");
-
-            metaTag.Key = "";
-            Assert.That(metaTag.Key == "");
-
-            metaTag.Key = "A";
-            Assert.That(metaTag.Key == "A");
-
-            metaTag.Key = "ABCDEFG";
-            Assert.That(metaTag.Key == "ABCDEFG");
-
-            //
-            // SetValue
-            //
-
-            try
-            {
-                metaTag.SetValue(null, FREE_IMAGE_MDTYPE.FIDT_ASCII);
-                Assert.Fail();
-            }
-            catch
-            {
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_ASCII
-            //
-
-            string testString = "";
-
-            Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((string)metaTag.Value).Length == 0);
-
-            testString = "X";
-
-            Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((string)metaTag.Value).Length == testString.Length);
-            Assert.That(((string)metaTag.Value) == testString);
-
-            testString = "TEST-STRING";
-
-            Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((string)metaTag.Value).Length == testString.Length);
-            Assert.That(((string)metaTag.Value) == testString);
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_BYTE
-            //			
-
-            byte testByte;
-            byte[] testByteArray;
-
-            Assert.IsTrue(metaTag.SetValue(byte.MinValue, FREE_IMAGE_MDTYPE.FIDT_BYTE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((byte[])metaTag.Value).Length == 1);
-            Assert.That(((byte[])metaTag.Value)[0] == byte.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(byte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_BYTE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((byte[])metaTag.Value).Length == 1);
-            Assert.That(((byte[])metaTag.Value)[0] == byte.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testByte = (byte)rand.Next(byte.MinValue, byte.MaxValue);
-                testByteArray = new byte[rand.Next(0, 31)];
-
-                for (int j = 0; j < testByteArray.Length; j++)
-                    testByteArray[j] = (byte)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testByte, FREE_IMAGE_MDTYPE.FIDT_BYTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((byte[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 1);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_BYTE);
-                Assert.That(((byte[])metaTag.Value)[0] == testByte);
-
-                Assert.IsTrue(metaTag.SetValue(testByteArray, FREE_IMAGE_MDTYPE.FIDT_BYTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((byte[])metaTag.Value).Length == testByteArray.Length);
-                Assert.That(metaTag.Count == testByteArray.Length);
-                Assert.That(metaTag.Length == testByteArray.Length * 1);
-
-                byte[] value = (byte[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testByteArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_DOUBLE
-            //
-
-            double testDouble;
-            double[] testDoubleArray;
-
-            Assert.IsTrue(metaTag.SetValue(double.MinValue, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((double[])metaTag.Value).Length == 1);
-            Assert.That(((double[])metaTag.Value)[0] == double.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(double.MaxValue, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((double[])metaTag.Value).Length == 1);
-            Assert.That(((double[])metaTag.Value)[0] == double.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testDouble = (double)rand.NextDouble();
-                testDoubleArray = new double[rand.Next(0, 31)];
-
-                for (int j = 0; j < testDoubleArray.Length; j++)
-                    testDoubleArray[j] = rand.NextDouble();
-
-                Assert.IsTrue(metaTag.SetValue(testDouble, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((double[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 8);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_DOUBLE);
-                Assert.That(((double[])metaTag.Value)[0] == testDouble);
-
-                Assert.IsTrue(metaTag.SetValue(testDoubleArray, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((double[])metaTag.Value).Length == testDoubleArray.Length);
-                Assert.That(metaTag.Count == testDoubleArray.Length);
-                Assert.That(metaTag.Length == testDoubleArray.Length * 8);
-
-                double[] value = (double[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testDoubleArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_FLOAT
-            //
-
-            float testfloat;
-            float[] testFloatArray;
-
-            Assert.IsTrue(metaTag.SetValue(float.MinValue, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((float[])metaTag.Value).Length == 1);
-            Assert.That(((float[])metaTag.Value)[0] == float.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(float.MaxValue, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((float[])metaTag.Value).Length == 1);
-            Assert.That(((float[])metaTag.Value)[0] == float.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testfloat = (float)rand.NextDouble();
-                testFloatArray = new float[rand.Next(0, 31)];
-
-                for (int j = 0; j < testFloatArray.Length; j++)
-                    testFloatArray[j] = (float)rand.NextDouble();
-
-                Assert.IsTrue(metaTag.SetValue(testfloat, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((float[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 4);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_FLOAT);
-                Assert.That(((float[])metaTag.Value)[0] == testfloat);
-
-                Assert.IsTrue(metaTag.SetValue(testFloatArray, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((float[])metaTag.Value).Length == testFloatArray.Length);
-                Assert.That(metaTag.Count == testFloatArray.Length);
-                Assert.That(metaTag.Length == testFloatArray.Length * 4);
-
-                float[] value = (float[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testFloatArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_IFD
-            //
-
-            uint testUint;
-            uint[] testUintArray;
-
-            Assert.IsTrue(metaTag.SetValue(uint.MinValue, FREE_IMAGE_MDTYPE.FIDT_IFD));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((uint[])metaTag.Value).Length == 1);
-            Assert.That(((uint[])metaTag.Value)[0] == uint.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(uint.MaxValue, FREE_IMAGE_MDTYPE.FIDT_IFD));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((uint[])metaTag.Value).Length == 1);
-            Assert.That(((uint[])metaTag.Value)[0] == uint.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testUint = (uint)rand.NextDouble();
-                testUintArray = new uint[rand.Next(0, 31)];
-
-                for (int j = 0; j < testUintArray.Length; j++)
-                    testUintArray[j] = (uint)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testUint, FREE_IMAGE_MDTYPE.FIDT_IFD));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((uint[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 4);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_IFD);
-                Assert.That(((uint[])metaTag.Value)[0] == testUint);
-
-                Assert.IsTrue(metaTag.SetValue(testUintArray, FREE_IMAGE_MDTYPE.FIDT_IFD));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((uint[])metaTag.Value).Length == testUintArray.Length);
-                Assert.That(metaTag.Count == testUintArray.Length);
-                Assert.That(metaTag.Length == testUintArray.Length * 4);
-
-                uint[] value = (uint[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testUintArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_LONG
-            //
-
-            Assert.IsTrue(metaTag.SetValue(uint.MinValue, FREE_IMAGE_MDTYPE.FIDT_LONG));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((uint[])metaTag.Value).Length == 1);
-            Assert.That(((uint[])metaTag.Value)[0] == uint.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(uint.MaxValue, FREE_IMAGE_MDTYPE.FIDT_LONG));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((uint[])metaTag.Value).Length == 1);
-            Assert.That(((uint[])metaTag.Value)[0] == uint.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testUint = (uint)rand.NextDouble();
-                testUintArray = new uint[rand.Next(0, 31)];
-
-                for (int j = 0; j < testUintArray.Length; j++)
-                    testUintArray[j] = (uint)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testUint, FREE_IMAGE_MDTYPE.FIDT_LONG));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((uint[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 4);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_LONG);
-                Assert.That(((uint[])metaTag.Value)[0] == testUint);
-
-                Assert.IsTrue(metaTag.SetValue(testUintArray, FREE_IMAGE_MDTYPE.FIDT_LONG));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((uint[])metaTag.Value).Length == testUintArray.Length);
-                Assert.That(metaTag.Count == testUintArray.Length);
-                Assert.That(metaTag.Length == testUintArray.Length * 4);
-
-                uint[] value = (uint[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testUintArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_NOTYPE
-            //
-
-            try
-            {
-                metaTag.SetValue(new object(), FREE_IMAGE_MDTYPE.FIDT_NOTYPE);
-                Assert.Fail();
-            }
-            catch (NotSupportedException)
-            {
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_PALETTE
-            //
-
-            RGBQUAD testRGBQUAD;
-            RGBQUAD[] testRGBQUADArray;
-
-            for (int i = 0; i < 10; i++)
-            {
-                testRGBQUAD = new RGBQUAD(Color.FromArgb(rand.Next()));
-                testRGBQUADArray = new RGBQUAD[rand.Next(0, 31)];
-
-                for (int j = 0; j < testRGBQUADArray.Length; j++)
-                    testRGBQUADArray[j] = new RGBQUAD(Color.FromArgb(rand.Next()));
-
-                Assert.IsTrue(metaTag.SetValue(testRGBQUAD, FREE_IMAGE_MDTYPE.FIDT_PALETTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((RGBQUAD[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 4);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_PALETTE);
-                Assert.That(((RGBQUAD[])metaTag.Value)[0] == testRGBQUAD);
-
-                Assert.IsTrue(metaTag.SetValue(testRGBQUADArray, FREE_IMAGE_MDTYPE.FIDT_PALETTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((RGBQUAD[])metaTag.Value).Length == testRGBQUADArray.Length);
-                Assert.That(metaTag.Count == testRGBQUADArray.Length);
-                Assert.That(metaTag.Length == testRGBQUADArray.Length * 4);
-
-                RGBQUAD[] value = (RGBQUAD[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testRGBQUADArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_RATIONAL
-            //
-
-            FIURational testFIURational;
-            FIURational[] testFIURationalArray;
-
-            for (int i = 0; i < 10; i++)
-            {
-                testFIURational = new FIURational((uint)rand.Next(), (uint)rand.Next());
-                testFIURationalArray = new FIURational[rand.Next(0, 31)];
-
-                for (int j = 0; j < testFIURationalArray.Length; j++)
-                    testFIURationalArray[j] = new FIURational((uint)rand.Next(), (uint)rand.Next());
-
-                Assert.IsTrue(metaTag.SetValue(testFIURational, FREE_IMAGE_MDTYPE.FIDT_RATIONAL));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((FIURational[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 8);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_RATIONAL);
-                Assert.That(((FIURational[])metaTag.Value)[0] == testFIURational);
-
-                Assert.IsTrue(metaTag.SetValue(testFIURationalArray, FREE_IMAGE_MDTYPE.FIDT_RATIONAL));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((FIURational[])metaTag.Value).Length == testFIURationalArray.Length);
-                Assert.That(metaTag.Count == testFIURationalArray.Length);
-                Assert.That(metaTag.Length == testFIURationalArray.Length * 8);
-
-                FIURational[] value = (FIURational[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testFIURationalArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_SBYTE
-            //
-
-            sbyte testSByte;
-            sbyte[] testSByteArray;
-
-            Assert.IsTrue(metaTag.SetValue(sbyte.MinValue, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((sbyte[])metaTag.Value).Length == 1);
-            Assert.That(((sbyte[])metaTag.Value)[0] == sbyte.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(sbyte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((sbyte[])metaTag.Value).Length == 1);
-            Assert.That(((sbyte[])metaTag.Value)[0] == sbyte.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testSByte = (sbyte)rand.Next(sbyte.MinValue, sbyte.MaxValue);
-                testSByteArray = new sbyte[rand.Next(0, 31)];
-
-                for (int j = 0; j < testSByteArray.Length; j++)
-                    testSByteArray[j] = (sbyte)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testSByte, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((sbyte[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 1);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SBYTE);
-                Assert.That(((sbyte[])metaTag.Value)[0] == testSByte);
-
-                Assert.IsTrue(metaTag.SetValue(testSByteArray, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((sbyte[])metaTag.Value).Length == testSByteArray.Length);
-                Assert.That(metaTag.Count == testSByteArray.Length);
-                Assert.That(metaTag.Length == testSByteArray.Length * 1);
-
-                sbyte[] value = (sbyte[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testSByteArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_SHORT
-            //
-
-            ushort testUShort;
-            ushort[] testUShortArray;
-
-            Assert.IsTrue(metaTag.SetValue(ushort.MinValue, FREE_IMAGE_MDTYPE.FIDT_SHORT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((ushort[])metaTag.Value).Length == 1);
-            Assert.That(((ushort[])metaTag.Value)[0] == ushort.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(ushort.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SHORT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((ushort[])metaTag.Value).Length == 1);
-            Assert.That(((ushort[])metaTag.Value)[0] == ushort.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testUShort = (ushort)rand.Next(ushort.MinValue, sbyte.MaxValue);
-                testUShortArray = new ushort[rand.Next(0, 31)];
-
-                for (int j = 0; j < testUShortArray.Length; j++)
-                    testUShortArray[j] = (ushort)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testUShort, FREE_IMAGE_MDTYPE.FIDT_SHORT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((ushort[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 2);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SHORT);
-                Assert.That(((ushort[])metaTag.Value)[0] == testUShort);
-
-                Assert.IsTrue(metaTag.SetValue(testUShortArray, FREE_IMAGE_MDTYPE.FIDT_SHORT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((ushort[])metaTag.Value).Length == testUShortArray.Length);
-                Assert.That(metaTag.Count == testUShortArray.Length);
-                Assert.That(metaTag.Length == testUShortArray.Length * 2);
-
-                ushort[] value = (ushort[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testUShortArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_SLONG
-            //
-
-            int testInt;
-            int[] testIntArray;
-
-            Assert.IsTrue(metaTag.SetValue(int.MinValue, FREE_IMAGE_MDTYPE.FIDT_SLONG));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((int[])metaTag.Value).Length == 1);
-            Assert.That(((int[])metaTag.Value)[0] == int.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(int.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SLONG));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((int[])metaTag.Value).Length == 1);
-            Assert.That(((int[])metaTag.Value)[0] == int.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testInt = (int)rand.NextDouble();
-                testIntArray = new int[rand.Next(0, 31)];
-
-                for (int j = 0; j < testIntArray.Length; j++)
-                    testIntArray[j] = rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testInt, FREE_IMAGE_MDTYPE.FIDT_SLONG));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((int[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 4);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SLONG);
-                Assert.That(((int[])metaTag.Value)[0] == testInt);
-
-                Assert.IsTrue(metaTag.SetValue(testIntArray, FREE_IMAGE_MDTYPE.FIDT_SLONG));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((int[])metaTag.Value).Length == testIntArray.Length);
-                Assert.That(metaTag.Count == testIntArray.Length);
-                Assert.That(metaTag.Length == testIntArray.Length * 4);
-
-                int[] value = (int[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testIntArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_SRATIONAL
-            //
-
-            FIRational testFIRational;
-            FIRational[] testFIRationalArray;
-
-            for (int i = 0; i < 10; i++)
-            {
-                testFIRational = new FIRational(rand.Next(), rand.Next());
-                testFIRationalArray = new FIRational[rand.Next(0, 31)];
-
-                for (int j = 0; j < testFIRationalArray.Length; j++)
-                    testFIRationalArray[j] = new FIRational(rand.Next(), rand.Next());
-
-                Assert.IsTrue(metaTag.SetValue(testFIRational, FREE_IMAGE_MDTYPE.FIDT_SRATIONAL));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((FIRational[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 8);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SRATIONAL);
-                Assert.That(((FIRational[])metaTag.Value)[0] == testFIRational);
-
-                Assert.IsTrue(metaTag.SetValue(testFIRationalArray, FREE_IMAGE_MDTYPE.FIDT_SRATIONAL));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((FIRational[])metaTag.Value).Length == testFIRationalArray.Length);
-                Assert.That(metaTag.Count == testFIRationalArray.Length);
-                Assert.That(metaTag.Length == testFIRationalArray.Length * 8);
-
-                FIRational[] value = (FIRational[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testFIRationalArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_SSHORT
-            //
-
-            short testShort;
-            short[] testShortArray;
-
-            Assert.IsTrue(metaTag.SetValue(short.MinValue, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((short[])metaTag.Value).Length == 1);
-            Assert.That(((short[])metaTag.Value)[0] == short.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(short.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((short[])metaTag.Value).Length == 1);
-            Assert.That(((short[])metaTag.Value)[0] == short.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testShort = (short)rand.Next(short.MinValue, short.MaxValue);
-                testShortArray = new short[rand.Next(0, 31)];
-
-                for (int j = 0; j < testShortArray.Length; j++)
-                    testShortArray[j] = (short)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testShort, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((short[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 2);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SSHORT);
-                Assert.That(((short[])metaTag.Value)[0] == testShort);
-
-                Assert.IsTrue(metaTag.SetValue(testShortArray, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((short[])metaTag.Value).Length == testShortArray.Length);
-                Assert.That(metaTag.Count == testShortArray.Length);
-                Assert.That(metaTag.Length == testShortArray.Length * 2);
-
-                short[] value = (short[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testShortArray[j] == value[j]);
-            }
-
-            //
-            // FREE_IMAGE_MDTYPE.FIDT_UNDEFINED
-            //
-
-            Assert.IsTrue(metaTag.SetValue(byte.MinValue, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((byte[])metaTag.Value).Length == 1);
-            Assert.That(((byte[])metaTag.Value)[0] == byte.MinValue);
-
-            Assert.IsTrue(metaTag.SetValue(byte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
-            Assert.IsNotNull(metaTag.Value);
-            Assert.That(((byte[])metaTag.Value).Length == 1);
-            Assert.That(((byte[])metaTag.Value)[0] == byte.MaxValue);
-
-            for (int i = 0; i < 10; i++)
-            {
-                testByte = (byte)rand.Next(byte.MinValue, byte.MaxValue);
-                testByteArray = new byte[rand.Next(0, 31)];
-
-                for (int j = 0; j < testByteArray.Length; j++)
-                    testByteArray[j] = (byte)rand.Next();
-
-                Assert.IsTrue(metaTag.SetValue(testByte, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((byte[])metaTag.Value).Length == 1);
-                Assert.That(metaTag.Count == 1);
-                Assert.That(metaTag.Length == 1);
-                Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_UNDEFINED);
-                Assert.That(((byte[])metaTag.Value)[0] == testByte);
-
-                Assert.IsTrue(metaTag.SetValue(testByteArray, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
-                Assert.IsNotNull(metaTag.Value);
-                Assert.That(((byte[])metaTag.Value).Length == testByteArray.Length);
-                Assert.That(metaTag.Count == testByteArray.Length);
-                Assert.That(metaTag.Length == testByteArray.Length * 1);
-
-                byte[] value = (byte[])metaTag.Value;
-
-                for (int j = 0; j < value.Length; j++)
-                    Assert.That(testByteArray[j] == value[j]);
-            }
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void MetadataModel()
-        {
-            MetadataTag tag;
-            dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            MetadataModel model = new MDM_GEOTIFF(dib);
-            Assert.AreEqual(0, model.Count);
-            Assert.IsFalse(model.Exists);
-            Assert.IsEmpty(model.List);
-            Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
-            Assert.IsTrue(model.DestoryModel());
-            foreach (MetadataTag m in model) Assert.Fail();
-
-            tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
-            tag.Key = "KEY";
-            tag.Value = 54321f;
-            Assert.IsTrue(model.AddTag(tag));
-
-            Assert.AreEqual(1, model.Count);
-            Assert.IsTrue(model.Exists);
-            Assert.IsNotEmpty(model.List);
-            Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
-
-            Assert.IsTrue(model.DestoryModel());
-            Assert.AreEqual(0, model.Count);
-            Assert.IsFalse(model.Exists);
-            Assert.IsEmpty(model.List);
-            Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
-
-            FreeImage.UnloadEx(ref dib);
-        }
-
-        [Test]
-        public void ImageMetadata()
-        {
-            ImageMetadata metadata;
-            List<MetadataModel> modelList;
-            MetadataTag tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
-            tag.Key = "KEY";
-            tag.ID = 11;
-            tag.Value = new double[] { 0d, 41d, -523d, -0.41d };
-
-            dib = FreeImage.Allocate(1, 1, 1, 1, 0, 0);
-            Assert.IsFalse(dib.IsNull);
-
-            metadata = new ImageMetadata(dib, true);
-            Assert.AreEqual(0, metadata.Count);
-            Assert.IsTrue(metadata.HideEmptyModels);
-            Assert.IsEmpty(metadata.List);
-
-            metadata = new ImageMetadata(dib, false);
-            Assert.AreEqual(FreeImage.FREE_IMAGE_MDMODELS.Length, metadata.Count);
-            Assert.IsFalse(metadata.HideEmptyModels);
-            Assert.IsNotEmpty(metadata.List);
-
-            metadata.HideEmptyModels = true;
-            metadata.AddTag(tag);
-
-            Assert.AreEqual(1, metadata.Count);
-            Assert.IsNotEmpty(metadata.List);
-
-            modelList = metadata.List;
-            Assert.AreEqual(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, modelList[0].Model);
-
-            System.Collections.IEnumerator enumerator = metadata.GetEnumerator();
-            Assert.IsTrue(enumerator.MoveNext());
-            Assert.IsNotNull((MetadataModel)enumerator.Current);
-            Assert.IsFalse(enumerator.MoveNext());
-
-            FreeImage.UnloadEx(ref dib);
-        }
-    }
+	[TestFixture]
+	public class WrapperStructsTest
+	{
+		ImageManager iManager = new ImageManager();
+		FIBITMAP dib = new FIBITMAP();
+
+		[SetUp]
+		public void InitEachTime()
+		{
+		}
+
+		[TearDown]
+		public void DeInitEachTime()
+		{
+		}
+
+		public bool EqualColors(Color color1, Color color2)
+		{
+			if (color1.A != color2.A)
+				return false;
+			if (color1.R != color2.R)
+				return false;
+			if (color1.G != color2.G)
+				return false;
+			if (color1.B != color2.B)
+				return false;
+			return true;
+		}
+
+		[Test]
+		public void FIRational()
+		{
+			FIRational rational1 = new FIRational();
+			FIRational rational2 = new FIRational();
+			FIRational rational3 = new FIRational();
+
+			//
+			// Constructors
+			//
+
+			Assert.That(rational1.Numerator == 0);
+			Assert.That(rational1.Denominator == 0);
+
+			rational1 = new FIRational(412, 33);
+			Assert.That(rational1.Numerator == 412);
+			Assert.That(rational1.Denominator == 33);
+
+			rational2 = new FIRational(rational1);
+			Assert.That(rational2.Numerator == 412);
+			Assert.That(rational2.Denominator == 33);
+
+			rational3 = new FIRational(5.75m);
+			Assert.That(rational3.Numerator == 23);
+			Assert.That(rational3.Denominator == 4);
+
+			//
+			// == !=
+			//
+
+			rational1 = new FIRational(421, 51);
+			rational2 = rational1;
+			Assert.That(rational1 == rational2);
+			Assert.That(!(rational1 != rational2));
+
+			rational2 = new FIRational(1, 7);
+			Assert.That(rational1 != rational2);
+			Assert.That(!(rational1 == rational2));
+
+			//
+			// > >= < <=
+			//
+
+			rational1 = new FIRational(51, 4);
+			rational2 = new FIRational(27, 9);
+			Assert.That(rational1 != rational2);
+			Assert.That(rational1 > rational2);
+			Assert.That(rational1 >= rational2);
+
+			rational1 = new FIRational(-412, 4);
+			Assert.That(rational1 != rational2);
+			Assert.That(rational1 < rational2);
+			Assert.That(rational1 <= rational2);
+
+			//
+			// + / -
+			//
+
+			rational1 = new FIRational(41, 3);
+			rational2 = new FIRational(612, 412);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(-7852, 63);
+			rational2 = new FIRational(666111, -7654);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(-513, 88);
+			rational2 = new FIRational(413, 5);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(-513, 88);
+			rational2 = new FIRational(413, 5);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(7531, 23144);
+			rational2 = new FIRational(-412, 78777);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(513, -42123);
+			rational2 = new FIRational(-42, 77);
+			rational3 = rational1 - rational2;
+			Assert.That((rational3 + rational2) == rational1);
+
+			rational1 = new FIRational(44, 11);
+			rational1 = -rational1;
+			Assert.That(rational1.Numerator == -4 && rational1.Denominator == 1);
+
+			//
+			// %
+			//
+
+			rational1 = new FIRational(23, 8);
+			rational2 = new FIRational(77, 777);
+			Assert.That((rational1 % rational2) == 0);
+
+			rational2 = -rational2;
+			Assert.That((rational1 % rational2) == 0);
+
+			rational2 = new FIRational(7, 4);
+			rational3 = new FIRational(9, 8);
+			Assert.That((rational1 % rational2) == rational3);
+
+			rational2 = -rational2;
+			Assert.That((rational1 % rational2) == rational3);
+
+			//
+			// ~
+			//
+
+			rational1 = new FIRational(41, 77);
+			rational1 = ~rational1;
+			Assert.That(rational1.Numerator == 77 && rational1.Denominator == 41);
+
+			//
+			// -
+			//
+
+			rational1 = new FIRational(52, 4);
+			rational1 = -rational1;
+			Assert.That(rational1 < 0);
+
+			//
+			// ++ --
+			//
+
+			rational1 = new FIRational(5, 3);
+			rational1++;
+			rational2 = new FIRational(8, 3);
+			Assert.That(rational1 == rational2);
+
+			rational1 = new FIRational(41, -43);
+			rational1++;
+			Assert.That(rational1 > 0.0f);
+
+			rational1--;
+			Assert.That(rational1 == new FIRational(41, -43));
+
+			rational1 = new FIRational(8134, 312);
+			Assert.That(rational1 != 26);
+
+			//
+			// Direct assigns
+			//
+
+			rational1 = (FIRational)0.75m;
+			Assert.That(rational1.Numerator == 3 && rational1.Denominator == 4);
+			rational1 = (FIRational)0.33;
+			Assert.That(rational1.Numerator == 33 && rational1.Denominator == 100);
+			rational1 = (FIRational)62.975m;
+			Assert.That(((decimal)rational1.Numerator / (decimal)rational1.Denominator) == 62.975m);
+			rational1 = (FIRational)(-73.0975m);
+			Assert.That(((decimal)rational1.Numerator / (decimal)rational1.Denominator) == -73.0975m);
+			rational1 = (FIRational)(7m / 9m);
+			Assert.That(rational1.Numerator == 7 && rational1.Denominator == 9);
+			rational1 = (FIRational)(-15m / 9m);
+			Assert.That(rational1.Numerator == -5 && rational1.Denominator == 3);
+			rational1 = (FIRational)(0.7777m);
+			Assert.That(rational1.Denominator != 9);
+
+			//
+			// Properties
+			//
+
+			rational1 = new FIRational(515, 5);
+			Assert.That(rational1.IsInteger);
+
+			rational1 = new FIRational(876, 77);
+			Assert.That(rational1.Truncate() == (876 / 77));
+
+			//
+			// Special cases
+			//
+
+			rational1 = new FIRational(0, 10000);
+			Assert.That(rational1 == 0m);
+
+			rational1 = new FIRational(10000, 0);
+			Assert.That(rational1 == 0f);
+
+			rational1 = new FIRational(0, 0);
+			Assert.That(rational1 == 0d);
+
+			rational1 = new FIRational(-1, 0);
+			Assert.That(rational1 == 0);
+
+			rational1 = new FIRational(0, -1);
+			Assert.That(rational1 == 0);
+		}
+
+		[Ignore("Ignoring StreamWrapper")]
+		public void StreamWrapper()
+		{
+			string url = @"http://freeimage.sourceforge.net/images/logo.jpg";
+
+			//
+			// Non blocking
+			//
+
+			HttpWebRequest req = (HttpWebRequest)HttpWebRequest.Create(url);
+			Assert.IsNotNull(req);
+
+			req.Timeout = 1000;
+			HttpWebResponse resp;
+			try
+			{
+				resp = (HttpWebResponse)req.GetResponse();
+			}
+			catch
+			{
+				return;
+			}
+			Assert.IsNotNull(resp);
+
+			Stream stream = resp.GetResponseStream();
+			Assert.IsNotNull(stream);
+
+			StreamWrapper wrapper = new StreamWrapper(stream, false);
+			Assert.IsNotNull(wrapper);
+			Assert.IsTrue(wrapper.CanRead && wrapper.CanSeek && !wrapper.CanWrite);
+
+			byte[] buffer = new byte[1024 * 100];
+			int read;
+			int count = 0;
+
+			do
+			{
+				read = wrapper.Read(buffer, count, buffer.Length - count);
+				count += read;
+			} while (read != 0);
+
+			Assert.AreEqual(7972, count);
+			Assert.AreEqual(7972, wrapper.Length);
+
+			wrapper.Position = 0;
+			Assert.AreEqual(0, wrapper.Position);
+
+			byte[] test = new byte[buffer.Length];
+			int countTest = 0;
+
+			do
+			{
+				read = wrapper.Read(test, countTest, test.Length - countTest);
+				countTest += read;
+			} while (read != 0);
+
+			Assert.AreEqual(count, countTest);
+
+			for (int i = 0; i < countTest; i++)
+				if (buffer[i] != test[i])
+					Assert.Fail();
+
+			resp.Close();
+			wrapper.Dispose();
+			stream.Dispose();
+
+			//
+			// Blocking
+			//
+
+			req = (HttpWebRequest)HttpWebRequest.Create(url);
+			Assert.IsNotNull(req);
+
+			resp = (HttpWebResponse)req.GetResponse();
+			Assert.IsNotNull(resp);
+
+			stream = resp.GetResponseStream();
+			Assert.IsNotNull(stream);
+
+			wrapper = new StreamWrapper(stream, true);
+			Assert.IsNotNull(wrapper);
+			Assert.IsTrue(wrapper.CanRead && wrapper.CanSeek && !wrapper.CanWrite);
+
+			buffer = new byte[1024 * 100];
+			count = 0;
+
+			count = wrapper.Read(buffer, 0, buffer.Length);
+			Assert.AreEqual(7972, count);
+
+			resp.Close();
+			stream.Dispose();
+			wrapper.Dispose();
+
+			//
+			// Position & Read byte
+			//
+
+			buffer = new byte[] { 0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD };
+			stream = new MemoryStream(buffer);
+			wrapper = new StreamWrapper(stream, false);
+
+			Assert.That(0x00 == wrapper.ReadByte());
+			Assert.That(0x01 == wrapper.ReadByte());
+			Assert.That(0x02 == wrapper.ReadByte());
+			Assert.That(0xFF == wrapper.ReadByte());
+			Assert.That(0xFE == wrapper.ReadByte());
+			Assert.That(0xFD == wrapper.ReadByte());
+			Assert.That(-1 == wrapper.ReadByte());
+
+			Assert.That(wrapper.Length == buffer.Length);
+
+			wrapper.Seek(0, SeekOrigin.Begin);
+			Assert.That(0x00 == wrapper.ReadByte());
+			wrapper.Seek(3, SeekOrigin.Begin);
+			Assert.That(0xFF == wrapper.ReadByte());
+			wrapper.Seek(0, SeekOrigin.End);
+			Assert.That(-1 == wrapper.ReadByte());
+			wrapper.Seek(-2, SeekOrigin.End);
+			Assert.That(0xFE == wrapper.ReadByte());
+			wrapper.Seek(0, SeekOrigin.Begin);
+			Assert.That(0x00 == wrapper.ReadByte());
+			wrapper.Seek(2, SeekOrigin.Current);
+			Assert.That(0xFF == wrapper.ReadByte());
+			wrapper.Seek(1, SeekOrigin.Current);
+			Assert.That(0xFD == wrapper.ReadByte());
+			Assert.That(wrapper.Position != 0);
+			wrapper.Reset();
+			Assert.That(wrapper.Position == 0);
+
+			wrapper.Dispose();
+			stream.Position = 0;
+			wrapper = new StreamWrapper(stream, false);
+
+			wrapper.Seek(10, SeekOrigin.Begin);
+			Assert.That(wrapper.Position == buffer.Length);
+
+			wrapper.Dispose();
+			stream.Dispose();
+		}
+
+		[Ignore("Ignoring LocalPlugin")]
+		public void LocalPlugin()
+		{
+		}
+
+		[Test]
+		public void FreeImageStreamIO()
+		{
+			Random rand = new Random();
+			byte[] bBuffer = new byte[256];
+			IntPtr buffer = Marshal.AllocHGlobal(256);
+
+			MemoryStream stream = new MemoryStream();
+			Assert.IsNotNull(stream);
+			using (fi_handle handle = new fi_handle(stream))
+			{
+
+				FreeImageIO io = FreeImageAPI.IO.FreeImageStreamIO.io;
+				Assert.IsNotNull(io.readProc);
+				Assert.IsNotNull(io.writeProc);
+				Assert.IsNotNull(io.seekProc);
+				Assert.IsNotNull(io.tellProc);
+
+				//
+				// Procs
+				//
+
+				rand.NextBytes(bBuffer);
+
+				stream.Write(bBuffer, 0, bBuffer.Length);
+				Assert.That(io.tellProc(handle) == stream.Position);
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
+				Assert.That(io.tellProc(handle) == 0);
+				Assert.That(io.tellProc(handle) == stream.Position);
+
+				// Read one block
+				Assert.That(io.readProc(buffer, (uint)bBuffer.Length, 1, handle) == 1);
+				for (int i = 0; i < bBuffer.Length; i++)
+					Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
+
+				Assert.That(io.tellProc(handle) == stream.Position);
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
+				Assert.That(io.tellProc(handle) == stream.Position);
+
+				// Read 1 byte block
+				Assert.That(io.readProc(buffer, 1, (uint)bBuffer.Length, handle) == bBuffer.Length);
+				for (int i = 0; i < bBuffer.Length; i++)
+					Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
+
+				Assert.That(io.tellProc(handle) == stream.Position);
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
+				Assert.That(io.tellProc(handle) == stream.Position);
+
+				rand.NextBytes(bBuffer);
+				for (int i = 0; i < bBuffer.Length; i++)
+					Marshal.WriteByte(buffer, i, bBuffer[i]);
+
+				// Write one block
+
+				Assert.That(io.writeProc(buffer, (uint)bBuffer.Length, 1, handle) == 1);
+				for (int i = 0; i < bBuffer.Length; i++)
+					Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
+				Assert.That(io.tellProc(handle) == stream.Position);
+
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
+				Assert.That(io.tellProc(handle) == 0);
+
+				// write 1 byte block
+
+				Assert.That(io.writeProc(buffer, 1, (uint)bBuffer.Length, handle) == bBuffer.Length);
+				for (int i = 0; i < bBuffer.Length; i++)
+					Assert.That(Marshal.ReadByte(buffer, i) == bBuffer[i]);
+				Assert.That(io.tellProc(handle) == stream.Position);
+
+				// Seek and tell
+
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.Begin) == 0);
+				Assert.That(io.tellProc(handle) == 0);
+
+				Assert.That(io.seekProc(handle, 127, SeekOrigin.Current) == 0);
+				Assert.That(io.tellProc(handle) == 127);
+
+				Assert.That(io.seekProc(handle, 0, SeekOrigin.End) == 0);
+				Assert.That(io.tellProc(handle) == 256);
+
+				Marshal.FreeHGlobal(buffer);
+				stream.Dispose();
+			}
+		}
+
+		[Test]
+		public void MetadataTag()
+		{
+			FITAG tag;
+			MetadataTag metaTag;
+
+			Random rand = new Random();
+			dib = iManager.GetBitmap(ImageType.Metadata, ImageColorType.Type_01_Dither);
+			Assert.IsFalse(dib.IsNull);
+
+			Assert.That(FreeImage.GetMetadataCount(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib) > 0);
+
+			FIMETADATA mData = FreeImage.FindFirstMetadata(FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN, dib, out tag);
+			Assert.IsFalse(tag.IsNull);
+			Assert.IsFalse(mData.IsNull);
+
+			//
+			// Constructors
+			//
+
+			metaTag = new MetadataTag(tag, dib);
+			Assert.That(metaTag.Model == FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
+
+			metaTag = new MetadataTag(tag, FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
+			Assert.That(metaTag.Model == FREE_IMAGE_MDMODEL.FIMD_EXIF_MAIN);
+
+			//
+			// Properties
+			//
+
+			metaTag.ID = ushort.MinValue;
+			Assert.That(metaTag.ID == ushort.MinValue);
+
+			metaTag.ID = ushort.MaxValue;
+			Assert.That(metaTag.ID == ushort.MaxValue);
+
+			metaTag.ID = ushort.MaxValue / 2;
+			Assert.That(metaTag.ID == ushort.MaxValue / 2);
+
+			metaTag.Description = "";
+			Assert.That(metaTag.Description == "");
+
+			metaTag.Description = "A";
+			Assert.That(metaTag.Description == "A");
+
+			metaTag.Description = "ABCDEFG";
+			Assert.That(metaTag.Description == "ABCDEFG");
+
+			metaTag.Key = "";
+			Assert.That(metaTag.Key == "");
+
+			metaTag.Key = "A";
+			Assert.That(metaTag.Key == "A");
+
+			metaTag.Key = "ABCDEFG";
+			Assert.That(metaTag.Key == "ABCDEFG");
+
+			//
+			// SetValue
+			//
+
+			try
+			{
+				metaTag.SetValue(null, FREE_IMAGE_MDTYPE.FIDT_ASCII);
+				Assert.Fail();
+			}
+			catch
+			{
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_ASCII
+			//
+
+			string testString = "";
+
+			Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((string)metaTag.Value).Length == 0);
+
+			testString = "X";
+
+			Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((string)metaTag.Value).Length == testString.Length);
+			Assert.That(((string)metaTag.Value) == testString);
+
+			testString = "TEST-STRING";
+
+			Assert.IsTrue(metaTag.SetValue(testString, FREE_IMAGE_MDTYPE.FIDT_ASCII));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((string)metaTag.Value).Length == testString.Length);
+			Assert.That(((string)metaTag.Value) == testString);
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_BYTE
+			//			
+
+			byte testByte;
+			byte[] testByteArray;
+
+			Assert.IsTrue(metaTag.SetValue(byte.MinValue, FREE_IMAGE_MDTYPE.FIDT_BYTE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((byte[])metaTag.Value).Length == 1);
+			Assert.That(((byte[])metaTag.Value)[0] == byte.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(byte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_BYTE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((byte[])metaTag.Value).Length == 1);
+			Assert.That(((byte[])metaTag.Value)[0] == byte.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testByte = (byte)rand.Next(byte.MinValue, byte.MaxValue);
+				testByteArray = new byte[rand.Next(0, 31)];
+
+				for (int j = 0; j < testByteArray.Length; j++)
+					testByteArray[j] = (byte)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testByte, FREE_IMAGE_MDTYPE.FIDT_BYTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((byte[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 1);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_BYTE);
+				Assert.That(((byte[])metaTag.Value)[0] == testByte);
+
+				Assert.IsTrue(metaTag.SetValue(testByteArray, FREE_IMAGE_MDTYPE.FIDT_BYTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((byte[])metaTag.Value).Length == testByteArray.Length);
+				Assert.That(metaTag.Count == testByteArray.Length);
+				Assert.That(metaTag.Length == testByteArray.Length * 1);
+
+				byte[] value = (byte[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testByteArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_DOUBLE
+			//
+
+			double testDouble;
+			double[] testDoubleArray;
+
+			Assert.IsTrue(metaTag.SetValue(double.MinValue, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((double[])metaTag.Value).Length == 1);
+			Assert.That(((double[])metaTag.Value)[0] == double.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(double.MaxValue, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((double[])metaTag.Value).Length == 1);
+			Assert.That(((double[])metaTag.Value)[0] == double.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testDouble = (double)rand.NextDouble();
+				testDoubleArray = new double[rand.Next(0, 31)];
+
+				for (int j = 0; j < testDoubleArray.Length; j++)
+					testDoubleArray[j] = rand.NextDouble();
+
+				Assert.IsTrue(metaTag.SetValue(testDouble, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((double[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 8);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_DOUBLE);
+				Assert.That(((double[])metaTag.Value)[0] == testDouble);
+
+				Assert.IsTrue(metaTag.SetValue(testDoubleArray, FREE_IMAGE_MDTYPE.FIDT_DOUBLE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((double[])metaTag.Value).Length == testDoubleArray.Length);
+				Assert.That(metaTag.Count == testDoubleArray.Length);
+				Assert.That(metaTag.Length == testDoubleArray.Length * 8);
+
+				double[] value = (double[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testDoubleArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_FLOAT
+			//
+
+			float testfloat;
+			float[] testFloatArray;
+
+			Assert.IsTrue(metaTag.SetValue(float.MinValue, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((float[])metaTag.Value).Length == 1);
+			Assert.That(((float[])metaTag.Value)[0] == float.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(float.MaxValue, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((float[])metaTag.Value).Length == 1);
+			Assert.That(((float[])metaTag.Value)[0] == float.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testfloat = (float)rand.NextDouble();
+				testFloatArray = new float[rand.Next(0, 31)];
+
+				for (int j = 0; j < testFloatArray.Length; j++)
+					testFloatArray[j] = (float)rand.NextDouble();
+
+				Assert.IsTrue(metaTag.SetValue(testfloat, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((float[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 4);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_FLOAT);
+				Assert.That(((float[])metaTag.Value)[0] == testfloat);
+
+				Assert.IsTrue(metaTag.SetValue(testFloatArray, FREE_IMAGE_MDTYPE.FIDT_FLOAT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((float[])metaTag.Value).Length == testFloatArray.Length);
+				Assert.That(metaTag.Count == testFloatArray.Length);
+				Assert.That(metaTag.Length == testFloatArray.Length * 4);
+
+				float[] value = (float[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testFloatArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_IFD
+			//
+
+			uint testUint;
+			uint[] testUintArray;
+
+			Assert.IsTrue(metaTag.SetValue(uint.MinValue, FREE_IMAGE_MDTYPE.FIDT_IFD));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((uint[])metaTag.Value).Length == 1);
+			Assert.That(((uint[])metaTag.Value)[0] == uint.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(uint.MaxValue, FREE_IMAGE_MDTYPE.FIDT_IFD));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((uint[])metaTag.Value).Length == 1);
+			Assert.That(((uint[])metaTag.Value)[0] == uint.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testUint = (uint)rand.NextDouble();
+				testUintArray = new uint[rand.Next(0, 31)];
+
+				for (int j = 0; j < testUintArray.Length; j++)
+					testUintArray[j] = (uint)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testUint, FREE_IMAGE_MDTYPE.FIDT_IFD));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((uint[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 4);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_IFD);
+				Assert.That(((uint[])metaTag.Value)[0] == testUint);
+
+				Assert.IsTrue(metaTag.SetValue(testUintArray, FREE_IMAGE_MDTYPE.FIDT_IFD));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((uint[])metaTag.Value).Length == testUintArray.Length);
+				Assert.That(metaTag.Count == testUintArray.Length);
+				Assert.That(metaTag.Length == testUintArray.Length * 4);
+
+				uint[] value = (uint[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testUintArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_LONG
+			//
+
+			Assert.IsTrue(metaTag.SetValue(uint.MinValue, FREE_IMAGE_MDTYPE.FIDT_LONG));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((uint[])metaTag.Value).Length == 1);
+			Assert.That(((uint[])metaTag.Value)[0] == uint.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(uint.MaxValue, FREE_IMAGE_MDTYPE.FIDT_LONG));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((uint[])metaTag.Value).Length == 1);
+			Assert.That(((uint[])metaTag.Value)[0] == uint.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testUint = (uint)rand.NextDouble();
+				testUintArray = new uint[rand.Next(0, 31)];
+
+				for (int j = 0; j < testUintArray.Length; j++)
+					testUintArray[j] = (uint)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testUint, FREE_IMAGE_MDTYPE.FIDT_LONG));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((uint[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 4);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_LONG);
+				Assert.That(((uint[])metaTag.Value)[0] == testUint);
+
+				Assert.IsTrue(metaTag.SetValue(testUintArray, FREE_IMAGE_MDTYPE.FIDT_LONG));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((uint[])metaTag.Value).Length == testUintArray.Length);
+				Assert.That(metaTag.Count == testUintArray.Length);
+				Assert.That(metaTag.Length == testUintArray.Length * 4);
+
+				uint[] value = (uint[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testUintArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_NOTYPE
+			//
+
+			try
+			{
+				metaTag.SetValue(new object(), FREE_IMAGE_MDTYPE.FIDT_NOTYPE);
+				Assert.Fail();
+			}
+			catch (NotSupportedException)
+			{
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_PALETTE
+			//
+
+			RGBQUAD testRGBQUAD;
+			RGBQUAD[] testRGBQUADArray;
+
+			for (int i = 0; i < 10; i++)
+			{
+				testRGBQUAD = new RGBQUAD(Color.FromArgb(rand.Next()));
+				testRGBQUADArray = new RGBQUAD[rand.Next(0, 31)];
+
+				for (int j = 0; j < testRGBQUADArray.Length; j++)
+					testRGBQUADArray[j] = new RGBQUAD(Color.FromArgb(rand.Next()));
+
+				Assert.IsTrue(metaTag.SetValue(testRGBQUAD, FREE_IMAGE_MDTYPE.FIDT_PALETTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((RGBQUAD[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 4);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_PALETTE);
+				Assert.That(((RGBQUAD[])metaTag.Value)[0] == testRGBQUAD);
+
+				Assert.IsTrue(metaTag.SetValue(testRGBQUADArray, FREE_IMAGE_MDTYPE.FIDT_PALETTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((RGBQUAD[])metaTag.Value).Length == testRGBQUADArray.Length);
+				Assert.That(metaTag.Count == testRGBQUADArray.Length);
+				Assert.That(metaTag.Length == testRGBQUADArray.Length * 4);
+
+				RGBQUAD[] value = (RGBQUAD[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testRGBQUADArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_RATIONAL
+			//
+
+			FIURational testFIURational;
+			FIURational[] testFIURationalArray;
+
+			for (int i = 0; i < 10; i++)
+			{
+				testFIURational = new FIURational((uint)rand.Next(), (uint)rand.Next());
+				testFIURationalArray = new FIURational[rand.Next(0, 31)];
+
+				for (int j = 0; j < testFIURationalArray.Length; j++)
+					testFIURationalArray[j] = new FIURational((uint)rand.Next(), (uint)rand.Next());
+
+				Assert.IsTrue(metaTag.SetValue(testFIURational, FREE_IMAGE_MDTYPE.FIDT_RATIONAL));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((FIURational[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 8);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_RATIONAL);
+				Assert.That(((FIURational[])metaTag.Value)[0] == testFIURational);
+
+				Assert.IsTrue(metaTag.SetValue(testFIURationalArray, FREE_IMAGE_MDTYPE.FIDT_RATIONAL));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((FIURational[])metaTag.Value).Length == testFIURationalArray.Length);
+				Assert.That(metaTag.Count == testFIURationalArray.Length);
+				Assert.That(metaTag.Length == testFIURationalArray.Length * 8);
+
+				FIURational[] value = (FIURational[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testFIURationalArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_SBYTE
+			//
+
+			sbyte testSByte;
+			sbyte[] testSByteArray;
+
+			Assert.IsTrue(metaTag.SetValue(sbyte.MinValue, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((sbyte[])metaTag.Value).Length == 1);
+			Assert.That(((sbyte[])metaTag.Value)[0] == sbyte.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(sbyte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((sbyte[])metaTag.Value).Length == 1);
+			Assert.That(((sbyte[])metaTag.Value)[0] == sbyte.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testSByte = (sbyte)rand.Next(sbyte.MinValue, sbyte.MaxValue);
+				testSByteArray = new sbyte[rand.Next(0, 31)];
+
+				for (int j = 0; j < testSByteArray.Length; j++)
+					testSByteArray[j] = (sbyte)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testSByte, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((sbyte[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 1);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SBYTE);
+				Assert.That(((sbyte[])metaTag.Value)[0] == testSByte);
+
+				Assert.IsTrue(metaTag.SetValue(testSByteArray, FREE_IMAGE_MDTYPE.FIDT_SBYTE));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((sbyte[])metaTag.Value).Length == testSByteArray.Length);
+				Assert.That(metaTag.Count == testSByteArray.Length);
+				Assert.That(metaTag.Length == testSByteArray.Length * 1);
+
+				sbyte[] value = (sbyte[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testSByteArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_SHORT
+			//
+
+			ushort testUShort;
+			ushort[] testUShortArray;
+
+			Assert.IsTrue(metaTag.SetValue(ushort.MinValue, FREE_IMAGE_MDTYPE.FIDT_SHORT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((ushort[])metaTag.Value).Length == 1);
+			Assert.That(((ushort[])metaTag.Value)[0] == ushort.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(ushort.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SHORT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((ushort[])metaTag.Value).Length == 1);
+			Assert.That(((ushort[])metaTag.Value)[0] == ushort.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testUShort = (ushort)rand.Next(ushort.MinValue, sbyte.MaxValue);
+				testUShortArray = new ushort[rand.Next(0, 31)];
+
+				for (int j = 0; j < testUShortArray.Length; j++)
+					testUShortArray[j] = (ushort)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testUShort, FREE_IMAGE_MDTYPE.FIDT_SHORT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((ushort[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 2);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SHORT);
+				Assert.That(((ushort[])metaTag.Value)[0] == testUShort);
+
+				Assert.IsTrue(metaTag.SetValue(testUShortArray, FREE_IMAGE_MDTYPE.FIDT_SHORT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((ushort[])metaTag.Value).Length == testUShortArray.Length);
+				Assert.That(metaTag.Count == testUShortArray.Length);
+				Assert.That(metaTag.Length == testUShortArray.Length * 2);
+
+				ushort[] value = (ushort[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testUShortArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_SLONG
+			//
+
+			int testInt;
+			int[] testIntArray;
+
+			Assert.IsTrue(metaTag.SetValue(int.MinValue, FREE_IMAGE_MDTYPE.FIDT_SLONG));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((int[])metaTag.Value).Length == 1);
+			Assert.That(((int[])metaTag.Value)[0] == int.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(int.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SLONG));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((int[])metaTag.Value).Length == 1);
+			Assert.That(((int[])metaTag.Value)[0] == int.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testInt = (int)rand.NextDouble();
+				testIntArray = new int[rand.Next(0, 31)];
+
+				for (int j = 0; j < testIntArray.Length; j++)
+					testIntArray[j] = rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testInt, FREE_IMAGE_MDTYPE.FIDT_SLONG));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((int[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 4);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SLONG);
+				Assert.That(((int[])metaTag.Value)[0] == testInt);
+
+				Assert.IsTrue(metaTag.SetValue(testIntArray, FREE_IMAGE_MDTYPE.FIDT_SLONG));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((int[])metaTag.Value).Length == testIntArray.Length);
+				Assert.That(metaTag.Count == testIntArray.Length);
+				Assert.That(metaTag.Length == testIntArray.Length * 4);
+
+				int[] value = (int[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testIntArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_SRATIONAL
+			//
+
+			FIRational testFIRational;
+			FIRational[] testFIRationalArray;
+
+			for (int i = 0; i < 10; i++)
+			{
+				testFIRational = new FIRational(rand.Next(), rand.Next());
+				testFIRationalArray = new FIRational[rand.Next(0, 31)];
+
+				for (int j = 0; j < testFIRationalArray.Length; j++)
+					testFIRationalArray[j] = new FIRational(rand.Next(), rand.Next());
+
+				Assert.IsTrue(metaTag.SetValue(testFIRational, FREE_IMAGE_MDTYPE.FIDT_SRATIONAL));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((FIRational[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 8);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SRATIONAL);
+				Assert.That(((FIRational[])metaTag.Value)[0] == testFIRational);
+
+				Assert.IsTrue(metaTag.SetValue(testFIRationalArray, FREE_IMAGE_MDTYPE.FIDT_SRATIONAL));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((FIRational[])metaTag.Value).Length == testFIRationalArray.Length);
+				Assert.That(metaTag.Count == testFIRationalArray.Length);
+				Assert.That(metaTag.Length == testFIRationalArray.Length * 8);
+
+				FIRational[] value = (FIRational[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testFIRationalArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_SSHORT
+			//
+
+			short testShort;
+			short[] testShortArray;
+
+			Assert.IsTrue(metaTag.SetValue(short.MinValue, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((short[])metaTag.Value).Length == 1);
+			Assert.That(((short[])metaTag.Value)[0] == short.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(short.MaxValue, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((short[])metaTag.Value).Length == 1);
+			Assert.That(((short[])metaTag.Value)[0] == short.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testShort = (short)rand.Next(short.MinValue, short.MaxValue);
+				testShortArray = new short[rand.Next(0, 31)];
+
+				for (int j = 0; j < testShortArray.Length; j++)
+					testShortArray[j] = (short)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testShort, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((short[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 2);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_SSHORT);
+				Assert.That(((short[])metaTag.Value)[0] == testShort);
+
+				Assert.IsTrue(metaTag.SetValue(testShortArray, FREE_IMAGE_MDTYPE.FIDT_SSHORT));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((short[])metaTag.Value).Length == testShortArray.Length);
+				Assert.That(metaTag.Count == testShortArray.Length);
+				Assert.That(metaTag.Length == testShortArray.Length * 2);
+
+				short[] value = (short[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testShortArray[j] == value[j]);
+			}
+
+			//
+			// FREE_IMAGE_MDTYPE.FIDT_UNDEFINED
+			//
+
+			Assert.IsTrue(metaTag.SetValue(byte.MinValue, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((byte[])metaTag.Value).Length == 1);
+			Assert.That(((byte[])metaTag.Value)[0] == byte.MinValue);
+
+			Assert.IsTrue(metaTag.SetValue(byte.MaxValue, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
+			Assert.IsNotNull(metaTag.Value);
+			Assert.That(((byte[])metaTag.Value).Length == 1);
+			Assert.That(((byte[])metaTag.Value)[0] == byte.MaxValue);
+
+			for (int i = 0; i < 10; i++)
+			{
+				testByte = (byte)rand.Next(byte.MinValue, byte.MaxValue);
+				testByteArray = new byte[rand.Next(0, 31)];
+
+				for (int j = 0; j < testByteArray.Length; j++)
+					testByteArray[j] = (byte)rand.Next();
+
+				Assert.IsTrue(metaTag.SetValue(testByte, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((byte[])metaTag.Value).Length == 1);
+				Assert.That(metaTag.Count == 1);
+				Assert.That(metaTag.Length == 1);
+				Assert.That(metaTag.Type == FREE_IMAGE_MDTYPE.FIDT_UNDEFINED);
+				Assert.That(((byte[])metaTag.Value)[0] == testByte);
+
+				Assert.IsTrue(metaTag.SetValue(testByteArray, FREE_IMAGE_MDTYPE.FIDT_UNDEFINED));
+				Assert.IsNotNull(metaTag.Value);
+				Assert.That(((byte[])metaTag.Value).Length == testByteArray.Length);
+				Assert.That(metaTag.Count == testByteArray.Length);
+				Assert.That(metaTag.Length == testByteArray.Length * 1);
+
+				byte[] value = (byte[])metaTag.Value;
+
+				for (int j = 0; j < value.Length; j++)
+					Assert.That(testByteArray[j] == value[j]);
+			}
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void MetadataModel()
+		{
+			MetadataTag tag;
+			dib = FreeImage.Allocate(1, 1, 1, 0, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			MetadataModel model = new MDM_GEOTIFF(dib);
+			Assert.AreEqual(0, model.Count);
+			Assert.IsFalse(model.Exists);
+			Assert.IsEmpty(model.List);
+			Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
+			Assert.IsTrue(model.DestoryModel());
+			foreach (MetadataTag m in model)
+				Assert.Fail();
+
+			tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
+			tag.Key = "KEY";
+			tag.Value = 54321f;
+			Assert.IsTrue(model.AddTag(tag));
+
+			Assert.AreEqual(1, model.Count);
+			Assert.IsTrue(model.Exists);
+			Assert.IsNotEmpty(model.List);
+			Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
+
+			Assert.IsTrue(model.DestoryModel());
+			Assert.AreEqual(0, model.Count);
+			Assert.IsFalse(model.Exists);
+			Assert.IsEmpty(model.List);
+			Assert.AreEqual(model.Model, FREE_IMAGE_MDMODEL.FIMD_GEOTIFF);
+
+			FreeImage.UnloadEx(ref dib);
+		}
+
+		[Test]
+		public void ImageMetadata()
+		{
+			ImageMetadata metadata;
+			List<MetadataModel> modelList;
+			MetadataTag tag = new MetadataTag(FREE_IMAGE_MDMODEL.FIMD_COMMENTS);
+			tag.Key = "KEY";
+			tag.ID = 11;
+			tag.Value = new double[] { 0d, 41d, -523d, -0.41d };
+
+			dib = FreeImage.Allocate(1, 1, 1, 1, 0, 0);
+			Assert.IsFalse(dib.IsNull);
+
+			metadata = new ImageMetadata(dib, true);
+			Assert.AreEqual(0, metadata.Count);
+			Assert.IsTrue(metadata.HideEmptyModels);
+			Assert.IsEmpty(metadata.List);
+
+			metadata = new ImageMetadata(dib, false);
+			Assert.AreEqual(FreeImage.FREE_IMAGE_MDMODELS.Length, metadata.Count);
+			Assert.IsFalse(metadata.HideEmptyModels);
+			Assert.IsNotEmpty(metadata.List);
+
+			metadata.HideEmptyModels = true;
+			metadata.AddTag(tag);
+
+			Assert.AreEqual(1, metadata.Count);
+			Assert.IsNotEmpty(metadata.List);
+
+			modelList = metadata.List;
+			Assert.AreEqual(FREE_IMAGE_MDMODEL.FIMD_COMMENTS, modelList[0].Model);
+
+			System.Collections.IEnumerator enumerator = metadata.GetEnumerator();
+			Assert.IsTrue(enumerator.MoveNext());
+			Assert.IsNotNull((MetadataModel)enumerator.Current);
+			Assert.IsFalse(enumerator.MoveNext());
+
+			FreeImage.UnloadEx(ref dib);
+		}
+	}
 }


### PR DESCRIPTION
Now that `.editorconfig` file is in place, ensure all code is formatted accordingly.