### PR TITLE
Add webp and jxr definitions

### DIFF
--- a/src/FreeImage.Standard/Enumerations/FREE_IMAGE_FORMAT.cs
+++ b/src/FreeImage.Standard/Enumerations/FREE_IMAGE_FORMAT.cs
@@ -188,5 +188,13 @@ namespace FreeImageAPI
         /// RAW camera image (*.*)
         /// </summary>
         FIF_RAW = 34,
+        /// <summary>
+        /// WEBP format (*.webp)
+        /// </summary>
+        FIF_WEBP = 35,
+        /// <summary>
+        /// JPEG XR (*.jxr)
+        /// </summary>
+        FIF_JXR = 36
     }
 }

--- a/src/FreeImage.Standard/Enumerations/FREE_IMAGE_SAVE_FLAGS.cs
+++ b/src/FreeImage.Standard/Enumerations/FREE_IMAGE_SAVE_FLAGS.cs
@@ -186,6 +186,26 @@ namespace FreeImageAPI
         /// <summary>
         /// Save using JPEG compression.
         /// </summary>
-        TIFF_JPEG = 0x8000
+        TIFF_JPEG = 0x8000,
+        /// <summary>
+        /// WEBP default quality (75)
+        /// </summary>
+        WEBP_DEFAULT = 0x0,
+        /// <summary>
+        /// WEBP lossless quality (100)
+        /// </summary>
+        WEBP_LOSSLESS = 0x100,
+        /// <summary>
+        /// save with quality 80 and no chroma subsampling (4:4:4)
+        /// </summary>
+        JXR_DEFAULT = 0x0,
+        /// <summary>
+        /// save lossless
+        /// </summary>
+        JXR_LOSSLESS = 0x0064,
+        /// <summary>
+        /// save as a progressive-JXR (use | to combine with other save flags)
+        /// </summary>
+        JXR_PROGRESSIVE = 0x2000
     }
 }


### PR DESCRIPTION
This does not have the new freeimage 3.18 binaries, ideally those could be added after this pull request is merged in. A quick test of webp load and save appears to work great.